### PR TITLE
Remove deprecated "use-std"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,11 +64,6 @@ v3 = ["md5", "rand"]
 v4 = ["rand"]
 v5 = ["sha1", "rand"]
 
-# deprecated
-#------------------------
-# Use `"std"` instead
-use_std = ["std"]
-
 # since rust 1.26.0
 u128 = ["byteorder"]
 


### PR DESCRIPTION
**I'm submitting a(n)** removal


# Description
feature `use-std` was renamed earlier in #108 and brought back and marked deprecated in #158. Removing it now

# Related Issue(s)
#108, #158