### PR TITLE
fix documentation links

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ license = "MIT/Apache-2.0"
 readme = "README.md"
 repository = "https://github.com/rust-lang/uuid"
 homepage = "https://github.com/rust-lang/uuid"
-documentation = "https://doc.rust-lang.org/uuid"
+documentation = "https://docs.rs/uuid"
 description = """
 A library to generate and parse UUIDs.
 """

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The uniqueness property is not strictly guaranteed, however for all practical
 purposes, it can be assumed that an unintentional collision would be extremely
 unlikely.
 
-[Documentation](https://doc.rust-lang.org/uuid)
+[Documentation](https://docs.rs/uuid)
 
 ## Usage
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,7 +100,7 @@
 
 #![doc(html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
        html_favicon_url = "https://www.rust-lang.org/favicon.ico",
-       html_root_url = "https://doc.rust-lang.org/uuid/")]
+       html_root_url = "https://docs.rs/uuid")]
 
 #![deny(warnings)]
 #![no_std]


### PR DESCRIPTION
Now routes to docs.rs instead of doc.rust-lang.org


closes #128 