### PR TITLE
Crate no longer compiles w/ `..` ranges.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -381,7 +381,7 @@ impl Uuid {
         // Make sure all chars are either hex digits or hyphen
         for (i, c) in us.chars().enumerate() {
             match c {
-                '0'..'9' | 'A'..'F' | 'a'..'f' | '-' => {},
+                '0'...'9' | 'A'...'F' | 'a'...'f' | '-' => {},
                 _ => return Err(ErrorInvalidCharacter(c, i)),
             }
         }


### PR DESCRIPTION
Ranges must use the `...` syntax as of [rust PR #17584](https://github.com/rust-lang/rust/pull/17584)
