### PR TITLE
Remove ParseError from the prelude

### DIFF
--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -20,13 +20,12 @@
 //!
 //! ## The core types
 //!
-//! [`uuid`]`::{`[`ParseError`], [`Uuid`], [`UuidVariant`]`}`: The fundamental
+//! [`uuid`]`::{`[`Uuid`], [`UuidVariant`]`}`: The fundamental
 //! types used in [`uuid`] crate.
 //!
 //! [`uuid`]: ../index.html
-//! [`ParseError`]: ../enum.ParseError.html
 //! [`Uuid`]: ../struct.Uuid.html
 //! [`UuidVariant`]: enum.UuidVariant.html
 
 #[doc(inline)]
-pub use super::{ParseError, Uuid, UuidVariant};
+pub use super::{Uuid, UuidVariant};


### PR DESCRIPTION
**I'm submitting a ...**
  - [ ] bug fix
  - [ ] feature enhancement
  - [x] deprecation or removal
  - [ ] refactor

# Description
Remove `ParseError` from the `prelude` reexports

# Motivation
`0.7` will rename `ParseError`, and `prelude` should only contain stable items, which will never altered in an unstable manner.

# Tests
N/A

# Related Issue(s)
#166 