### PR TITLE
[WIP] Upgrade rand 0.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ version = "0.3"
 
 [dependencies.rand]
 optional = true
-version = "0.4"
+version = "0.5"
 
 [dependencies.serde]
 default-features = false

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -164,6 +164,11 @@ cfg_if! {
                 use std::sync::atomic;
             }
         }
+        cfg_if! {
+            if #[cfg(feature = "rand")] {
+                use rand::RngCore;
+            }
+        }
     } else if #[cfg(not(feature = "std"))] {
         use core::fmt;
         use core::str;
@@ -171,6 +176,11 @@ cfg_if! {
         cfg_if! {
             if #[cfg(feature = "v1")] {
                 use core::sync::atomic;
+            }
+        }
+        cfg_if! {
+            if #[cfg(feature = "rand")] {
+                use rand::RngCore;
             }
         }
     }


### PR DESCRIPTION
**I'm submitting a ...**
  - [ ] bug fix
  - [x] feature enhancement
  - [ ] deprecation or removal
  - [ ] refactor

# Description
Upgrades rand to 0.5, thus enabling stdweb support, among other upgrades.  For the full changelog, check https://github.com/rust-lang-nursery/rand/blob/master/CHANGELOG.md#050---2018-05-21.

# Related Issue(s)
https://github.com/uuid-rs/uuid/issues/257
