### PR TITLE
add UuidLength enum

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -142,6 +142,7 @@ use core::{fmt, str};
 pub mod adapter;
 pub mod ns;
 pub mod prelude;
+pub mod util;
 #[cfg(feature = "v1")]
 pub mod v1;
 

--- a/src/util/core_support.rs
+++ b/src/util/core_support.rs
@@ -17,9 +17,9 @@ where
     T: AsRef<[usize]> + fmt::Debug,
 {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match self {
+        match *self {
             util::UuidLength::Exact(v) => write!(f, "{}", v),
-            util::UuidLength::OneOf(v) => write!(f, "any one of {:?}", v),
+            util::UuidLength::OneOf(ref v) => write!(f, "any one of {:?}", v),
             util::UuidLength::Range { max, min } => {
                 write!(f, "{}..{}", min, max)
             }

--- a/src/util/core_support.rs
+++ b/src/util/core_support.rs
@@ -1,0 +1,28 @@
+// Copyright 2013-2014 The Rust Project Developers.
+// Copyright 2018 The Uuid Project Developers.
+//
+// See the COPYRIGHT file at the top-level directory of this distribution.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use core::fmt;
+use util;
+
+impl<T> fmt::Display for util::UuidLength<T>
+where
+    T: AsRef<[usize]> + fmt::Debug,
+{
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            util::UuidLength::Exact(v) => write!(f, "{}", v),
+            util::UuidLength::OneOf(v) => write!(f, "any one of {:?}", v),
+            util::UuidLength::Range { max, min } => {
+                write!(f, "{}..{}", min, max)
+            }
+        }
+    }
+}

--- a/src/util/mod.rs
+++ b/src/util/mod.rs
@@ -1,0 +1,49 @@
+// Copyright 2013-2014 The Rust Project Developers.
+// Copyright 2018 The Uuid Project Developers.
+//
+// See the COPYRIGHT file at the top-level directory of this distribution.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+//! Utility constructs for ['Uuid`] use.
+//!
+//! [`Uuid`]: ../struct.Uuid.html
+
+use core::fmt;
+
+mod core_support;
+
+/// Possible [`Uuid`] lengths.
+///
+/// [`Uuid`]: ../struct.Uuid.html
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub enum UuidLength<T>
+where
+    T: AsRef<[usize]> + fmt::Debug,
+{
+    /// The [`Uuid`] length is exactly as given.
+    ///
+    /// [`Uuid`]: ../struct.Uuid.html
+    Exact(usize),
+    /// The [`Uuid`] length is one of the given values.
+    ///
+    /// [`Uuid`]: ../struct.Uuid.html
+    OneOf(T),
+    /// The [`Uuid`] length is between the given range inclusive.
+    ///
+    /// [`Uuid`]: ../struct.Uuid.html
+    Range {
+        /// The maximum [`Uuid`] length.
+        ///
+        /// [`Uuid`]: ../struct.Uuid.html
+        max: usize,
+        /// The minimum [`Uuid`] length.
+        ///
+        /// [`Uuid`]: ../struct.Uuid.html
+        min: usize,
+    },
+}


### PR DESCRIPTION
**I'm submitting a(n)** feature

# Description
Adds a `UuidLength` utility enum. Useful for parsing. The location is not final and may be moved around as we start using in the crate.

This is currently not used in the crate, however, future PRs are expected to rectify this.

# Motivation
Current parsing mechanism assumes only `Hyphenated`, `Simple`, `Urn` and `SIV` uuids exist. However this not true. This will help make parsers, especially external parsers for other formats 

# Tests
No tests currently. However, when other parts use this enum they can update their tests to use this

# Related Issue(s)
#276