### PR TITLE
Release  for 0.6.0-beta

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Add this to your `Cargo.toml`:
 
 ```toml
 [dependencies]
-uuid = "0.5.1"
+uuid = "0.6.0-beta"
 ```
 
 and this to your crate root:

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ you'll need to change how you depend on `uuid`:
 
 ```toml
 [dependencies]
-uuid = { version = "0.5", features = ["v4"] }
+uuid = { version = "0.6", features = ["v4"] }
 ```
 
 Next, you'll write:
@@ -85,7 +85,7 @@ you'll also need to change how you depend on `uuid`:
 
 ```toml
 [dependencies]
-uuid = { version = "0.5.1", features = ["v5"] }
+uuid = { version = "0.6.0-beta", features = ["v5"] }
 ```
 
 Next, you'll write:

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,14 +52,14 @@
 //!
 //! ```toml
 //! [dependencies]
-//! uuid = { version = "0.5.1", features = ["serde", "v4"] }
+//! uuid = { version = "0.6.0-beta", features = ["serde", "v4"] }
 //! ```
 //!
 //! You can disable default features with:
 //!
 //! ```toml
 //! [dependencies]
-//! uuid = { version = "0.5.1", default-features = false }
+//! uuid = { version = "0.6.0-beta", default-features = false }
 //! ```
 //!
 //! # Examples

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -45,7 +45,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! uuid = "0.5.1"
+//! uuid = "0.6.0-beta"
 //! ```
 //!
 //! To activate various features, use syntax like:


### PR DESCRIPTION
References #132 

Fist beta release for 0.6.0. We will release a stable 0.6.0 either this week or next week once all bugs have been fixed or attended to. 