### PR TITLE
move slog implementation into its own module

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -175,6 +175,12 @@ cfg_if! {
 }
 
 cfg_if! {
+    if #[cfg(feature = "slog")] {
+        mod slog_support;
+    }
+}
+
+cfg_if! {
     if #[cfg(feature = "std")] {
         mod std_support;
     }
@@ -1067,18 +1073,6 @@ impl fmt::LowerHex for Uuid {
     }
 }
 
-#[cfg(feature = "slog")]
-impl slog::Value for Uuid {
-    fn serialize(
-        &self,
-        _record: &slog::Record,
-        key: slog::Key,
-        serializer: &mut slog::Serializer,
-    ) -> Result<(), slog::Error> {
-        serializer.emit_arguments(key, &format_args!("{}", self))
-    }
-}
-
 impl<'a> fmt::Display for Simple<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::LowerHex::fmt(self, f)
@@ -1180,9 +1174,6 @@ mod tests {
 
     use super::{NAMESPACE_X500, NAMESPACE_DNS, NAMESPACE_OID, NAMESPACE_URL};
     use super::{Uuid, UuidVariant, UuidVersion};
-
-    #[cfg(feature = "slog")]
-    use slog::{self, Drain};
 
     #[cfg(feature = "v3")]
     static FIXTURE_V3: &'static [(&'static Uuid, &'static str, &'static str)] = &[
@@ -1859,13 +1850,5 @@ mod tests {
 
         assert!(set.contains(&id1));
         assert!(!set.contains(&id2));
-    }
-
-    #[cfg(feature = "slog")]
-    #[test]
-    fn test_slog_kv() {
-        let root = slog::Logger::root(slog::Discard.fuse(), o!());
-        let u1 = test_util::new();
-        crit!(root, "test"; "u1" => u1);
     }
 }

--- a/src/slog_support.rs
+++ b/src/slog_support.rs
@@ -1,0 +1,28 @@
+use slog;
+use Uuid;
+
+impl slog::Value for Uuid {
+    fn serialize(
+        &self,
+        _: &slog::Record,
+        key: slog::Key,
+        serializer: &mut slog::Serializer,
+    ) -> Result<(), slog::Error> {
+        serializer.emit_arguments(key, &format_args!("{}", self))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+
+    #[test]
+    fn test_slog_kv() {
+        use slog;
+        use test_util;
+        use slog::Drain;
+
+        let root = slog::Logger::root(slog::Discard.fuse(), o!());
+        let u1 = test_util::new();
+        crit!(root, "test"; "u1" => u1);
+    }
+}


### PR DESCRIPTION
**I'm submitting a ...**
  - [ ] bug fix
  - [ ] feature enhancement
  - [ ] deprecation or removal
  - [x] refactor

# Description
The slog impl and tests are moved into `slog_support` module

# Motivation
As part of the refactor effort, feature gated implementations need to be moved into their own modules.

# Tests
Current provided tests are passing

# Related Issue(s)
#124 
