### PR TITLE
`cargo install uuid` should give me a uuid tool.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,3 +22,7 @@ sha1 = { version = "0.2", optional = true }
 use_std = []
 v4 = ["rand"]
 v5 = ["sha1"]
+
+[[bin]]
+name = "uuid"
+doc = false

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,0 +1,11 @@
+extern crate uuid;
+
+use uuid::{Uuid, UuidVersion};
+
+fn main() {
+    let i = Uuid::new(UuidVersion::Random);
+    match i {
+        Some(name) => println!("{}", name),
+        None => panic!("unable to generate name")
+    }
+}


### PR DESCRIPTION
We could consider adding options for version or other things in the future, but for now this suites my needs at least.
