### PR TITLE
fix prelude UuidVersion item missing

### DIFF
--- a/benches/parse_str.rs
+++ b/benches/parse_str.rs
@@ -5,9 +5,9 @@ extern crate slog;
 extern crate test;
 extern crate uuid;
 #[cfg(feature = "slog")]
+use uuid::prelude::*;
 use slog::Drain;
 use test::Bencher;
-use uuid::Uuid;
 
 #[bench]
 fn bench_parse(b: &mut Bencher) {

--- a/benches/parse_str.rs
+++ b/benches/parse_str.rs
@@ -4,10 +4,11 @@
 extern crate slog;
 extern crate test;
 extern crate uuid;
+
 #[cfg(feature = "slog")]
-use uuid::prelude::*;
 use slog::Drain;
 use test::Bencher;
+use uuid::prelude::*;
 
 #[bench]
 fn bench_parse(b: &mut Bencher) {

--- a/src/core_support.rs
+++ b/src/core_support.rs
@@ -125,6 +125,7 @@ mod tests {
         );
     }
 
+    //noinspection RsAssertEqual
     #[test]
     fn test_uuid_operator_eq() {
         let uuid1 = test_util::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -984,7 +984,8 @@ mod tests {
     use super::test_util;
 
     use super::ns::{NAMESPACE_X500, NAMESPACE_DNS, NAMESPACE_OID, NAMESPACE_URL};
-    use super::{Uuid, UuidVariant, UuidVersion};
+
+    use prelude::*;
 
     #[cfg(feature = "v3")]
     static FIXTURE_V3: &'static [(&'static Uuid, &'static str, &'static str)] = &[

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -18,12 +18,13 @@
 //!
 //! Currently the prelude reexports the following:
 //!
-//! [`uuid`]`::{`[`Uuid`], [`UuidVariant`]`}`: The fundamental types used in
+//! [`uuid`]`::{`[`Uuid`], [`UuidVariant`], [`UuidVersion`]`}`: The fundamental types used in
 //! [`uuid`] crate.
 //!
 //! [`uuid`]: ../index.html
 //! [`Uuid`]: ../struct.Uuid.html
-//! [`UuidVariant`]: enum.UuidVariant.html
+//! [`UuidVariant`]: ../enum.UuidVariant.html
+//! [`UuidVersion`]: ../enum.UuidVersion.html
 //!
 #![cfg_attr(feature = "v1",
 doc = "
@@ -35,7 +36,7 @@ handling uuid version 1. Requires feature `v1`.
 [`UuidClockSequence`]: ../v1/trait.UuidClockSequence.html")]
 
 #[doc(inline)]
-pub use super::{Uuid, UuidVariant};
+pub use super::{Uuid, UuidVariant, UuidVersion};
 
 cfg_if! {
     if #[cfg(feature = "v1")] {

--- a/src/serde_support.rs
+++ b/src/serde_support.rs
@@ -1,7 +1,6 @@
 use fmt;
+use prelude::*;
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
-
-use Uuid;
 
 impl Serialize for Uuid {
     fn serialize<S: Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {

--- a/src/v1.rs
+++ b/src/v1.rs
@@ -110,7 +110,7 @@ impl Uuid {
             time_high_and_version = (((uuid_time >> 48) & 0x0FFF) as u16) | (1 << 12);
         }
 
-        let mut d4 = [0_u8; 8];
+        let mut d4 = [0; 8];
 
         {
             let count = context.generate_sequence(seconds, nano_seconds);
@@ -153,7 +153,6 @@ mod tests {
     #[test]
     fn test_new_v1() {
         use super::UuidContext;
-        use UuidVersion;
         use prelude::*;
 
         let time: u64 = 1_496_854_535;

--- a/src/v4.rs
+++ b/src/v4.rs
@@ -43,7 +43,7 @@ mod tests {
     fn test_new() {
         let uuid = Uuid::new_v4();
 
-        assert_eq!(uuid.get_version(), Some(super::super::UuidVersion::Random));
+        assert_eq!(uuid.get_version(), Some(UuidVersion::Random));
         assert_eq!(uuid.get_variant(), Some(UuidVariant::RFC4122));
     }
 
@@ -51,7 +51,7 @@ mod tests {
     fn test_get_version() {
         let uuid = Uuid::new_v4();
 
-        assert_eq!(uuid.get_version(), Some(super::super::UuidVersion::Random));
+        assert_eq!(uuid.get_version(), Some(UuidVersion::Random));
         assert_eq!(uuid.get_version_num(), 4)
     }
 }

--- a/src/v5.rs
+++ b/src/v5.rs
@@ -29,7 +29,7 @@ impl Uuid {
 
         uuid.bytes.copy_from_slice(&buffer[..16]);
         uuid.set_variant(UuidVariant::RFC4122);
-        uuid.set_version(super::UuidVersion::Sha1);
+        uuid.set_version(UuidVersion::Sha1);
 
         uuid
     }
@@ -122,7 +122,7 @@ mod tests {
             Uuid::new_v5(&ns::NAMESPACE_DNS, "rust-lang.org")
         };
 
-        assert_eq!(uuid.get_version(), Some(::UuidVersion::Sha1));
+        assert_eq!(uuid.get_version(), Some(UuidVersion::Sha1));
         assert_eq!(uuid.get_version_num(), 5);
     }
 
@@ -141,7 +141,7 @@ mod tests {
             let uuid = Uuid::new_v5(*ns, *name);
 
             assert_eq!(uuid.get_variant(), Some(UuidVariant::RFC4122));
-            assert_eq!(uuid.get_version(), Some(::UuidVersion::Sha1));
+            assert_eq!(uuid.get_version(), Some(UuidVersion::Sha1));
             assert_eq!(Ok(uuid), u.parse());
         }
     }


### PR DESCRIPTION
**I'm submitting a ...**
  - [x] bug fix
  - [ ] feature enhancement
  - [ ] deprecation or removal
  - [ ] refactor

# Description
UuidVersion added back into the prelude, was accidently removed

# Motivation
n/a

# Tests
n/a

# Related Issue(s)
closes #202 
