### PR TITLE
(wip for master branch freeze) WIP: Generalize sequence incrementing and only increment sequences when time doesn't move forwards

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ cmake-build-debug/
 /target/
 Cargo.lock
 
+/.criterion

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ md5 = { version = "0.3", optional = true }
 
 [dev-dependencies]
 serde_test = "1.0.19"
+criterion = "0.1.0"
 
 [features]
 default = ["std"]
@@ -31,3 +32,7 @@ v1 = []
 v3 = ["md5"]
 v4 = ["rand"]
 v5 = ["sha1"]
+
+[[bench]]
+name = "v1_generation"
+harness = false

--- a/benches/v1_generation.rs
+++ b/benches/v1_generation.rs
@@ -1,0 +1,58 @@
+#[macro_use]
+extern crate criterion;
+
+extern crate uuid;
+
+use std::sync::atomic::{AtomicUsize, Ordering};
+use criterion::Criterion;
+
+use uuid::{Uuid, UuidV1Context, DefaultUuidV1Context};
+
+struct OldContext {
+    count: AtomicUsize,
+}
+impl UuidV1Context for OldContext {
+    fn generate(&self, _current_seconds: u64, _current_nanoseconds: u32) -> u16 {
+        (self.count.fetch_add(1, Ordering::SeqCst) & 0xffff) as u16
+    }
+}
+
+
+fn generate_v1s(c: &mut Criterion) {
+    let node = [0, 1, 2, 3, 4, 5];
+    c.bench_function("mutex context", |b| {
+        let context = DefaultUuidV1Context::new(0);
+        b.iter(move || {
+            Uuid::new_v1(&context, 0, 0, &node[..])
+        })
+    });
+
+
+    c.bench_function("mutex context increasing time", |b| {
+        let mut time: u64 = 0;
+        let context = DefaultUuidV1Context::new(0);
+        b.iter(move || {
+            time += 1;
+            Uuid::new_v1(&context, time, 0, &node[..])
+        })
+    });
+
+    c.bench_function("old context", |b| {
+        let context = OldContext { count: AtomicUsize::new(0) };
+        b.iter(move || {
+            Uuid::new_v1(&context, 0, 0, &node[..])
+        })
+    });
+
+    c.bench_function("old context increasing time", |b| {
+        let mut time: u64 = 0;
+        let context = OldContext { count: AtomicUsize::new(0) };
+        b.iter(move || {
+            time += 1;
+            Uuid::new_v1(&context, time, 0, &node[..])
+        })
+    });
+
+}
+criterion_group!(benches, generate_v1s);
+criterion_main!(benches);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -222,14 +222,28 @@ pub struct Urn<'a> {
     inner: &'a Uuid,
 }
 
+#[cfg(feature = "v1")]
+pub trait UuidV1Context {
+    fn generate(&self, current_seconds: u64, current_nanoseconds: u32) -> u16;
+}
+
 /// A stateful context for the v1 generator to help ensure process-wide uniqueness
 #[cfg(feature = "v1")]
-pub struct UuidV1Context {
+pub struct DefaultUuidV1Context {
+    #[allow(unused)]
+    last_fetch: (u64, u32),
     count: AtomicUsize,
 }
 
 #[cfg(feature = "v1")]
-impl UuidV1Context {
+impl UuidV1Context for DefaultUuidV1Context {
+    fn generate(&self, _current_seconds: u64, _current_nanoseconds: u32) -> u16 {
+        (self.count.fetch_add(1, Ordering::SeqCst) & 0xffff) as u16
+    }
+}
+
+#[cfg(feature = "v1")]
+impl DefaultUuidV1Context {
 
     /// Creates a thread-safe, internally mutable context to help ensure uniqueness
     ///
@@ -237,8 +251,9 @@ impl UuidV1Context {
     /// counter that is incremented at every request, the value ends up in the clock_seq
     /// portion of the V1 uuid (the fourth group).  This will improve the probability
     /// that the UUID is unique across the process.
-    pub fn new(count : u16) -> UuidV1Context {
-        UuidV1Context {
+    pub fn new(count : u16) -> DefaultUuidV1Context {
+        DefaultUuidV1Context {
+            last_fetch: (0, 0),
             count: AtomicUsize::new(count as usize)
         }
     }
@@ -361,19 +376,20 @@ impl Uuid {
     /// Basic usage:
     /// 
     /// ```
-    /// use uuid::{Uuid, UuidV1Context};
+    /// use uuid::{Uuid, DefaultUuidV1Context};
     ///
-    /// let ctx = UuidV1Context::new(42);
+    /// let ctx = DefaultUuidV1Context::new(42);
     /// let v1uuid = Uuid::new_v1(&ctx, 1497624119, 1234, &[1,2,3,4,5,6]).unwrap();
     ///
     /// assert_eq!(v1uuid.hyphenated().to_string(), "f3b4958c-52a1-11e7-802a-010203040506");
     /// ```
     #[cfg(feature = "v1")]
-    pub fn new_v1(context: &UuidV1Context, seconds: u64, nsecs: u32, node: &[u8]) -> Result<Uuid, ParseError> {
+    pub fn new_v1<T: UuidV1Context>(context: &T, seconds: u64, nsecs: u32, node: &[u8])
+        -> Result<Uuid, ParseError> {
         if node.len() != 6 {
             return Err(ParseError::InvalidLength(node.len()))
         }
-        let count = (context.count.fetch_add(1, Ordering::SeqCst) & 0xffff) as u16;
+        let count = context.generate(seconds, nsecs);
         let timestamp = seconds * 10_000_000 + (nsecs / 100) as u64;
         let uuidtime = timestamp + UUID_TICKS_BETWEEN_EPOCHS; 
         let time_low : u32 = (uuidtime & 0xFFFFFFFF) as u32;
@@ -1106,11 +1122,11 @@ mod tests {
     #[cfg(feature = "v1")]
     #[test]
     fn test_new_v1() {
-        use UuidV1Context;
+        use DefaultUuidV1Context;
         let time : u64 = 1_496_854_535;
         let timefrac : u32 = 812_946_000;
         let node = [1,2,3,4,5,6];
-        let ctx = UuidV1Context::new(0);
+        let ctx = DefaultUuidV1Context::new(0);
         let uuid = Uuid::new_v1(&ctx, time, timefrac, &node[..]).unwrap();
         assert_eq!(uuid.get_version().unwrap(), UuidVersion::Mac);
         assert_eq!(uuid.get_variant().unwrap(), UuidVariant::RFC4122);


### PR DESCRIPTION
This is a big backwards-incompatible change, and WORK-IN-PROGRESS.

* `UuidV1Context` was renamed to `DefaultUuidV1Context`
* a new trait called `UuidV1Context` is added. This trait has a method for getting a u16 sequence number given the current time.
* `DefaultUuidV1Context` now has a Mutex in it for storing and updating the last time that a sequence number was requested. This means that `DefaultUuidV1Context` is only available when the `std` feature is enabled.


Is there any way we can avoid the context? I'm sure it probably slows down new_v1 a lot (though I plan on adding some benchmarks for this).

Also, while #106 proposed changing `UuidV1Context` to a trait, I think this might be unnecessary churn. A trait is a good idea, but it should probably be called something else so that `UuidV1Context` can remain backwards compatible.