### PR TITLE
Update sha1 crate to 0.6.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ all-features = true
 [dependencies]
 serde = { version = "1.0.16", optional = true, default-features = false }
 rand = { version = "0.4", optional = true }
-sha1 = { version = "0.5", optional = true }
+sha1 = { version = "0.6", optional = true }
 md5 = { version = "0.3", optional = true }
 
 [dev-dependencies]


### PR DESCRIPTION
- No changes that affect us, but keeping the crate updated.