### PR TITLE
use UuidBytes instead of [u8; 16]

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -502,7 +502,7 @@ impl Uuid {
     /// assert_eq!(expected_uuid, uuid);
     /// ```
     ///
-    pub fn from_random_bytes(b: [u8; 16]) -> Uuid {
+    pub fn from_random_bytes(b: UuidBytes) -> Uuid {
         let mut uuid = Uuid { bytes: b };
         uuid.set_variant(UuidVariant::RFC4122);
         uuid.set_version(UuidVersion::Random);
@@ -649,7 +649,7 @@ impl Uuid {
     /// );
     /// ```
     #[cfg(feature = "const_fn")]
-    pub const fn as_bytes(&self) -> &[u8; 16] {
+    pub const fn as_bytes(&self) -> &UuidBytes {
         &self.bytes
     }
 
@@ -673,7 +673,7 @@ impl Uuid {
     /// );
     /// ```
     #[cfg(not(feature = "const_fn"))]
-    pub fn as_bytes(&self) -> &[u8; 16] {
+    pub fn as_bytes(&self) -> &UuidBytes {
         &self.bytes
     }
 
@@ -1335,7 +1335,7 @@ mod tests {
 
     #[test]
     fn test_bytes_roundtrip() {
-        let b_in: [u8; 16] = [
+        let b_in: ::UuidBytes = [
             0xa1, 0xa2, 0xa3, 0xa4, 0xb1, 0xb2, 0xc1, 0xc2, 0xd1, 0xd2, 0xd3,
             0xd4, 0xd5, 0xd6, 0xd7, 0xd8,
         ];

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -29,12 +29,11 @@
 //!
 //! Currently the prelude reexports the following:
 //!
-//! [`uuid`]`::{`[`Uuid`], [`UuidBytes`], [`UuidVariant`], [`UuidVersion`]`}`:
-//! The fundamental types used in [`uuid`] crate.
+//! [`uuid`]`::{`[`Uuid`], [`UuidVariant`], [`UuidVersion`]`}`: The fundamental
+//! types used in [`uuid`] crate.
 //!
 //! [`uuid`]: ../index.html
 //! [`Uuid`]: ../struct.Uuid.html
-//! [`UuidBytes`]: ../type.UuidBytes.html
 //! [`UuidVariant`]: ../enum.UuidVariant.html
 //! [`UuidVersion`]: ../enum.UuidVersion.html
 //!

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -29,11 +29,12 @@
 //!
 //! Currently the prelude reexports the following:
 //!
-//! [`uuid`]`::{`[`Uuid`], [`UuidVariant`], [`UuidVersion`]`}`: The fundamental
-//! types used in [`uuid`] crate.
+//! [`uuid`]`::{`[`Uuid`], [`UuidBytes`], [`UuidVariant`], [`UuidVersion`]`}`:
+//! The fundamental types used in [`uuid`] crate.
 //!
 //! [`uuid`]: ../index.html
 //! [`Uuid`]: ../struct.Uuid.html
+//! [`UuidBytes`]: ../type.UuidBytes.html
 //! [`UuidVariant`]: ../enum.UuidVariant.html
 //! [`UuidVersion`]: ../enum.UuidVersion.html
 //!
@@ -47,7 +48,7 @@ handling uuid version 1. Requires feature `v1`.
 [`UuidClockSequence`]: ../v1/trait.UuidClockSequence.html")]
 
 #[doc(inline)]
-pub use super::{Uuid, UuidVariant, UuidVersion};
+pub use super::{Uuid, UuidBytes, UuidVariant, UuidVersion};
 #[cfg(feature = "v1")]
 #[doc(inline)]
 pub use v1::{UuidClockSequence, UuidContext};

--- a/src/u128_support.rs
+++ b/src/u128_support.rs
@@ -27,7 +27,7 @@ impl Uuid {
 
 impl From<u128> for Uuid {
     fn from(f: u128) -> Self {
-        let mut bytes = [0; 16];
+        let mut bytes: ::UuidBytes = [0; 16];
 
         {
             use byteorder::ByteOrder;


### PR DESCRIPTION
**I'm submitting a ...**
  - [ ] bug fix
  - [ ] feature enhancement
  - [ ] deprecation or removal
  - [x] refactor

# Description
* Change from `[u8; 16]` to `UuidBytes` across files

# Motivation
Consistency

# Tests
All current tests pass