### PR TITLE
Add Nil variant

### DIFF
--- a/benches/parse_str.rs
+++ b/benches/parse_str.rs
@@ -4,10 +4,10 @@
 extern crate slog;
 extern crate test;
 extern crate uuid;
-use test::Bencher;
-use uuid::Uuid;
 #[cfg(feature = "slog")]
 use slog::Drain;
+use test::Bencher;
+use uuid::Uuid;
 
 #[bench]
 fn bench_parse(b: &mut Bencher) {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,7 +151,9 @@ pub type UuidBytes = [u8; 16];
 /// The version of the UUID, denoting the generating algorithm.
 #[derive(Debug, PartialEq, Copy, Clone)]
 pub enum UuidVersion {
-    /// Special case for `nil` [`struct.Uuid.html`].
+    /// Special case for `nil` [`Uuid`].
+    ///
+    /// [`Uuid`]: struct.Uuid.html
     Nil,
     /// Version 1: MAC address
     Mac = 1,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1275,7 +1275,8 @@ mod tests {
     fn test_nil() {
         let nil = Uuid::nil();
         let not_nil = new();
-        let from_bytes = Uuid::from_uuid_bytes([4, 54, 67, 12, 43, 2, 2, 76, 32, 50, 87, 5, 1, 33, 43, 87]);
+        let from_bytes =
+            Uuid::from_uuid_bytes([4, 54, 67, 12, 43, 2, 2, 76, 32, 50, 87, 5, 1, 33, 43, 87]);
 
         assert_eq!(from_bytes.get_version(), None);
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -131,10 +131,10 @@ use core::fmt;
 use core::hash;
 use core::str::FromStr;
 
-#[cfg(feature = "std")]
-mod std_support;
 #[cfg(feature = "serde")]
 mod serde;
+#[cfg(feature = "std")]
+mod std_support;
 
 #[cfg(feature = "v1")]
 use core::sync::atomic::{AtomicUsize, Ordering};

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1047,29 +1047,27 @@ impl<'a> fmt::Display for Hyphenated<'a> {
 }
 
 macro_rules! hyphnated_write {
-    ($f:expr, $format:expr, $bytes:expr) => {{
-        let data1 = (($bytes[0] as u32) << 24) |
-                    (($bytes[1] as u32) << 16) |
-                    (($bytes[2] as u32) <<  8) |
-                    (($bytes[3] as u32) <<  0);
-        let data2 = (($bytes[4] as u16) <<  8) |
-                    (($bytes[5] as u16) <<  0);
-        let data3 = (($bytes[6] as u16) <<  8) |
-                    (($bytes[7] as u16) <<  0);
+    ($f: expr, $format: expr, $bytes: expr) => {{
+        let data1 = (($bytes[0] as u32) << 24) | (($bytes[1] as u32) << 16)
+            | (($bytes[2] as u32) << 8) | (($bytes[3] as u32) << 0);
+        let data2 = (($bytes[4] as u16) << 8) | (($bytes[5] as u16) << 0);
+        let data3 = (($bytes[6] as u16) << 8) | (($bytes[7] as u16) << 0);
 
-        write!($f,
-               $format,
-               data1,
-               data2,
-               data3,
-               $bytes[8],
-               $bytes[9],
-               $bytes[10],
-               $bytes[11],
-               $bytes[12],
-               $bytes[13],
-               $bytes[14],
-               $bytes[15])
+        write!(
+            $f,
+            $format,
+            data1,
+            data2,
+            data3,
+            $bytes[8],
+            $bytes[9],
+            $bytes[10],
+            $bytes[11],
+            $bytes[12],
+            $bytes[13],
+            $bytes[14],
+            $bytes[15]
+        )
     }};
 }
 
@@ -1581,7 +1579,7 @@ mod tests {
         let u = new();
 
         macro_rules! check {
-            ($buf:ident, $format:expr, $target:expr, $len:expr, $cond:expr) => {
+            ($buf: ident, $format: expr, $target: expr, $len: expr, $cond: expr) => {
                 $buf.clear();
                 write!($buf, $format, $target).unwrap();
                 assert!(buf.len() == $len);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -151,6 +151,8 @@ pub type UuidBytes = [u8; 16];
 /// The version of the UUID, denoting the generating algorithm.
 #[derive(Debug, PartialEq, Copy, Clone)]
 pub enum UuidVersion {
+    /// Special case for `nil` [`struct.Uuid.html`].
+    Nil,
     /// Version 1: MAC address
     Mac = 1,
     /// Version 2: DCE Security
@@ -697,6 +699,7 @@ impl Uuid {
     pub fn get_version(&self) -> Option<UuidVersion> {
         let v = self.bytes[6] >> 4;
         match v {
+            0 if self.is_nil() => Some(UuidVersion::Nil),
             1 => Some(UuidVersion::Mac),
             2 => Some(UuidVersion::Dce),
             3 => Some(UuidVersion::Md5),
@@ -1272,9 +1275,15 @@ mod tests {
     fn test_nil() {
         let nil = Uuid::nil();
         let not_nil = new();
+        let from_bytes = Uuid::from_uuid_bytes([4, 54, 67, 12, 43, 2, 2, 76, 32, 50, 87, 5, 1, 33, 43, 87]);
+
+        assert_eq!(from_bytes.get_version(), None);
 
         assert!(nil.is_nil());
         assert!(!not_nil.is_nil());
+
+        assert_eq!(nil.get_version(), Some(UuidVersion::Nil));
+        assert_eq!(not_nil.get_version(), Some(UuidVersion::Random))
     }
 
     #[test]

--- a/src/serde.rs
+++ b/src/serde.rs
@@ -1,7 +1,7 @@
 extern crate serde;
 
-use core::fmt;
 use self::serde::{de, Deserialize, Deserializer, Serialize, Serializer};
+use core::fmt;
 
 use Uuid;
 


### PR DESCRIPTION
<!--
    As we are working towards a stable version of uuid, we require that you 
    open an issue, before submitting a pull request. If the pull request is 
    imcomplete, prepend the Title with WIP: 
-->

**I'm submitting a ...**
  - [ ] bug fix
  - [x] feature enhancement
  - [ ] deprecation or removal
  - [ ] refactor

# Description
Adds `Nil` variant to the `UuidVersion`.

# Motivation
`nil` `Uuid`, containing all zeros, is a valid `Uuid`, as per the specification. This will allow users doing pattern matching to explicitly check for it.

# Tests
Updated `test_nil` to ensure that 

# Related Issue(s)
closes #133
supersedes #176