### PR TITLE
remove Uuid prefix

### DIFF
--- a/src/adapter/core_support/mod.rs
+++ b/src/adapter/core_support/mod.rs
@@ -15,49 +15,49 @@ use prelude::*;
 #[macro_use]
 mod macros;
 
-impl fmt::Display for super::UuidHyphenated {
+impl fmt::Display for super::Hyphenated {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::LowerHex::fmt(self, f)
     }
 }
 
-impl<'a> fmt::Display for super::UuidHyphenatedRef<'a> {
+impl<'a> fmt::Display for super::HyphenatedRef<'a> {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::LowerHex::fmt(self, f)
     }
 }
 
-impl fmt::Display for super::UuidSimple {
+impl fmt::Display for super::Simple {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::LowerHex::fmt(self, f)
     }
 }
 
-impl<'a> fmt::Display for super::UuidSimpleRef<'a> {
+impl<'a> fmt::Display for super::SimpleRef<'a> {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::LowerHex::fmt(self, f)
     }
 }
 
-impl fmt::Display for super::UuidUrn {
+impl fmt::Display for super::Urn {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::LowerHex::fmt(self, f)
     }
 }
 
-impl<'a> fmt::Display for super::UuidUrnRef<'a> {
+impl<'a> fmt::Display for super::UrnRef<'a> {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::LowerHex::fmt(self, f)
     }
 }
 
-impl fmt::LowerHex for super::UuidHyphenated {
+impl fmt::LowerHex for super::Hyphenated {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         hyphenated_write!(
             f,
@@ -71,7 +71,7 @@ impl fmt::LowerHex for super::UuidHyphenated {
     }
 }
 
-impl<'a> fmt::LowerHex for super::UuidHyphenatedRef<'a> {
+impl<'a> fmt::LowerHex for super::HyphenatedRef<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         hyphenated_write!(
             f,
@@ -85,7 +85,7 @@ impl<'a> fmt::LowerHex for super::UuidHyphenatedRef<'a> {
     }
 }
 
-impl fmt::LowerHex for super::UuidSimple {
+impl fmt::LowerHex for super::Simple {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         for byte in self.0.as_bytes() {
             write!(f, "{:02x}", byte)?
@@ -95,7 +95,7 @@ impl fmt::LowerHex for super::UuidSimple {
     }
 }
 
-impl<'a> fmt::LowerHex for super::UuidSimpleRef<'a> {
+impl<'a> fmt::LowerHex for super::SimpleRef<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         for byte in self.0.as_bytes() {
             write!(f, "{:02x}", byte)?
@@ -105,7 +105,7 @@ impl<'a> fmt::LowerHex for super::UuidSimpleRef<'a> {
     }
 }
 
-impl fmt::LowerHex for super::UuidUrn {
+impl fmt::LowerHex for super::Urn {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         hyphenated_write!(
             f,
@@ -120,7 +120,7 @@ impl fmt::LowerHex for super::UuidUrn {
     }
 }
 
-impl<'a> fmt::LowerHex for super::UuidUrnRef<'a> {
+impl<'a> fmt::LowerHex for super::UrnRef<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         hyphenated_write!(
             f,
@@ -135,7 +135,7 @@ impl<'a> fmt::LowerHex for super::UuidUrnRef<'a> {
     }
 }
 
-impl fmt::UpperHex for super::UuidHyphenated {
+impl fmt::UpperHex for super::Hyphenated {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         hyphenated_write!(
             f,
@@ -149,7 +149,7 @@ impl fmt::UpperHex for super::UuidHyphenated {
     }
 }
 
-impl<'a> fmt::UpperHex for super::UuidHyphenatedRef<'a> {
+impl<'a> fmt::UpperHex for super::HyphenatedRef<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         hyphenated_write!(
             f,
@@ -163,7 +163,7 @@ impl<'a> fmt::UpperHex for super::UuidHyphenatedRef<'a> {
     }
 }
 
-impl fmt::UpperHex for super::UuidSimple {
+impl fmt::UpperHex for super::Simple {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         for byte in self.0.as_bytes() {
             write!(f, "{:02X}", byte)?
@@ -173,7 +173,7 @@ impl fmt::UpperHex for super::UuidSimple {
     }
 }
 
-impl<'a> fmt::UpperHex for super::UuidSimpleRef<'a> {
+impl<'a> fmt::UpperHex for super::SimpleRef<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         for byte in self.0.as_bytes() {
             write!(f, "{:02X}", byte)?
@@ -183,7 +183,7 @@ impl<'a> fmt::UpperHex for super::UuidSimpleRef<'a> {
     }
 }
 
-impl fmt::UpperHex for super::UuidUrn {
+impl fmt::UpperHex for super::Urn {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         hyphenated_write!(
             f,
@@ -198,7 +198,7 @@ impl fmt::UpperHex for super::UuidUrn {
     }
 }
 
-impl<'a> fmt::UpperHex for super::UuidUrnRef<'a> {
+impl<'a> fmt::UpperHex for super::UrnRef<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         hyphenated_write!(
             f,
@@ -213,44 +213,44 @@ impl<'a> fmt::UpperHex for super::UuidUrnRef<'a> {
     }
 }
 
-impl From<Uuid> for super::UuidHyphenated {
+impl From<Uuid> for super::Hyphenated {
     #[inline]
     fn from(f: Uuid) -> Self {
-        super::UuidHyphenated::from_uuid(f)
+        super::Hyphenated::from_uuid(f)
     }
 }
 
-impl<'a> From<&'a Uuid> for super::UuidHyphenatedRef<'a> {
+impl<'a> From<&'a Uuid> for super::HyphenatedRef<'a> {
     #[inline]
     fn from(f: &'a Uuid) -> Self {
-        super::UuidHyphenatedRef::from_uuid_ref(f)
+        super::HyphenatedRef::from_uuid_ref(f)
     }
 }
 
-impl From<Uuid> for super::UuidSimple {
+impl From<Uuid> for super::Simple {
     #[inline]
     fn from(f: Uuid) -> Self {
-        super::UuidSimple::from_uuid(f)
+        super::Simple::from_uuid(f)
     }
 }
 
-impl<'a> From<&'a Uuid> for super::UuidSimpleRef<'a> {
+impl<'a> From<&'a Uuid> for super::SimpleRef<'a> {
     #[inline]
     fn from(f: &'a Uuid) -> Self {
-        super::UuidSimpleRef::from_uuid_ref(f)
+        super::SimpleRef::from_uuid_ref(f)
     }
 }
 
-impl From<Uuid> for super::UuidUrn {
+impl From<Uuid> for super::Urn {
     #[inline]
     fn from(f: Uuid) -> Self {
-        super::UuidUrn::from_uuid(f)
+        super::Urn::from_uuid(f)
     }
 }
 
-impl<'a> From<&'a Uuid> for super::UuidUrnRef<'a> {
+impl<'a> From<&'a Uuid> for super::UrnRef<'a> {
     #[inline]
     fn from(f: &'a Uuid) -> Self {
-        super::UuidUrnRef::from_uuid_ref(f)
+        super::UrnRef::from_uuid_ref(f)
     }
 }

--- a/src/adapter/mod.rs
+++ b/src/adapter/mod.rs
@@ -23,7 +23,7 @@ mod core_support;
 ///
 /// [`Uuid`]: ../struct.Uuid.html
 #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct UuidHyphenated(Uuid);
+pub struct Hyphenated(Uuid);
 
 /// An adaptor for formatting an [`Uuid`] as a hyphenated string.
 ///
@@ -31,7 +31,7 @@ pub struct UuidHyphenated(Uuid);
 ///
 /// [`Uuid`]: ../struct.Uuid.html
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct UuidHyphenatedRef<'a>(&'a Uuid);
+pub struct HyphenatedRef<'a>(&'a Uuid);
 
 /// An adaptor for formatting an [`Uuid`] as a simple string.
 ///
@@ -39,7 +39,7 @@ pub struct UuidHyphenatedRef<'a>(&'a Uuid);
 ///
 /// [`Uuid`]: ../struct.Uuid.html
 #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct UuidSimple(Uuid);
+pub struct Simple(Uuid);
 
 /// An adaptor for formatting an [`Uuid`] as a simple string.
 ///
@@ -47,7 +47,7 @@ pub struct UuidSimple(Uuid);
 ///
 /// [`Uuid`]: ../struct.Uuid.html
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct UuidSimpleRef<'a>(&'a Uuid);
+pub struct SimpleRef<'a>(&'a Uuid);
 
 /// An adaptor for formatting an [`Uuid`] as a URN string.
 ///
@@ -55,7 +55,7 @@ pub struct UuidSimpleRef<'a>(&'a Uuid);
 ///
 /// [`Uuid`]: ../struct.Uuid.html
 #[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct UuidUrn(Uuid);
+pub struct Urn(Uuid);
 
 /// An adaptor for formatting an [`Uuid`] as a URN string.
 ///
@@ -63,143 +63,143 @@ pub struct UuidUrn(Uuid);
 ///
 /// [`Uuid`]: ../struct.Uuid.html
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct UuidUrnRef<'a>(&'a Uuid);
+pub struct UrnRef<'a>(&'a Uuid);
 
 impl Uuid {
     /// Creates a [`UuidHyphenated`] instance from a [`Uuid`].
     ///
     /// [`Uuid`]: ../struct.Uuid.html
     /// [`UuidHyphenated`]: struct.UuidHyphenated.html
-    // TODO(kinggoesgaming): discuss to_ vs as_ vs into_
+    // TODO: discuss to_ vs as_ vs into_
     #[cfg(not(feature = "const_fn"))]
     #[inline]
-    pub fn to_hyphenated(self) -> UuidHyphenated {
-        UuidHyphenated::from_uuid(self)
+    pub fn to_hyphenated(self) -> Hyphenated {
+        Hyphenated::from_uuid(self)
     }
 
     /// Creates a [`UuidHyphenated`] instance from a [`Uuid`].
     ///
     /// [`Uuid`]: ../struct.Uuid.html
     /// [`UuidHyphenated`]: struct.UuidHyphenated.html
-    // TODO(kinggoesgaming): discuss to_ vs as_ vs into_
+    // TODO: discuss to_ vs as_ vs into_
     #[cfg(feature = "const_fn")]
     #[inline]
-    pub fn to_hyphenated(self) -> UuidHyphenated {
-        UuidHyphenated::from_uuid(self)
+    pub fn to_hyphenated(self) -> Hyphenated {
+        Hyphenated::from_uuid(self)
     }
 
     /// Creates a [`UuidHyphenatedRef`] instance from a [`Uuid`] reference.
     ///
     /// [`Uuid`]: ../struct.Uuid.html
     /// [`UuidHyphenatedRef`]: struct.UuidHyphenatedRef.html
-    // TODO(kinggoesgaming): discuss to_ vs as_ vs into_
+    // TODO(: discuss to_ vs as_ vs into_
     #[cfg(not(feature = "const_fn"))]
     #[inline]
-    pub fn to_hyphenated_ref(&self) -> UuidHyphenatedRef {
-        UuidHyphenatedRef::from_uuid_ref(self)
+    pub fn to_hyphenated_ref(&self) -> HyphenatedRef {
+        HyphenatedRef::from_uuid_ref(self)
     }
 
     /// Creates a [`UuidHyphenatedRef`] instance from a [`Uuid`] reference.
     ///
     /// [`Uuid`]: ../struct.Uuid.html
     /// [`UuidHyphenatedRef`]: struct.UuidHyphenatedRef.html
-    // TODO(kinggoesgaming): discuss to_ vs as_ vs into_
+    // TODO: discuss to_ vs as_ vs into_
     #[cfg(feature = "const_fn")]
     #[inline]
-    pub fn to_hyphenated_ref(&self) -> UuidHyphenatedRef {
-        UuidHyphenatedRef::from_uuid_ref(self)
+    pub fn to_hyphenated_ref(&self) -> HyphenatedRef {
+        HyphenatedRef::from_uuid_ref(self)
     }
 
     /// Creates a [`UuidSimple`] instance from a [`Uuid`].
     ///
     /// [`Uuid`]: ../struct.Uuid.html
     /// [`UuidSimple`]: struct.UuidSimple.html
-    // TODO(kinggoesgaming): discuss to_ vs as_ vs into_
+    // TODO: discuss to_ vs as_ vs into_
     #[cfg(not(feature = "const_fn"))]
     #[inline]
-    pub fn to_simple(self) -> UuidSimple {
-        UuidSimple::from_uuid(self)
+    pub fn to_simple(self) -> Simple {
+        Simple::from_uuid(self)
     }
 
     /// Creates a [`UuidSimple`] instance from a [`Uuid`].
     ///
     /// [`Uuid`]: ../struct.Uuid.html
     /// [`UuidSimple`]: struct.UuidSimple.html
-    // TODO(kinggoesgaming): discuss to_ vs as_ vs into_
+    // TODO: discuss to_ vs as_ vs into_
     #[cfg(feature = "const_fn")]
     #[inline]
-    pub fn to_simple(self) -> UuidSimple {
-        UuidSimple::from_uuid(self)
+    pub fn to_simple(self) -> Simple {
+        Simple::from_uuid(self)
     }
 
     /// Creates a [`UuidSimpleRef`] instance from a [`Uuid`] reference.
     ///
     /// [`Uuid`]: ../struct.Uuid.html
     /// [`UuidSimpleRef`]: struct.UuidSimpleRef.html
-    // TODO(kinggoesgaming): discuss to_ vs as_ vs into_
+    // TODO: discuss to_ vs as_ vs into_
     #[cfg(not(feature = "const_fn"))]
     #[inline]
-    pub fn to_simple_ref(&self) -> UuidSimpleRef {
-        UuidSimpleRef::from_uuid_ref(self)
+    pub fn to_simple_ref(&self) -> SimpleRef {
+        SimpleRef::from_uuid_ref(self)
     }
 
     /// Creates a [`UuidSimpleRef`] instance from a [`Uuid`] reference.
     ///
     /// [`Uuid`]: ../struct.Uuid.html
     /// [`UuidSimpleRef`]: struct.UuidSimpleRef.html
-    // TODO(kinggoesgaming): discuss to_ vs as_ vs into_
+    // TODO: discuss to_ vs as_ vs into_
     #[cfg(feature = "const_fn")]
     #[inline]
-    pub fn to_simple_ref(&self) -> UuidSimpleRef {
-        UuidSimpleRef::from_uuid_ref(self)
+    pub fn to_simple_ref(&self) -> SimpleRef {
+        SimpleRef::from_uuid_ref(self)
     }
 
     /// Creates a [`UuidUrn`] instance from a [`Uuid`].
     ///
     /// [`Uuid`]: ../struct.Uuid.html
     /// [`UuidUrn`]: struct.UuidUrn.html
-    // TODO(kinggoesgaming): discuss to_ vs as_ vs into_
+    // TODO: discuss to_ vs as_ vs into_
     #[cfg(not(feature = "const_fn"))]
     #[inline]
-    pub fn to_urn(self) -> UuidUrn {
-        UuidUrn::from_uuid(self)
+    pub fn to_urn(self) -> Urn {
+        Urn::from_uuid(self)
     }
 
     /// Creates a [`UuidUrn`] instance from a [`Uuid`].
     ///
     /// [`Uuid`]: ../struct.Uuid.html
     /// [`UuidUrn`]: struct.UuidUrn.html
-    // TODO(kinggoesgaming): discuss to_ vs as_ vs into_
+    // TODO: discuss to_ vs as_ vs into_
     #[cfg(feature = "const_fn")]
     #[inline]
-    pub fn to_urn(self) -> UuidUrn {
-        UuidUrn::from_uuid(self)
+    pub fn to_urn(self) -> Urn {
+        Urn::from_uuid(self)
     }
 
     /// Creates a [`UuidUrnRef`] instance from a [`Uuid`] reference.
     ///
     /// [`Uuid`]: ../struct.Uuid.html
     /// [`UuidUrnRef`]: struct.UuidUrnRef.html
-    // TODO(kinggoesgaming): discuss to_ vs as_ vs into_
+    // TODO: discuss to_ vs as_ vs into_
     #[cfg(not(feature = "const_fn"))]
     #[inline]
-    pub fn to_urn_ref(&self) -> UuidUrnRef {
-        UuidUrnRef::from_uuid_ref(self)
+    pub fn to_urn_ref(&self) -> UrnRef {
+        UrnRef::from_uuid_ref(self)
     }
 
     /// Creates a [`UuidUrnRef`] instance from a [`Uuid`] reference.
     ///
     /// [`Uuid`]: ../struct.Uuid.html
     /// [`UuidUrnRef`]: struct.UuidUrnRef.html
-    // TODO(kinggoesgaming): discuss to_ vs as_ vs into_
+    // TODO: discuss to_ vs as_ vs into_
     #[cfg(feature = "const_fn")]
     #[inline]
-    pub fn to_urn_ref(&self) -> UuidUrnRef {
-        UuidUrnRef::from_uuid_ref(self)
+    pub fn to_urn_ref(&self) -> UrnRef {
+        UrnRef::from_uuid_ref(self)
     }
 }
 
-impl UuidHyphenated {
+impl Hyphenated {
     /// The length of a hyphenated [`Uuid`] string.
     ///
     /// [`Uuid`]: ../struct.Uuid.html
@@ -211,7 +211,7 @@ impl UuidHyphenated {
     /// [`UuidHyphenated`]: struct.UuidHyphenated.html
     #[cfg(not(feature = "const_fn"))]
     pub fn from_uuid(uuid: Uuid) -> Self {
-        UuidHyphenated(uuid)
+        Hyphenated(uuid)
     }
 
     /// Creates a [`UuidHyphenated`] from a [`Uuid`].
@@ -220,11 +220,11 @@ impl UuidHyphenated {
     /// [`UuidHyphenated`]: struct.UuidHyphenated.html
     #[cfg(feature = "const_fn")]
     pub fn from_uuid(uuid: Uuid) -> Self {
-        UuidHyphenated(uuid)
+        Hyphenated(uuid)
     }
 }
 
-impl<'a> UuidHyphenatedRef<'a> {
+impl<'a> HyphenatedRef<'a> {
     /// The length of a hyphenated [`Uuid`] string.
     ///
     /// [`Uuid`]: ../struct.Uuid.html
@@ -236,7 +236,7 @@ impl<'a> UuidHyphenatedRef<'a> {
     /// [`UuidHyphenatedRef`]: struct.UuidHyphenatedRef.html
     #[cfg(not(feature = "const_fn"))]
     pub fn from_uuid_ref(uuid: &'a Uuid) -> Self {
-        UuidHyphenatedRef(uuid)
+        HyphenatedRef(uuid)
     }
 
     /// Creates a [`UuidHyphenatedRef`] from a [`Uuid`] reference.
@@ -245,11 +245,11 @@ impl<'a> UuidHyphenatedRef<'a> {
     /// [`UuidHyphenatedRef`]: struct.UuidHyphenatedRef.html
     #[cfg(feature = "const_fn")]
     pub fn from_uuid_ref(uuid: &'a Uuid) -> Self {
-        UuidHyphenatedRef(uuid)
+        HyphenatedRef(uuid)
     }
 }
 
-impl UuidSimple {
+impl Simple {
     /// The length of a simple [`Uuid`] string.
     ///
     /// [`Uuid`]: ../struct.Uuid.html
@@ -261,7 +261,7 @@ impl UuidSimple {
     /// [`UuidSimple`]: struct.UuidSimple.html
     #[cfg(not(feature = "const_fn"))]
     pub fn from_uuid(uuid: Uuid) -> Self {
-        UuidSimple(uuid)
+        Simple(uuid)
     }
 
     /// Creates a [`UuidSimple`] from a [`Uuid`].
@@ -270,11 +270,11 @@ impl UuidSimple {
     /// [`UuidSimple`]: struct.UuidSimple.html
     #[cfg(feature = "const_fn")]
     pub fn from_uuid(uuid: Uuid) -> Self {
-        UuidSimple(uuid)
+        Simple(uuid)
     }
 }
 
-impl<'a> UuidSimpleRef<'a> {
+impl<'a> SimpleRef<'a> {
     /// The length of a simple [`Uuid`] string.
     ///
     /// [`Uuid`]: ../struct.Uuid.html
@@ -286,7 +286,7 @@ impl<'a> UuidSimpleRef<'a> {
     /// [`UuidSimpleRef`]: struct.UuidSimpleRef.html
     #[cfg(not(feature = "const_fn"))]
     pub fn from_uuid_ref(uuid: &'a Uuid) -> Self {
-        UuidSimpleRef(uuid)
+        SimpleRef(uuid)
     }
 
     /// Creates a [`UuidSimpleRef`] from a [`Uuid`] reference.
@@ -295,11 +295,11 @@ impl<'a> UuidSimpleRef<'a> {
     /// [`UuidSimpleRef`]: struct.UuidSimpleRef.html
     #[cfg(feature = "const_fn")]
     pub fn from_uuid_ref(uuid: &'a Uuid) -> Self {
-        UuidSimpleRef(uuid)
+        SimpleRef(uuid)
     }
 }
 
-impl UuidUrn {
+impl Urn {
     /// The length of a URN [`Uuid`] string.
     ///
     /// [`Uuid`]: ../struct.Uuid.html
@@ -311,7 +311,7 @@ impl UuidUrn {
     /// [`UuidUrn`]: struct.UuidUrn.html
     #[cfg(not(feature = "const_fn"))]
     pub fn from_uuid(uuid: Uuid) -> Self {
-        UuidUrn(uuid)
+        Urn(uuid)
     }
 
     /// Creates a [`UuidUrn`] from a [`Uuid`].
@@ -320,11 +320,11 @@ impl UuidUrn {
     /// [`UuidUrn`]: struct.UuidUrn.html
     #[cfg(feature = "const_fn")]
     pub fn from_uuid(uuid: Uuid) -> Self {
-        UuidUrn(uuid)
+        Urn(uuid)
     }
 }
 
-impl<'a> UuidUrnRef<'a> {
+impl<'a> UrnRef<'a> {
     /// The length of a URN [`Uuid`] string.
     ///
     /// [`Uuid`]: ../struct.Uuid.html
@@ -336,7 +336,7 @@ impl<'a> UuidUrnRef<'a> {
     /// [`UuidUrnRef`]: struct.UuidUrnRef.html
     #[cfg(not(feature = "const_fn"))]
     pub fn from_uuid_ref(uuid: &'a Uuid) -> Self {
-        UuidUrnRef(uuid)
+        UrnRef(uuid)
     }
 
     /// Creates a [`UuidUrnRef`] from a [`Uuid`] reference.
@@ -345,6 +345,6 @@ impl<'a> UuidUrnRef<'a> {
     /// [`UuidUrnRef`]: struct.UuidUrnRef.html
     #[cfg(feature = "const_fn")]
     pub fn from_uuid_ref(uuid: &'a Uuid) -> Self {
-        UuidUrnRef(&uuid)
+        UrnRef(&uuid)
     }
 }

--- a/src/core_support.rs
+++ b/src/core_support.rs
@@ -19,18 +19,18 @@ impl fmt::Display for Uuid {
     }
 }
 
-impl fmt::Display for UuidVariant {
+impl fmt::Display for Variant {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match *self {
-            UuidVariant::NCS => write!(f, "NCS"),
-            UuidVariant::RFC4122 => write!(f, "RFC4122"),
-            UuidVariant::Microsoft => write!(f, "Microsoft"),
-            UuidVariant::Future => write!(f, "Future"),
+            Variant::NCS => write!(f, "NCS"),
+            Variant::RFC4122 => write!(f, "RFC4122"),
+            Variant::Microsoft => write!(f, "Microsoft"),
+            Variant::Future => write!(f, "Future"),
         }
     }
 }
 
-impl fmt::Display for ::UuidError {
+impl fmt::Display for ::BytesError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         write!(
             f,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,8 +137,6 @@ extern crate sha1;
 #[cfg_attr(test, macro_use)]
 extern crate slog;
 
-use core::{fmt, str};
-
 pub mod adapter;
 pub mod parser;
 pub mod prelude;
@@ -383,7 +381,7 @@ impl Uuid {
     ///
     /// let uuid = uuid::Uuid::from_fields(42, 12, 5, &d4);
     ///
-    /// let expected_uuid = Err(uuid::UuidError::new(8, d4.len()));
+    /// let expected_uuid = Err(uuid::BytesError::new(8, d4.len()));
     ///
     /// assert_eq!(expected_uuid, uuid);
     /// ```
@@ -455,7 +453,7 @@ impl Uuid {
     ///
     /// let uuid = Uuid::from_bytes(&bytes);
     ///
-    /// let expected_uuid = Err(uuid::UuidError::new(16, 8));
+    /// let expected_uuid = Err(uuid::BytesError::new(16, 8));
     ///
     /// assert_eq!(expected_uuid, uuid);
     /// ```
@@ -522,9 +520,9 @@ impl Uuid {
     ///
     /// ```
     /// use uuid::Uuid;
-    /// use uuid::UuidBytes;
+    /// use uuid::Bytes;
     ///
-    /// let bytes: UuidBytes = [
+    /// let bytes: Bytes = [
     ///     70, 235, 208, 238, 14, 109, 67, 201, 185, 13, 204, 195, 90, 145, 63,
     ///     62,
     /// ];
@@ -541,10 +539,9 @@ impl Uuid {
     ///
     /// ```compile_fail
     /// use uuid::Uuid;
-    /// use uuid::UuidBytes;
+    /// use uuid::Bytes;
     ///
-    /// let bytes: UuidBytes = [4, 54, 67, 12, 43, 2, 98, 76]; // doesn't
-    /// compile
+    /// let bytes: Bytes = [4, 54, 67, 12, 43, 2, 98, 76]; // doesn't compile
     ///
     /// let uuid = Uuid::from_uuid_bytes(bytes);
     /// ```
@@ -563,9 +560,9 @@ impl Uuid {
     ///
     /// ```
     /// use uuid::Uuid;
-    /// use uuid::UuidBytes;
+    /// use uuid::Bytes;
     ///
-    /// let bytes: UuidBytes = [
+    /// let bytes: Bytes = [
     ///     70, 235, 208, 238, 14, 109, 67, 201, 185, 13, 204, 195, 90, 145, 63,
     ///     62,
     /// ];
@@ -1260,7 +1257,7 @@ mod tests {
 
     #[test]
     fn test_upper_lower_hex() {
-        use super::fmt::Write;
+        use tests::std::fmt::Write;
 
         let mut buf = String::new();
         let u = test_util::new();

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -162,13 +162,13 @@ mod v4;
 mod v5;
 
 /// A 128-bit (16 byte) buffer containing the ID.
-pub type UuidBytes = [u8; 16];
+pub type Bytes = [u8; 16];
 
 /// The error that can occur when creating a [`Uuid`].
 ///
 /// [`Uuid`]: struct.Uuid.html
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct UuidError {
+pub struct BytesError {
     expected: usize,
     found: usize,
 }
@@ -176,7 +176,7 @@ pub struct UuidError {
 /// The version of the UUID, denoting the generating algorithm.
 #[derive(Debug, PartialEq, Copy, Clone)]
 #[repr(C)]
-pub enum UuidVersion {
+pub enum Version {
     /// Special case for `nil` [`Uuid`].
     ///
     /// [`Uuid`]: struct.Uuid.html
@@ -196,7 +196,7 @@ pub enum UuidVersion {
 /// The reserved variants of UUIDs.
 #[derive(Clone, Copy, Debug, PartialEq)]
 #[repr(C)]
-pub enum UuidVariant {
+pub enum Variant {
     /// Reserved by the NCS for backward compatibility
     NCS = 0,
     /// As described in the RFC4122 Specification (default)
@@ -209,9 +209,9 @@ pub enum UuidVariant {
 
 /// A Universally Unique Identifier (UUID).
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub struct Uuid(UuidBytes);
+pub struct Uuid(Bytes);
 
-impl UuidError {
+impl BytesError {
     /// The expected number of bytes.
     #[cfg(feature = "const_fn")]
     #[inline]
@@ -246,7 +246,7 @@ impl UuidError {
     #[cfg(feature = "const_fn")]
     #[inline]
     pub const fn new(expected: usize, found: usize) -> Self {
-        UuidError {
+        BytesError {
             expected: expected,
             found: found,
         }
@@ -258,9 +258,9 @@ impl UuidError {
     #[cfg(not(feature = "const_fn"))]
     #[inline]
     pub fn new(expected: usize, found: usize) -> Self {
-        UuidError {
-            expected: expected,
-            found: found,
+        BytesError {
+            expected,
+            found,
         }
     }
 }
@@ -387,18 +387,19 @@ impl Uuid {
     ///
     /// assert_eq!(expected_uuid, uuid);
     /// ```
+    // TODO: discuss rename to `from_slice`
     pub fn from_fields(
         d1: u32,
         d2: u16,
         d3: u16,
         d4: &[u8],
-    ) -> Result<Uuid, UuidError> {
+    ) -> Result<Uuid, BytesError> {
         const D4_LEN: usize = 8;
 
         let len = d4.len();
 
         if len != D4_LEN {
-            return Err(UuidError::new(D4_LEN, len));
+            return Err(BytesError::new(D4_LEN, len));
         }
 
         Ok(Uuid::from_uuid_bytes([
@@ -458,16 +459,17 @@ impl Uuid {
     ///
     /// assert_eq!(expected_uuid, uuid);
     /// ```
-    pub fn from_bytes(b: &[u8]) -> Result<Uuid, UuidError> {
+    // TODO: discuss rename to `from_slice`
+    pub fn from_bytes(b: &[u8]) -> Result<Uuid, BytesError> {
         const BYTES_LEN: usize = 16;
 
         let len = b.len();
 
         if len != BYTES_LEN {
-            return Err(UuidError::new(BYTES_LEN, len));
+            return Err(BytesError::new(BYTES_LEN, len));
         }
 
-        let mut bytes: UuidBytes = [0; 16];
+        let mut bytes: Bytes = [0; 16];
         bytes.copy_from_slice(b);
         Ok(Uuid::from_uuid_bytes(bytes))
     }
@@ -506,8 +508,9 @@ impl Uuid {
     ///
     /// let uuid = Uuid::from_uuid_bytes(bytes);
     /// ```
+    // TODO: discuss rename to `from_bytes`
     #[cfg(not(feature = "const_fn"))]
-    pub fn from_uuid_bytes(bytes: UuidBytes) -> Uuid {
+    pub fn from_uuid_bytes(bytes: Bytes) -> Uuid {
         Uuid(bytes)
     }
 
@@ -545,8 +548,9 @@ impl Uuid {
     ///
     /// let uuid = Uuid::from_uuid_bytes(bytes);
     /// ```
+    // TODO: discuss rename to `from_bytes`
     #[cfg(feature = "const_fn")]
-    pub const fn from_uuid_bytes(bytes: UuidBytes) -> Uuid {
+    pub const fn from_uuid_bytes(bytes: Bytes) -> Uuid {
         Uuid(bytes)
     }
 
@@ -573,21 +577,21 @@ impl Uuid {
     /// assert_eq!(expected_uuid, uuid);
     /// ```
     ///
-    pub fn from_random_bytes(bytes: UuidBytes) -> Uuid {
+    pub fn from_random_bytes(bytes: Bytes) -> Uuid {
         let mut uuid = Uuid::from_uuid_bytes(bytes);
-        uuid.set_variant(UuidVariant::RFC4122);
-        uuid.set_version(UuidVersion::Random);
+        uuid.set_variant(Variant::RFC4122);
+        uuid.set_version(Version::Random);
         uuid
     }
 
     /// Specifies the variant of the UUID structure
-    fn set_variant(&mut self, v: UuidVariant) {
+    fn set_variant(&mut self, v: Variant) {
         // Octet 8 contains the variant in the most significant 3 bits
         self.0[8] = match v {
-            UuidVariant::NCS => self.as_bytes()[8] & 0x7f, // b0xx...
-            UuidVariant::RFC4122 => (self.as_bytes()[8] & 0x3f) | 0x80, /* b10x... */
-            UuidVariant::Microsoft => (self.as_bytes()[8] & 0x1f) | 0xc0, /* b110... */
-            UuidVariant::Future => (self.as_bytes()[8] & 0x1f) | 0xe0, /* b111... */
+            Variant::NCS => self.as_bytes()[8] & 0x7f, // b0xx...
+            Variant::RFC4122 => (self.as_bytes()[8] & 0x3f) | 0x80, /* b10x... */
+            Variant::Microsoft => (self.as_bytes()[8] & 0x1f) | 0xc0, /* b110... */
+            Variant::Future => (self.as_bytes()[8] & 0x1f) | 0xe0, /* b111... */
         }
     }
 
@@ -597,18 +601,18 @@ impl Uuid {
     /// Currently only the RFC4122 variant is generated by this module.
     ///
     /// * [Variant Reference](http://tools.ietf.org/html/rfc4122#section-4.1.1)
-    pub fn get_variant(&self) -> Option<UuidVariant> {
+    pub fn get_variant(&self) -> Option<Variant> {
         match self.as_bytes()[8] {
-            x if x & 0x80 == 0x00 => Some(UuidVariant::NCS),
-            x if x & 0xc0 == 0x80 => Some(UuidVariant::RFC4122),
-            x if x & 0xe0 == 0xc0 => Some(UuidVariant::Microsoft),
-            x if x & 0xe0 == 0xe0 => Some(UuidVariant::Future),
+            x if x & 0x80 == 0x00 => Some(Variant::NCS),
+            x if x & 0xc0 == 0x80 => Some(Variant::RFC4122),
+            x if x & 0xe0 == 0xc0 => Some(Variant::Microsoft),
+            x if x & 0xe0 == 0xe0 => Some(Variant::Future),
             _ => None,
         }
     }
 
     /// Specifies the version number of the `Uuid`.
-    fn set_version(&mut self, v: UuidVersion) {
+    fn set_version(&mut self, v: Version) {
         self.0[6] = (self.as_bytes()[6] & 0xF) | ((v as u8) << 4);
     }
 
@@ -630,15 +634,15 @@ impl Uuid {
     /// Returns the version of the `Uuid`.
     ///
     /// This represents the algorithm used to generate the contents
-    pub fn get_version(&self) -> Option<UuidVersion> {
+    pub fn get_version(&self) -> Option<Version> {
         let v = self.as_bytes()[6] >> 4;
         match v {
-            0 if self.is_nil() => Some(UuidVersion::Nil),
-            1 => Some(UuidVersion::Mac),
-            2 => Some(UuidVersion::Dce),
-            3 => Some(UuidVersion::Md5),
-            4 => Some(UuidVersion::Random),
-            5 => Some(UuidVersion::Sha1),
+            0 if self.is_nil() => Some(Version::Nil),
+            1 => Some(Version::Mac),
+            2 => Some(Version::Dce),
+            3 => Some(Version::Md5),
+            4 => Some(Version::Random),
+            5 => Some(Version::Sha1),
             _ => None,
         }
     }
@@ -720,7 +724,7 @@ impl Uuid {
     /// );
     /// ```
     #[cfg(feature = "const_fn")]
-    pub const fn as_bytes(&self) -> &UuidBytes {
+    pub const fn as_bytes(&self) -> &Bytes {
         &self.0
     }
 
@@ -744,7 +748,7 @@ impl Uuid {
     /// );
     /// ```
     #[cfg(not(feature = "const_fn"))]
-    pub fn as_bytes(&self) -> &UuidBytes {
+    pub fn as_bytes(&self) -> &Bytes {
         &self.0
     }
 
@@ -754,7 +758,7 @@ impl Uuid {
     pub fn to_timestamp(&self) -> Option<(u64, u16)> {
         if self
             .get_version()
-            .map(|v| v != UuidVersion::Mac)
+            .map(|v| v != Version::Mac)
             .unwrap_or(true)
         {
             return None;
@@ -784,16 +788,16 @@ impl Uuid {
         // Ensure length is valid for any of the supported formats
         let len = input.len();
 
-        if len == adapter::UuidUrn::LENGTH && input.starts_with("urn:uuid:") {
+        if len == adapter::Urn::LENGTH && input.starts_with("urn:uuid:") {
             input = &input[9..];
         } else if !parser::len_matches_any(
             len,
-            &[adapter::UuidHyphenated::LENGTH, adapter::UuidSimple::LENGTH],
+            &[adapter::Hyphenated::LENGTH, adapter::Simple::LENGTH],
         ) {
             return Err(parser::UuidParseError::InvalidLength {
                 expected: parser::Expected::Any(&[
-                    adapter::UuidHyphenated::LENGTH,
-                    adapter::UuidSimple::LENGTH,
+                    adapter::Hyphenated::LENGTH,
+                    adapter::Simple::LENGTH,
                 ]),
                 found: len,
             });
@@ -806,12 +810,12 @@ impl Uuid {
         let mut buffer = [0u8; 16];
 
         for (i_char, chr) in input.bytes().enumerate() {
-            if digit as usize >= adapter::UuidSimple::LENGTH && group != 4 {
+            if digit as usize >= adapter::Simple::LENGTH && group != 4 {
                 if group == 0 {
                     return Err(parser::UuidParseError::InvalidLength {
                         expected: parser::Expected::Any(&[
-                            adapter::UuidHyphenated::LENGTH,
-                            adapter::UuidSimple::LENGTH,
+                            adapter::Hyphenated::LENGTH,
+                            adapter::Simple::LENGTH,
                         ]),
                         found: len,
                     });
@@ -953,8 +957,8 @@ mod tests {
         assert!(nil.is_nil());
         assert!(!not_nil.is_nil());
 
-        assert_eq!(nil.get_version(), Some(UuidVersion::Nil));
-        assert_eq!(not_nil.get_version(), Some(UuidVersion::Random))
+        assert_eq!(nil.get_version(), Some(Version::Nil));
+        assert_eq!(not_nil.get_version(), Some(Version::Random))
     }
 
     #[test]
@@ -983,7 +987,7 @@ mod tests {
         let uuid =
             Uuid::new_v3(&Uuid::NAMESPACE_DNS, "rust-lang.org".as_bytes());
 
-        assert_eq!(uuid.get_version().unwrap(), UuidVersion::Md5);
+        assert_eq!(uuid.get_version().unwrap(), Version::Md5);
         assert_eq!(uuid.get_version_num(), 3);
     }
 
@@ -1001,12 +1005,12 @@ mod tests {
         let uuid6 =
             Uuid::parse_str("f81d4fae-7dec-11d0-7765-00a0c91e6bf6").unwrap();
 
-        assert_eq!(uuid1.get_variant().unwrap(), UuidVariant::RFC4122);
-        assert_eq!(uuid2.get_variant().unwrap(), UuidVariant::RFC4122);
-        assert_eq!(uuid3.get_variant().unwrap(), UuidVariant::RFC4122);
-        assert_eq!(uuid4.get_variant().unwrap(), UuidVariant::Microsoft);
-        assert_eq!(uuid5.get_variant().unwrap(), UuidVariant::Microsoft);
-        assert_eq!(uuid6.get_variant().unwrap(), UuidVariant::NCS);
+        assert_eq!(uuid1.get_variant().unwrap(), Variant::RFC4122);
+        assert_eq!(uuid2.get_variant().unwrap(), Variant::RFC4122);
+        assert_eq!(uuid3.get_variant().unwrap(), Variant::RFC4122);
+        assert_eq!(uuid4.get_variant().unwrap(), Variant::Microsoft);
+        assert_eq!(uuid5.get_variant().unwrap(), Variant::Microsoft);
+        assert_eq!(uuid6.get_variant().unwrap(), Variant::NCS);
     }
 
     #[test]
@@ -1016,8 +1020,8 @@ mod tests {
 
         const EXPECTED_UUID_LENGTHS: parser::Expected =
             parser::Expected::Any(&[
-                adapter::UuidHyphenated::LENGTH,
-                adapter::UuidSimple::LENGTH,
+                adapter::Hyphenated::LENGTH,
+                adapter::Simple::LENGTH,
             ]);
 
         const EXPECTED_GROUP_COUNTS: parser::Expected =
@@ -1401,7 +1405,7 @@ mod tests {
 
     #[test]
     fn test_bytes_roundtrip() {
-        let b_in: ::UuidBytes = [
+        let b_in: ::Bytes = [
             0xa1, 0xa2, 0xa3, 0xa4, 0xb1, 0xb2, 0xc1, 0xc2, 0xd1, 0xd2, 0xd3,
             0xd4, 0xd5, 0xd6, 0xd7, 0xd8,
         ];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -256,10 +256,7 @@ impl BytesError {
     #[cfg(not(feature = "const_fn"))]
     #[inline]
     pub fn new(expected: usize, found: usize) -> Self {
-        BytesError {
-            expected,
-            found,
-        }
+        BytesError { expected, found }
     }
 }
 
@@ -479,8 +476,8 @@ impl Uuid {
     /// Basic usage:
     ///
     /// ```
-    /// use uuid::Uuid;
     /// use uuid::Bytes;
+    /// use uuid::Uuid;
     ///
     /// let bytes: Bytes = [
     ///     70, 235, 208, 238, 14, 109, 67, 201, 185, 13, 204, 195, 90, 145, 63,
@@ -519,8 +516,8 @@ impl Uuid {
     /// Basic usage:
     ///
     /// ```
-    /// use uuid::Uuid;
     /// use uuid::Bytes;
+    /// use uuid::Uuid;
     ///
     /// let bytes: Bytes = [
     ///     70, 235, 208, 238, 14, 109, 67, 201, 185, 13, 204, 195, 90, 145, 63,
@@ -538,8 +535,8 @@ impl Uuid {
     /// An incorrect number of bytes:
     ///
     /// ```compile_fail
-    /// use uuid::Uuid;
     /// use uuid::Bytes;
+    /// use uuid::Uuid;
     ///
     /// let bytes: Bytes = [4, 54, 67, 12, 43, 2, 98, 76]; // doesn't compile
     ///
@@ -559,8 +556,8 @@ impl Uuid {
     /// Basic usage:
     ///
     /// ```
-    /// use uuid::Uuid;
     /// use uuid::Bytes;
+    /// use uuid::Uuid;
     ///
     /// let bytes: Bytes = [
     ///     70, 235, 208, 238, 14, 109, 67, 201, 185, 13, 204, 195, 90, 145, 63,
@@ -586,9 +583,9 @@ impl Uuid {
         // Octet 8 contains the variant in the most significant 3 bits
         self.0[8] = match v {
             Variant::NCS => self.as_bytes()[8] & 0x7f, // b0xx...
-            Variant::RFC4122 => (self.as_bytes()[8] & 0x3f) | 0x80, /* b10x... */
-            Variant::Microsoft => (self.as_bytes()[8] & 0x1f) | 0xc0, /* b110... */
-            Variant::Future => (self.as_bytes()[8] & 0x1f) | 0xe0, /* b111... */
+            Variant::RFC4122 => (self.as_bytes()[8] & 0x3f) | 0x80, // b10x...
+            Variant::Microsoft => (self.as_bytes()[8] & 0x1f) | 0xc0, // b110...
+            Variant::Future => (self.as_bytes()[8] & 0x1f) | 0xe0, // b111...
         }
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -480,9 +480,9 @@ impl Uuid {
     ///
     /// ```
     /// use uuid::Uuid;
-    /// use uuid::UuidBytes;
+    /// use uuid::Bytes;
     ///
-    /// let bytes: UuidBytes = [
+    /// let bytes: Bytes = [
     ///     70, 235, 208, 238, 14, 109, 67, 201, 185, 13, 204, 195, 90, 145, 63,
     ///     62,
     /// ];

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -47,7 +47,7 @@ handling uuid version 1. Requires feature `v1`.
 [`UuidClockSequence`]: ../v1/trait.UuidClockSequence.html")]
 
 #[doc(inline)]
-pub use super::{Uuid, Bytes, Variant, Version};
+pub use super::{Bytes, Uuid, Variant, Version};
 #[cfg(feature = "v1")]
 #[doc(inline)]
 pub use v1::{ClockSequence, Context};

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -39,15 +39,15 @@
 //!
 #![cfg_attr(feature = "v1",
 doc = "
-[`uuid::v1`]`::{`[`UuidClockSequence`],[`UuidContext`]`}`: The types useful for
+[`uuid::v1`]`::{`[`UuidClockSequence`],[`Context`]`}`: The types useful for
 handling uuid version 1. Requires feature `v1`.
 
 [`uuid::v1`]: ../v1/index.html
-[`UuidContext`]: ../v1/struct.UuidContext.html
+[`Context`]: ../v1/struct.Context.html
 [`UuidClockSequence`]: ../v1/trait.UuidClockSequence.html")]
 
 #[doc(inline)]
-pub use super::{Uuid, UuidBytes, UuidVariant, UuidVersion};
+pub use super::{Uuid, Bytes, Variant, Version};
 #[cfg(feature = "v1")]
 #[doc(inline)]
-pub use v1::{UuidClockSequence, UuidContext};
+pub use v1::{ClockSequence, Context};

--- a/src/u128_support.rs
+++ b/src/u128_support.rs
@@ -27,7 +27,7 @@ impl Uuid {
 
 impl From<u128> for Uuid {
     fn from(f: u128) -> Self {
-        let mut bytes: ::UuidBytes = [0; 16];
+        let mut bytes: ::Bytes = [0; 16];
 
         {
             use byteorder::ByteOrder;

--- a/src/v1.rs
+++ b/src/v1.rs
@@ -10,12 +10,12 @@ use prelude::*;
 /// A thread-safe, stateful context for the v1 generator to help ensure
 /// process-wide uniqueness.
 #[derive(Debug)]
-pub struct UuidContext {
+pub struct Context {
     count: atomic::AtomicUsize,
 }
 
 /// A trait that abstracts over generation of Uuid v1 "Clock Sequence" values.
-pub trait UuidClockSequence {
+pub trait ClockSequence {
     /// Return a 16-bit number that will be used as the "clock sequence" in
     /// the Uuid. The number must be different if the time has changed since
     /// the last time a clock sequence was requested.
@@ -37,7 +37,7 @@ impl Uuid {
     /// 3. The [`UuidClockSequence`] implementation reliably returns unique
     ///    clock sequences (this crate provides [`UuidV1Context`] for this
     ///    purpose. However you can create your own [`UuidClockSequence`]
-    ///    implementation, if [`UuidContext`] does not meet your needs).
+    ///    implementation, if [`Context`] does not meet your needs).
     ///
     /// The NodeID must be exactly 6 bytes long. If the NodeID is not a valid
     /// length this will return a [`ParseError`]`::InvalidLength`.
@@ -59,10 +59,10 @@ impl Uuid {
     /// Basic usage:
     ///
     /// ```rust
-    /// use uuid::v1::UuidContext;
+    /// use uuid::v1::Context;
     /// use uuid::Uuid;
     ///
-    /// let context = UuidContext::new(42);
+    /// let context = Context::new(42);
     /// if let Ok(uuid) =
     ///     Uuid::new_v1(&context, 1497624119, 1234, &[1, 2, 3, 4, 5, 6])
     /// {
@@ -78,21 +78,21 @@ impl Uuid {
     /// [`ParseError`]: ../enum.ParseError.html
     /// [`Uuid`]: ../struct.Uuid.html
     /// [`UuidClockSequence`]: struct.UuidClockSequence.html
-    /// [`UuidContext`]: struct.UuidContext.html
+    /// [`Context`]: struct.Context.html
     pub fn new_v1<T>(
         context: &T,
         seconds: u64,
         nano_seconds: u32,
         node_id: &[u8],
-    ) -> Result<Self, ::UuidError>
+    ) -> Result<Self, ::BytesError>
     where
-        T: UuidClockSequence,
+        T: ClockSequence,
     {
         const NODE_ID_LEN: usize = 6;
 
         let len = node_id.len();
         if len != NODE_ID_LEN {
-            return Err(::UuidError::new(NODE_ID_LEN, len));
+            return Err(::BytesError::new(NODE_ID_LEN, len));
         }
 
         let time_low;
@@ -128,7 +128,7 @@ impl Uuid {
     }
 }
 
-impl UuidContext {
+impl Context {
     /// Creates a thread-safe, internally mutable context to help ensure
     /// uniqueness.
     ///
@@ -146,7 +146,7 @@ impl UuidContext {
     }
 }
 
-impl UuidClockSequence for UuidContext {
+impl ClockSequence for Context {
     fn generate_sequence(&self, _: u64, _: u32) -> u16 {
         (self.count.fetch_add(1, atomic::Ordering::SeqCst) & 0xffff) as u16
     }
@@ -156,20 +156,20 @@ impl UuidClockSequence for UuidContext {
 mod tests {
     #[test]
     fn test_new_v1() {
-        use super::UuidContext;
+        use super::Context;
         use prelude::*;
 
         let time: u64 = 1_496_854_535;
         let time_fraction: u32 = 812_946_000;
         let node = [1, 2, 3, 4, 5, 6];
-        let context = UuidContext::new(0);
+        let context = Context::new(0);
 
         {
             let uuid =
                 Uuid::new_v1(&context, time, time_fraction, &node).unwrap();
 
-            assert_eq!(uuid.get_version(), Some(UuidVersion::Mac));
-            assert_eq!(uuid.get_variant(), Some(UuidVariant::RFC4122));
+            assert_eq!(uuid.get_version(), Some(Version::Mac));
+            assert_eq!(uuid.get_variant(), Some(Variant::RFC4122));
             assert_eq!(
                 uuid.to_hyphenated().to_string(),
                 "20616934-4ba2-11e7-8000-010203040506"

--- a/src/v3.rs
+++ b/src/v3.rs
@@ -28,8 +28,8 @@ impl Uuid {
 
         let mut uuid = Uuid::from_uuid_bytes(context.compute().into());
 
-        uuid.set_variant(UuidVariant::RFC4122);
-        uuid.set_version(UuidVersion::Md5);
+        uuid.set_variant(Variant::RFC4122);
+        uuid.set_version(Version::Md5);
         uuid
     }
 }
@@ -125,8 +125,8 @@ mod tests {
     fn test_new() {
         for &(ref ns, ref name, _) in FIXTURE {
             let uuid = Uuid::new_v3(*ns, name.as_bytes());
-            assert_eq!(uuid.get_version().unwrap(), UuidVersion::Md5);
-            assert_eq!(uuid.get_variant().unwrap(), UuidVariant::RFC4122);
+            assert_eq!(uuid.get_version().unwrap(), Version::Md5);
+            assert_eq!(uuid.get_variant().unwrap(), Variant::RFC4122);
         }
     }
 

--- a/src/v4.rs
+++ b/src/v4.rs
@@ -43,15 +43,15 @@ mod tests {
     fn test_new() {
         let uuid = Uuid::new_v4();
 
-        assert_eq!(uuid.get_version(), Some(UuidVersion::Random));
-        assert_eq!(uuid.get_variant(), Some(UuidVariant::RFC4122));
+        assert_eq!(uuid.get_version(), Some(Version::Random));
+        assert_eq!(uuid.get_variant(), Some(Variant::RFC4122));
     }
 
     #[test]
     fn test_get_version() {
         let uuid = Uuid::new_v4();
 
-        assert_eq!(uuid.get_version(), Some(UuidVersion::Random));
+        assert_eq!(uuid.get_version(), Some(Version::Random));
         assert_eq!(uuid.get_version_num(), 4)
     }
 }

--- a/src/v5.rs
+++ b/src/v5.rs
@@ -28,8 +28,8 @@ impl Uuid {
         let mut uuid = Uuid::default();
 
         uuid.0.copy_from_slice(&buffer[..16]);
-        uuid.set_variant(UuidVariant::RFC4122);
-        uuid.set_version(UuidVersion::Sha1);
+        uuid.set_variant(Variant::RFC4122);
+        uuid.set_version(Version::Sha1);
 
         uuid
     }
@@ -127,7 +127,7 @@ mod tests {
         let uuid =
             Uuid::new_v5(&Uuid::NAMESPACE_DNS, "rust-lang.org".as_bytes());
 
-        assert_eq!(uuid.get_version(), Some(UuidVersion::Sha1));
+        assert_eq!(uuid.get_version(), Some(Version::Sha1));
         assert_eq!(uuid.get_version_num(), 5);
     }
 
@@ -145,8 +145,8 @@ mod tests {
         for &(ref ns, ref name, ref u) in FIXTURE {
             let uuid = Uuid::new_v5(*ns, name.as_bytes());
 
-            assert_eq!(uuid.get_variant(), Some(UuidVariant::RFC4122));
-            assert_eq!(uuid.get_version(), Some(UuidVersion::Sha1));
+            assert_eq!(uuid.get_variant(), Some(Variant::RFC4122));
+            assert_eq!(uuid.get_version(), Some(Version::Sha1));
             assert_eq!(Ok(uuid), u.parse());
         }
     }


### PR DESCRIPTION
**I'm submitting a(n)** refactor


# Description

It was discussed in the gitter chat that prefixing every data structure with `Uuid` is redundant.
