### PR TITLE
make `rand` public again

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -121,7 +121,7 @@ cfg_if! {
 
 cfg_if! {
     if #[cfg(feature = "rand")] {
-        extern crate rand;
+        pub extern crate rand;
     }
 }
 


### PR DESCRIPTION
<!--
    As we are working towards a stable version of uuid, we require that you 
    open an issue, before submitting a pull request. If the pull request is 
    imcomplete, prepend the Title with WIP: 
-->

**I'm submitting a ...**
  - [x] bug fix
  - [ ] feature enhancement
  - [ ] deprecation or removal
  - [ ] refactor

# Description
`rand` is once again declared as a public dependency.

# Motivation
Servo is currently uses custom `Rng` and as a result of #112, cannot use its own `Rng` implementation. Multiple other people also had this issue with the change in #112.

# Tests
N/A

# Related Issue(s)
<!-- 
    As noted above, we require an issue for every PR. Please link to the issue
    here
-->
#112
servo/servo#20306

closes #153  
