### PR TITLE
Bring back the renamed `use_std` feature for backwards compat

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ serde_test = "1.0.19"
 [features]
 default = ["std"]
 std = []
+use_std = ["std"] # Compatibility shim for 0.5 and earlier
 v1 = []
 v3 = ["md5"]
 v4 = ["rand"]


### PR DESCRIPTION
addaecd0fc9a1dbb053420ff91ed61ec1fc31395
removed this feature, which was intentionally left deprecated for
backwards compatibility. This "cleanup" removed a deprecated feature
before any released version actually had the deprecation present.

Removing this feature makes it impossible for other crates to support
UUID 0.6 without dropping support for UUID 0.5 and earlier. This is a
major problem for crates like Diesel, which are post-1.0