### PR TITLE
Fix minimum required cfg_if version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ rand = { version = "0.4", optional = true }
 sha1 = { version = "0.6", optional = true }
 md5 = { version = "0.3", optional = true }
 slog = { version = "2", optional = true }
-cfg-if = "0.1"
+cfg-if = "0.1.2"
 
 [dev-dependencies]
 serde_test = "1.0.19"


### PR DESCRIPTION
cfg_if without an else block is not supported until 0.1.2, see https://github.com/alexcrichton/cfg-if/commit/8a594d0994b5c37f3cad035a6c76ae0105bce013

<!--
    As we are working towards a stable version of uuid, we require that you 
    open an issue, before submitting a pull request. If the pull request is 
    imcomplete, prepend the Title with WIP: 
-->

**I'm submitting a ...**
  - [x] bug fix
  - [ ] feature enhancement
  - [ ] deprecation or removal
  - [ ] refactor

# Description
<!-- Provide a summary of your changes in the Title above -->

# Motivation
<!-- Why is this change required -->

# Tests
<!-- How are these changes tested? -->

# Related Issue(s)
<!-- 
    As noted above, we require an issue for every PR. Please link to the issue
    here
-->
Fixes #205