### PR TITLE
add issue and PR templates

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,58 @@
+**Note: for support questions, please use [gitter] or [users forums]**. This 
+repository's issues are reserved for feature requests and bug reports.
+
+[gitter]: https://gitter.im/uuid-rs/Lobby
+[users forums]: https://users.rust-lang.org
+
+**I'm submitting a ...**
+  - [ ] bug report
+  - [ ] feature request
+  - [ ] support request => Please do not submit support request here, see note 
+  at the top of this template.
+
+
+# Description
+<!-- Provide a summary of your issue in the Title above -->
+
+<!-- 
+    The following section is only needed for bug reports, delete otherwise.
+-->
+# Bug Report
+
+## Current Behaviour
+<!-- What is the current behavior? -->
+
+## Expected Behaviour
+<!-- What is the expected behaviour? -->
+
+## Steps to Reproduce
+<!-- How can we reproduce this bug? -->
+1. ...
+2. ...
+3. ...
+
+## Example
+<!-- 
+    A code snippet or a play.rust-lang.org link will do.
+    Not obligatory, but will provide a context for the bug.
+-->
+
+## Environment
+<!-- Please tell us about your environment -->
+- Version: <!-- uuid version -->
+- Target: <!-- Your target triple -->
+- Features: <!-- uuid features enabled -->
+
+## Meta
+<!-- 
+    Information like detailed explanation, stacktraces, suggested fixes, etc
+-->
+
+<!-- 
+    The following section is only for feature requests, delete otherwise
+-->
+# Feature Request
+<!-- What is the motivation/ use-case(s) for changing the behavior? -->
+
+# Other
+<!-- Other information like relevant issues, external links, etc -->

--- a/.github/ISSUE_TEMPLATE/bug
+++ b/.github/ISSUE_TEMPLATE/bug
@@ -1,0 +1,32 @@
+# Description
+<!-- Provide a summary of your issue in the Title above -->
+
+# Current Behaviour
+<!-- What is the current behavior? -->
+
+# Expected Behaviour
+<!-- What is the expected behaviour? -->
+
+# Steps to Reproduce
+<!-- How can we reproduce this bug? -->
+1. ...
+2. ...
+3. ...
+
+# Example
+<!--
+    A code snippet or a play.rust-lang.org link will do.
+    Not obligatory, but will provide a context for the bug.
+-->
+
+# Environment
+<!-- Please tell us about your environment -->
+- Version: <!-- uuid version -->
+- Target: <!-- Your target triple -->
+- Features: <!-- uuid features enabled -->
+
+# Meta
+<!-- Information like detailed explanation, stacktraces, suggested fixes, etc -->
+
+# Other
+<!-- Other information like relevant issues, external links, etc -->

--- a/.github/ISSUE_TEMPLATE/feature
+++ b/.github/ISSUE_TEMPLATE/feature
@@ -1,0 +1,8 @@
+# Description
+<!-- Provide a summary of your issue in the Title above -->
+
+# Feature Request
+<!-- What is the motivation/ use-case(s) for changing the behavior? -->
+
+# Other
+<!-- Other information like relevant issues, external links, etc -->

--- a/.github/ISSUE_TEMPLATE/tracker
+++ b/.github/ISSUE_TEMPLATE/tracker
@@ -1,0 +1,16 @@
+<!--
+    Title should be in the format:
+
+        `Tracker: version release`
+
+    Replace version with the target release.
+-->
+
+<!-- Replace version with the version for this tracker is being opened -->
+Items left to do for __*version*__ release:
+
+* [ ] Update version numbers
+* [ ] Push to crates.io
+* [ ] Write release notes on:
+    * [ ] Github Releases
+    * [ ] users.rust-lang.org

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -5,9 +5,9 @@
 -->
 
 **I'm submitting a ...**
-  - [ ] bug fixes
-  - [ ] feature enhancements
-  - [ ] deprecations or removals
+  - [ ] bug fix
+  - [ ] feature enhancement
+  - [ ] deprecation or removal
   - [ ] refactor
 
 # Description

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,26 @@
+<!--
+    As we are working towards a stable version of uuid, we require that you 
+    open an issue, before submitting a pull request. If the pull request is 
+    imcomplete, prepend the Title with WIP: 
+-->
+
+**I'm submitting a ...**
+  - [ ] bug fixes
+  - [ ] feature enhancements
+  - [ ] deprecations or removals
+  - [ ] refactor
+
+# Description
+<!-- Provide a summary of your changes in the Title above -->
+
+# Motivation
+<!-- Why is this change required -->
+
+# Tests
+<!-- How are these changes tested? -->
+
+# Related Issue(s)
+<!-- 
+    As noted above, we require an issue for every PR. Please link to the issue
+    here
+-->

--- a/.github/PULL_REQUEST_TEMPLATE/release
+++ b/.github/PULL_REQUEST_TEMPLATE/release
@@ -1,0 +1,14 @@
+<!--
+    Title should be in the format:
+
+        `version release update`
+
+    Replace version with the target release.
+-->
+
+<!-- Replace version with the version for this tracker is being opened -->
+Items left to do for __*version*__ release:
+
+* [ ] Update version numbers
+    * [ ] lib.rs
+    * [ ] Cargo.toml

--- a/.github/PULL_REQUEST_TEMPLATE/release
+++ b/.github/PULL_REQUEST_TEMPLATE/release
@@ -12,3 +12,5 @@ Items left to do for __*version*__ release:
 * [ ] Update version numbers
     * [ ] lib.rs
     * [ ] Cargo.toml
+
+Reference: #<!-- Tracker issue -->

--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 uuid
 ====
 
-[![Build Status](https://travis-ci.org/uuid-rs/uuid.svg?branch=master)](https://travis-ci.org/uuid-rs/uuid) [![Appveyor Status](https://ci.appveyor.com/api/projects/status/github/uuid-rs/uuid?branch=master&svg=true)](https://ci.appveyor.com/project/KodrAus/uuid) [![Latest Version](https://img.shields.io/crates/v/uuid.svg)](https://crates.io/crates/uuid) [![Join the chat at https://gitter.im/uuid-rs/Lobby](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/uuid-rs/Lobby?utm_source=badge&utm_medium=badge&utm_content=badge)
+[![Build Status](https://travis-ci.org/uuid-rs/uuid.svg?branch=master)](https://travis-ci.org/uuid-rs/uuid) 
+[![Appveyor Status](https://ci.appveyor.com/api/projects/status/github/uuid-rs/uuid?branch=master&svg=true)](https://ci.appveyor.com/project/KodrAus/uuid) 
+[![Latest Version](https://img.shields.io/crates/v/uuid.svg)](https://crates.io/crates/uuid) 
+[![Join the chat at https://gitter.im/uuid-rs/Lobby](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/uuid-rs/Lobby?utm_source=badge&utm_medium=badge&utm_content=badge)
 
 A Rust library to generate and parse UUIDs.
 


### PR DESCRIPTION
Issues:

[`/issues/new`]: Use the default issue template.
[`/issues/new?template=bug`]: Use the bug report template.
[`/issues/new?template=feature`]: Use the feature request template.
[`/issues/new?template=tracker`]: Use the tracker template. Only for us to use.

[`/issues/new`]: https://github.com/uuid-rs/uuid/issues/new
[`/issues/new?template=bug`]: https://github.com/uuid-rs/uuid/issues/new?template=bug
[`/issues/new?template=feature`]: https://github.com/uuid-rs/uuid/issues/new?template=feature
[`/issues/new?template=tracker`]: https://github.com/uuid-rs/uuid/issues/new?template=tracker

---
PRs:

[`/pulls/new`]: Use the default PR template.
[`/pulls/new?template=release`]: Use the release preparations template. Our own use only.

[`/pulls/new`]: https://github.com/uuid-rs/uuid/pulls/new
[`/pulls/new?template=release`]: https://github.com/uuid-rs/uuid/pulls/new?template=bug

---
Also makes having an issue for any PR a requirement. I have that so that as part of stabilization, we don't just go overboard with features and such.

closes #116 