### PR TITLE
introduce UuidError for general Uuid use

### DIFF
--- a/src/core_support.rs
+++ b/src/core_support.rs
@@ -31,12 +31,7 @@ impl fmt::Display for UuidVariant {
 
 impl fmt::Display for ::UuidError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        match *self {
-            ::UuidError::InvalidLength{
-                expected,
-                found,
-            } => write!(f, "invalid bytes length: expected {}, found {}",  expected, found)
-        }
+       write!(f, "invalid bytes length: expected {}, found {}",  self.expected(), self.found())
     }
 }
 

--- a/src/core_support.rs
+++ b/src/core_support.rs
@@ -31,7 +31,12 @@ impl fmt::Display for UuidVariant {
 
 impl fmt::Display for ::UuidError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-       write!(f, "invalid bytes length: expected {}, found {}",  self.expected(), self.found())
+        write!(
+            f,
+            "invalid bytes length: expected {}, found {}",
+            self.expected(),
+            self.found()
+        )
     }
 }
 

--- a/src/core_support.rs
+++ b/src/core_support.rs
@@ -29,6 +29,17 @@ impl fmt::Display for UuidVariant {
     }
 }
 
+impl fmt::Display for ::UuidError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match *self {
+            ::UuidError::InvalidLength{
+                expected,
+                found,
+            } => write!(f, "invalid bytes length: expected {}, found {}",  expected, found)
+        }
+    }
+}
+
 impl fmt::LowerHex for Uuid {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::LowerHex::fmt(&self.to_hyphenated_ref(), f)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -401,10 +401,7 @@ impl Uuid {
     ///
     /// let uuid = uuid::Uuid::from_fields(42, 12, 5, &d4);
     ///
-    /// let expected_uuid = Err(uuid::UuidError::InvalidLength {
-    ///     expected: 8,
-    ///     found: d4.len(),
-    /// });
+    /// let expected_uuid = Err(uuid::UuidError::new(8, d4.len()));
     ///
     /// assert_eq!(expected_uuid, uuid);
     /// ```
@@ -474,11 +471,8 @@ impl Uuid {
     /// let bytes = [4, 54, 67, 12, 43, 2, 98, 76];
     ///
     /// let uuid = Uuid::from_bytes(&bytes);
-    ///
-    /// let expected_uuid = Err(uuid::UuidError::InvalidLength {
-    ///     expected: 16,
-    ///     found: 8
-    /// });
+    /// 
+    /// let expected_uuid = Err(uuid::UuidError::new(16, 8));
     ///
     /// assert_eq!(expected_uuid, uuid);
     /// ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -416,7 +416,7 @@ impl Uuid {
         let len = d4.len();
 
         if len != D4_LEN {
-            return Err(UuidError::new(D4_LEN, len))
+            return Err(UuidError::new(D4_LEN, len));
         }
 
         Ok(Uuid::from_uuid_bytes([
@@ -471,7 +471,7 @@ impl Uuid {
     /// let bytes = [4, 54, 67, 12, 43, 2, 98, 76];
     ///
     /// let uuid = Uuid::from_bytes(&bytes);
-    /// 
+    ///
     /// let expected_uuid = Err(uuid::UuidError::new(16, 8));
     ///
     /// assert_eq!(expected_uuid, uuid);
@@ -482,7 +482,7 @@ impl Uuid {
         let len = b.len();
 
         if len != BYTES_LEN {
-            return Err(UuidError::new(BYTES_LEN, len))
+            return Err(UuidError::new(BYTES_LEN, len));
         }
 
         let mut bytes: UuidBytes = [0; 16];

--- a/src/std_support.rs
+++ b/src/std_support.rs
@@ -17,3 +17,9 @@ impl error::Error for ParseError {
         "UUID parse error"
     }
 }
+
+impl error::Error for ::UuidError {
+    fn description(&self) -> &str {
+        "Uuid error"
+    }
+}

--- a/src/v1.rs
+++ b/src/v1.rs
@@ -89,10 +89,10 @@ impl Uuid {
         T: UuidClockSequence,
     {
         const NODE_ID_LEN: usize = 6;
-        
+
         let len = node_id.len();
         if len != NODE_ID_LEN {
-            return Err(::UuidError::new(NODE_ID_LEN, len))
+            return Err(::UuidError::new(NODE_ID_LEN, len));
         }
 
         let time_low;

--- a/src/v1.rs
+++ b/src/v1.rs
@@ -84,12 +84,18 @@ impl Uuid {
         seconds: u64,
         nano_seconds: u32,
         node_id: &[u8],
-    ) -> Result<Self, super::ParseError>
+    ) -> Result<Self, ::UuidError>
     where
         T: UuidClockSequence,
     {
-        if node_id.len() != 6 {
-            return Err(super::ParseError::InvalidLength(node_id.len()));
+        const NODE_ID_LEN: usize = 6;
+        
+        let len = node_id.len();
+        if len != NODE_ID_LEN {
+            return Err(::UuidError::InvalidLength {
+                expected: NODE_ID_LEN,
+                found: len,
+            })
         }
 
         let time_low;

--- a/src/v1.rs
+++ b/src/v1.rs
@@ -92,10 +92,7 @@ impl Uuid {
         
         let len = node_id.len();
         if len != NODE_ID_LEN {
-            return Err(::UuidError::InvalidLength {
-                expected: NODE_ID_LEN,
-                found: len,
-            })
+            return Err(::UuidError::new(NODE_ID_LEN, len))
         }
 
         let time_low;


### PR DESCRIPTION
**I'm submitting a(n)** feature, refactor

# Description
* Introduce a `::UuidError` type.
* Change signature of `::Uuid::from_fields`, `::Uuid::new_v1` and `::Uuid::from_bytes` to use the new error type.

This now splits the `Uuid` creation types into 3 categories:
* those which have no errors for creating
* those which throw errors based around parsing (currently `ParseError`)
* those which throw errors based around bytes (`UuidError`)

# Motivation
`ParseError` is oriented around parsing uuid strings. However, that error type does not bode well functions that are accepting bytes. 

# Tests
All current tests pass with the signature change. No new tests added

# Related Issue(s)
closes #281 
