### PR TITLE
Fix v1 import of atomic module

### DIFF
--- a/src/v1.rs
+++ b/src/v1.rs
@@ -9,7 +9,7 @@ use prelude::*;
 cfg_if! {
     if #[cfg(feature = "std")] {
         use std::sync::atomic;
-    } else if #[cfg(not(feature = "v1"))] {
+    } else {
         use core::sync::atomic;
     }
 }


### PR DESCRIPTION
**I'm submitting a ...**
  - [x] bug fix
  - [ ] feature enhancement
  - [ ] deprecation or removal
  - [ ] refactor

# Description
unnecessary cfg_if if check causes compile error 

observed with no_std + `v1` feature environment

# Motivation
Squash bugs :man_shrugging: 

# Tests
build uuid with `cargo build --no-default-features --features v1` with this change and without

# Related Issue(s)
N/A
