### PR TITLE
Add fmt_default_simple feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ v1 = []
 v3 = ["md5", "rand"]
 v4 = ["rand"]
 v5 = ["sha1", "rand"]
+fmt_default_simple = []
 
 # Get features picked up by the Integer 32 playground. Not public API.
 #

--- a/src/core_support.rs
+++ b/src/core_support.rs
@@ -174,8 +174,13 @@ mod tests {
 
         assert_eq!(s.len(), FMT_LENGTH);
 
-        check!(buffer, "{}", s, FMT_LENGTH, |c| c.is_lowercase() || c.is_digit(10)
-            || c == '-');
+        check!(
+            buffer,
+            "{}",
+            s,
+            FMT_LENGTH,
+            |c| c.is_lowercase() || c.is_digit(10) || c == '-'
+        );
     }
 
     #[test]

--- a/src/core_support.rs
+++ b/src/core_support.rs
@@ -27,15 +27,31 @@ impl fmt::Display for UuidVariant {
     }
 }
 
-impl fmt::LowerHex for Uuid {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        <super::Hyphenated as fmt::LowerHex>::fmt(&self.hyphenated(), f)
-    }
-}
+cfg_if! {
+    if #[cfg(feature = "fmt_default_simple")] {
+        impl fmt::LowerHex for Uuid {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                <super::Simple as fmt::LowerHex>::fmt(&self.simple(), f)
+            }
+        }
 
-impl fmt::UpperHex for Uuid {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        <super::Hyphenated as fmt::UpperHex>::fmt(&self.hyphenated(), f)
+        impl fmt::UpperHex for Uuid {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                <super::Simple as fmt::UpperHex>::fmt(&self.simple(), f)
+            }
+        }
+    } else {
+        impl fmt::LowerHex for Uuid {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                <super::Hyphenated as fmt::LowerHex>::fmt(&self.hyphenated(), f)
+            }
+        }
+
+        impl fmt::UpperHex for Uuid {
+            fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+                <super::Hyphenated as fmt::UpperHex>::fmt(&self.hyphenated(), f)
+            }
+        }
     }
 }
 
@@ -60,6 +76,7 @@ mod tests {
     use self::std::prelude::v1::*;
     use prelude::*;
     use test_util;
+    use test_util::FMT_LENGTH;
 
     macro_rules! check {
         ($buf:ident, $format:expr, $target:expr, $len:expr, $cond:expr) => {
@@ -98,13 +115,19 @@ mod tests {
         let s = uuid.to_string();
         let mut buffer = String::new();
 
-        assert_eq!(s, uuid.hyphenated().to_string());
+        let expected = if cfg!(feature = "fmt_default_simple") {
+            uuid.simple().to_string()
+        } else {
+            uuid.hyphenated().to_string()
+        };
+
+        assert_eq!(s, expected);
 
         check!(
             buffer,
             "{}",
             uuid,
-            36,
+            FMT_LENGTH,
             |c| c.is_lowercase() || c.is_digit(10) || c == '-'
         );
     }
@@ -120,7 +143,7 @@ mod tests {
             buffer,
             "{:x}",
             uuid,
-            36,
+            FMT_LENGTH,
             |c| c.is_lowercase() || c.is_digit(10) || c == '-'
         );
     }
@@ -149,9 +172,9 @@ mod tests {
         let s = uuid.to_string();
         let mut buffer = String::new();
 
-        assert_eq!(s.len(), 36);
+        assert_eq!(s.len(), FMT_LENGTH);
 
-        check!(buffer, "{}", s, 36, |c| c.is_lowercase() || c.is_digit(10)
+        check!(buffer, "{}", s, FMT_LENGTH, |c| c.is_lowercase() || c.is_digit(10)
             || c == '-');
     }
 
@@ -166,7 +189,7 @@ mod tests {
             buffer,
             "{:X}",
             uuid,
-            36,
+            FMT_LENGTH,
             |c| c.is_uppercase() || c.is_digit(10) || c == '-'
         );
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1152,6 +1152,7 @@ mod tests {
     use self::std::prelude::v1::*;
 
     use super::test_util;
+    use super::test_util::FMT_LENGTH;
 
     use super::{NAMESPACE_X500, NAMESPACE_DNS, NAMESPACE_OID, NAMESPACE_URL};
     use super::{Uuid, UuidVariant, UuidVersion};
@@ -1606,7 +1607,7 @@ mod tests {
             };
         }
 
-        check!(buf, "{:X}", u, 36, |c| c.is_uppercase() || c.is_digit(10)
+        check!(buf, "{:X}", u, FMT_LENGTH, |c| c.is_uppercase() || c.is_digit(10)
             || c == '-');
         check!(
             buf,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1607,8 +1607,13 @@ mod tests {
             };
         }
 
-        check!(buf, "{:X}", u, FMT_LENGTH, |c| c.is_uppercase() || c.is_digit(10)
-            || c == '-');
+        check!(
+            buf,
+            "{:X}",
+            u,
+            FMT_LENGTH,
+            |c| c.is_uppercase() || c.is_digit(10) || c == '-'
+        );
         check!(
             buf,
             "{:X}",

--- a/src/test_util.rs
+++ b/src/test_util.rs
@@ -1,5 +1,13 @@
 use Uuid;
 
+cfg_if! {
+    if #[cfg(feature = "fmt_default_simple")] {
+        pub const FMT_LENGTH: usize = 32;
+    } else {
+        pub const FMT_LENGTH: usize = 36;
+    }
+}
+
 pub fn new() -> Uuid {
     Uuid {
         bytes: [


### PR DESCRIPTION
**I'm submitting a ...**
  - [ ] bug fix
  - [x] feature enhancement
  - [ ] deprecation or removal
  - [ ] refactor

# Description
Possible implementation for #207 using conditional compilation feature flag.

# Motivation
For projects which consistently use Simple formatting and not Hyphenated formatting.

# Tests
Existing tests which test the default behavior of string formatting are modified to reference constants and variables which use the new feature flag.

# Other
I am new to Rust, so if anything in this PR is not good Rust practice, do let me know!

# Related Issue(s)

#207 