### PR TITLE
backport u128 support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,7 @@ A library to generate and parse UUIDs.
 all-features = true
 
 [package.metadata.playground]
-features = ["serde", "v1", "v3", "v4", "v5"]
+features = ["serde", "u128", "v1", "v3", "v4", "v5"]
 
 [dependencies]
 serde = { version = "1.0.16", optional = true, default-features = false }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,6 +31,12 @@ md5 = { version = "0.3", optional = true }
 slog = { version = "2", optional = true }
 cfg-if = "0.1.2"
 
+[dependencies.byteorder]
+default-features = false
+features = ["i128"]
+optional = true
+version = "1"
+
 [dev-dependencies]
 serde_test = "1.0.19"
 
@@ -43,4 +49,9 @@ v1 = []
 v3 = ["md5", "rand"]
 v4 = ["rand"]
 v5 = ["sha1", "rand"]
+
+# since rust 1.26.0
+u128 = ["byteorder"]
+
+# only rust nightly
 const-fn = ["nightly"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,8 +114,12 @@
 #![cfg_attr(not(feature = "std"), no_std)]
 #![cfg_attr(feature = "const-fn", feature(const_fn))]
 
+#[cfg(feature = "byteorder")]
+extern crate byteorder;
 #[macro_use]
 extern crate cfg_if;
+#[cfg(feature = "std")]
+extern crate core;
 
 cfg_if! {
     if #[cfg(feature = "md5")] {
@@ -176,6 +180,8 @@ pub mod adapter;
 pub mod prelude;
 
 mod core_support;
+#[cfg(feature = "u128")]
+mod u128_support;
 
 cfg_if! {
     if #[cfg(feature = "serde")] {

--- a/src/u128_support.rs
+++ b/src/u128_support.rs
@@ -1,0 +1,41 @@
+// Copyright 2013-2014 The Rust Project Developers.
+// Copyright 2018 The Uuid Project Developers.
+//
+// See the COPYRIGHT file at the top-level directory of this distribution.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use byteorder;
+use prelude::*;
+
+impl Uuid {
+    /// Creates a new [`Uuid`] from a `u128` value.
+    ///
+    /// To create a [`Uuid`] from `u128`s, you need `u128` feature enabled for this crate.
+    ///
+    /// [`Uuid`]: ../struct.Uuid.html
+    #[inline]
+    pub fn from_u128(quad: u128) -> Self {
+        Uuid::from(quad)
+    }
+}
+
+impl From<u128> for Uuid {
+    fn from(f: u128) -> Self {
+        let mut bytes = [0; 16];
+
+        {
+            use byteorder::ByteOrder;
+
+            byteorder::NativeEndian::write_u128(&mut bytes[..], f);
+        }
+
+        Uuid {
+            bytes
+        }
+    }
+}

--- a/src/u128_support.rs
+++ b/src/u128_support.rs
@@ -37,3 +37,20 @@ impl From<u128> for Uuid {
         Uuid { bytes }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use prelude::*;
+
+    #[test]
+    fn test_from_u128() {
+        const U128: u128 = 0x3a0724b4_93a0_4d87_ac28_759c6caa13c4;
+
+        let uuid = Uuid::from(U128);
+
+        let uuid2: Uuid = U128.into();
+
+        assert_eq!(uuid, uuid2)
+    }
+
+}

--- a/src/u128_support.rs
+++ b/src/u128_support.rs
@@ -34,8 +34,6 @@ impl From<u128> for Uuid {
             byteorder::NativeEndian::write_u128(&mut bytes[..], f);
         }
 
-        Uuid {
-            bytes
-        }
+        Uuid { bytes }
     }
 }


### PR DESCRIPTION
**I'm submitting a ...**
  - [ ] bug fix
  - [x] feature enhancement
  - [ ] deprecation or removal
  - [ ] refactor

# Description
allow support for `u128` <-> `Uuid`

# Motivation
As of `1.26.0` rust you can use `u128` in stable rust

# Tests
added `test_from_u128` test function

# Related Issue(s)
#234 
