### PR TITLE
Add minimum supported rustc version

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ matrix:
     - env: FEATURES="v4"
     - env: FEATURES="v5"
     - env: FEATURES="serde v1 v3 v4 v5 std"
+    - rust: 1.18.0
     - rust: beta
     - rust: nightly
 


### PR DESCRIPTION
Specifically test against `rustc 1.18.0` so we know when we regress the minimum supported version. Personally, I'm ok with pushing the minimum version as a non-breaking change, but it's always good to know and communicate in the release notes.