### PR TITLE
adds optional slog::Value impl

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,6 +25,7 @@ serde = { version = "1.0.16", optional = true, default-features = false }
 rand = { version = "0.4", optional = true }
 sha1 = { version = "0.6", optional = true }
 md5 = { version = "0.3", optional = true }
+slog = { version = "2", optional = true }
 
 [dev-dependencies]
 serde_test = "1.0.19"

--- a/benches/parse_str.rs
+++ b/benches/parse_str.rs
@@ -2,9 +2,14 @@
 
 extern crate test;
 extern crate uuid;
+#[cfg(feature = "slog")]
+#[macro_use]
+extern crate slog;
 
 use test::Bencher;
 use uuid::Uuid;
+#[cfg(feature = "slog")]
+use slog::Drain;
 
 #[bench]
 fn bench_parse(b: &mut Bencher) {
@@ -83,5 +88,15 @@ fn bench_valid_hyphenated(b: &mut Bencher) {
 fn bench_valid_short(b: &mut Bencher) {
     b.iter(|| {
         let _ = Uuid::parse_str("67e5504410b1426f9247bb680e5fe0c8");
+    });
+}
+
+#[cfg(feature = "slog")]
+#[bench]
+fn bench_log_discard_kv(b: &mut Bencher) {
+    let root = slog::Logger::root(slog::Discard.fuse(), o!());
+    let u1 = Uuid::parse_str("F9168C5E-CEB2-4FAB-B6BF-329BF39FA1E4").unwrap();
+    b.iter(|| {
+        crit!(root, "test"; "u1" => u1);
     });
 }

--- a/benches/parse_str.rs
+++ b/benches/parse_str.rs
@@ -1,9 +1,9 @@
 #![feature(test)]
-extern crate test;
-extern crate uuid;
 #[cfg(feature = "slog")]
 #[macro_use]
 extern crate slog;
+extern crate test;
+extern crate uuid;
 use test::Bencher;
 use uuid::Uuid;
 #[cfg(feature = "slog")]

--- a/benches/parse_str.rs
+++ b/benches/parse_str.rs
@@ -1,11 +1,9 @@
 #![feature(test)]
-
 extern crate test;
 extern crate uuid;
 #[cfg(feature = "slog")]
 #[macro_use]
 extern crate slog;
-
 use test::Bencher;
 use uuid::Uuid;
 #[cfg(feature = "slog")]


### PR DESCRIPTION
This implements `slog::Value` behind a feature-gate, allowing the use of `Uuid` in a key-value pair. Includes a test and bench.