### PR TITLE
Add from_uuid_bytes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ all-features = true
 [dependencies]
 serde = { version = "1.0.16", optional = true, default-features = false }
 rand = { version = "0.4", optional = true }
-sha1 = { version = "0.5", optional = true }
+sha1 = { version = "0.6", optional = true }
 md5 = { version = "0.3", optional = true }
 
 [dev-dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -603,6 +603,41 @@ impl Uuid {
         Ok(uuid)
     }
 
+    /// Creates a `Uuid` using the supplied bytes.
+    ///
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// use uuid::Uuid;
+    /// use uuid::UuidBytes;
+    ///
+    /// let bytes:UuidBytes = [70, 235, 208, 238, 14, 109, 67, 201, 185, 13, 204, 195, 90, 145, 63, 62];
+    ///
+    /// let uuid = Uuid::from_uuid_bytes(&bytes);
+    /// let uuid = uuid.hyphenated().to_string();
+    ///
+    /// let expected_uuid = String::from("46ebd0ee-0e6d-43c9-b90d-ccc35a913f3e");
+    ///
+    /// assert_eq!(expected_uuid, uuid);
+    /// ```
+    ///
+    /// An incorrect number of bytes:
+    ///
+    /// ```compile_fail
+    /// use uuid::Uuid;
+    /// use uuid::UuidBytes;
+    ///
+    /// let bytes:UuidBytes = [4, 54, 67, 12, 43, 2, 98, 76]; // doesn't compile
+    ///
+    /// let uuid = Uuid::from_uuid_bytes(&bytes);
+    /// ```
+    pub fn from_uuid_bytes(b: &UuidBytes) -> Uuid {
+        Uuid { bytes: b.clone() }
+    }
+
     /// Specifies the variant of the UUID structure
     #[allow(dead_code)]
     fn set_variant(&mut self, v: UuidVariant) {
@@ -1666,6 +1701,18 @@ mod tests {
         ];
 
         let u = Uuid::from_bytes(&b).unwrap();
+        let expected = "a1a2a3a4b1b2c1c2d1d2d3d4d5d6d7d8";
+
+        assert_eq!(u.simple().to_string(), expected);
+    }
+
+    #[test]
+    fn test_from_uuid_bytes() {
+        let b = [
+            0xa1, 0xa2, 0xa3, 0xa4, 0xb1, 0xb2, 0xc1, 0xc2, 0xd1, 0xd2, 0xd3, 0xd4, 0xd5, 0xd6, 0xd7, 0xd8,
+        ];
+
+        let u = Uuid::from_uuid_bytes(&b);
         let expected = "a1a2a3a4b1b2c1c2d1d2d3d4d5d6d7d8";
 
         assert_eq!(u.simple().to_string(), expected);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -615,7 +615,7 @@ impl Uuid {
     ///
     /// let bytes:UuidBytes = [70, 235, 208, 238, 14, 109, 67, 201, 185, 13, 204, 195, 90, 145, 63, 62];
     ///
-    /// let uuid = Uuid::from_uuid_bytes(&bytes);
+    /// let uuid = Uuid::from_uuid_bytes(bytes);
     /// let uuid = uuid.hyphenated().to_string();
     ///
     /// let expected_uuid = String::from("46ebd0ee-0e6d-43c9-b90d-ccc35a913f3e");
@@ -631,10 +631,10 @@ impl Uuid {
     ///
     /// let bytes:UuidBytes = [4, 54, 67, 12, 43, 2, 98, 76]; // doesn't compile
     ///
-    /// let uuid = Uuid::from_uuid_bytes(&bytes);
+    /// let uuid = Uuid::from_uuid_bytes(bytes);
     /// ```
-    pub fn from_uuid_bytes(b: &UuidBytes) -> Uuid {
-        Uuid { bytes: b.clone() }
+    pub fn from_uuid_bytes(b: UuidBytes) -> Uuid {
+        Uuid { bytes: b }
     }
 
     /// Specifies the variant of the UUID structure
@@ -1708,10 +1708,11 @@ mod tests {
     #[test]
     fn test_from_uuid_bytes() {
         let b = [
-            0xa1, 0xa2, 0xa3, 0xa4, 0xb1, 0xb2, 0xc1, 0xc2, 0xd1, 0xd2, 0xd3, 0xd4, 0xd5, 0xd6, 0xd7, 0xd8,
+            0xa1, 0xa2, 0xa3, 0xa4, 0xb1, 0xb2, 0xc1, 0xc2, 0xd1, 0xd2, 0xd3, 0xd4, 0xd5, 0xd6,
+            0xd7, 0xd8,
         ];
 
-        let u = Uuid::from_uuid_bytes(&b);
+        let u = Uuid::from_uuid_bytes(b);
         let expected = "a1a2a3a4b1b2c1c2d1d2d3d4d5d6d7d8";
 
         assert_eq!(u.simple().to_string(), expected);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -354,15 +354,15 @@ impl Uuid {
 
     /// Creates a new `Uuid` (version 1 style) using a time value + seq + NodeID.
     ///
-    /// This expects two values representing a monotonically increasing value 
+    /// This expects two values representing a monotonically increasing value
     /// as well as a unique 6 byte NodeId, and an implementation of `UuidV1ClockSequence`.
-    /// This function is only guaranteed to produce unique values if the following conditions hold: 
-    /// 
+    /// This function is only guaranteed to produce unique values if the following conditions hold:
+    ///
     /// 1. The NodeID is unique for this process,
     /// 2. The Context is shared across all threads which are generating V1 UUIDs,
     /// 3. The `UuidV1ClockSequence` implementation reliably returns unique clock sequences
     ///    (this crate provides `UuidV1Context` for this purpose).
-    /// 
+    ///
     /// The NodeID must be exactly 6 bytes long. If the NodeID is not a valid length
     /// this will return a `ParseError::InvalidLength`.
     ///
@@ -604,7 +604,6 @@ impl Uuid {
     }
 
     /// Creates a `Uuid` using the supplied bytes.
-    ///
     ///
     /// # Examples
     ///


### PR DESCRIPTION
This adds a constructor that uses the explicit type `UuidBytes`.

The main difference between this constructor and `from_bytes` is that the length of `UuidBytes` is fixed at the correct length, so any use of `from_uuid_bytes` cannot fail. As such, instead of returning a `Result` it simply returns a `uuid`.

A secondary reason for this is that, if `const` functions ever move into nightly, this function would be an easy way to allow external consumers of this library to create `const` UUIDs.

If there are any other tests, or contribution guidelines that I've failed to include, please let me know.