### PR TITLE
Update Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,4 @@ license = "MIT/APL2"
 readme = "README.md"
 repository = "https://github.com/rust-lang/uuid"
 homepage = "https://github.com/rust-lang/uuid"
-description = """
-A library to generate and parse UUIDs.
-"""
+description = """A library to generate and parse UUIDs."""


### PR DESCRIPTION
fixing "Cargo.toml:10:18-11:0 control character `\r` must be escaped" error.
