### PR TITLE
fix `const_fn` marked functions not being const for adapters

### DIFF
--- a/src/adapter/mod.rs
+++ b/src/adapter/mod.rs
@@ -162,7 +162,7 @@ impl Uuid {
     /// [`UuidUrn`]: struct.UuidUrn.html
     #[cfg(feature = "const_fn")]
     #[inline]
-    pub constfn to_urn(self) -> Urn {
+    pub const fn to_urn(self) -> Urn {
         Urn::from_uuid(self)
     }
 

--- a/src/adapter/mod.rs
+++ b/src/adapter/mod.rs
@@ -82,7 +82,7 @@ impl Uuid {
     /// [`UuidHyphenated`]: struct.UuidHyphenated.html
     #[cfg(feature = "const_fn")]
     #[inline]
-    pub fn to_hyphenated(self) -> Hyphenated {
+    pub const fn to_hyphenated(self) -> Hyphenated {
         Hyphenated::from_uuid(self)
     }
 
@@ -102,7 +102,7 @@ impl Uuid {
     /// [`UuidHyphenatedRef`]: struct.UuidHyphenatedRef.html
     #[cfg(feature = "const_fn")]
     #[inline]
-    pub fn to_hyphenated_ref(&self) -> HyphenatedRef {
+    pub const fn to_hyphenated_ref(&self) -> HyphenatedRef {
         HyphenatedRef::from_uuid_ref(self)
     }
 
@@ -122,7 +122,7 @@ impl Uuid {
     /// [`UuidSimple`]: struct.UuidSimple.html
     #[cfg(feature = "const_fn")]
     #[inline]
-    pub fn to_simple(self) -> Simple {
+    pub const fn to_simple(self) -> Simple {
         Simple::from_uuid(self)
     }
 
@@ -142,7 +142,7 @@ impl Uuid {
     /// [`UuidSimpleRef`]: struct.UuidSimpleRef.html
     #[cfg(feature = "const_fn")]
     #[inline]
-    pub fn to_simple_ref(&self) -> SimpleRef {
+    pub const fn to_simple_ref(&self) -> SimpleRef {
         SimpleRef::from_uuid_ref(self)
     }
 
@@ -162,7 +162,7 @@ impl Uuid {
     /// [`UuidUrn`]: struct.UuidUrn.html
     #[cfg(feature = "const_fn")]
     #[inline]
-    pub fn to_urn(self) -> Urn {
+    pub constfn to_urn(self) -> Urn {
         Urn::from_uuid(self)
     }
 
@@ -182,7 +182,7 @@ impl Uuid {
     /// [`UuidUrnRef`]: struct.UuidUrnRef.html
     #[cfg(feature = "const_fn")]
     #[inline]
-    pub fn to_urn_ref(&self) -> UrnRef {
+    pub const fn to_urn_ref(&self) -> UrnRef {
         UrnRef::from_uuid_ref(self)
     }
 }
@@ -207,7 +207,7 @@ impl Hyphenated {
     /// [`Uuid`]: ../struct.Uuid.html
     /// [`UuidHyphenated`]: struct.UuidHyphenated.html
     #[cfg(feature = "const_fn")]
-    pub fn from_uuid(uuid: Uuid) -> Self {
+    pub const fn from_uuid(uuid: Uuid) -> Self {
         Hyphenated(uuid)
     }
 }
@@ -232,7 +232,7 @@ impl<'a> HyphenatedRef<'a> {
     /// [`Uuid`]: ../struct.Uuid.html
     /// [`UuidHyphenatedRef`]: struct.UuidHyphenatedRef.html
     #[cfg(feature = "const_fn")]
-    pub fn from_uuid_ref(uuid: &'a Uuid) -> Self {
+    pub const fn from_uuid_ref(uuid: &'a Uuid) -> Self {
         HyphenatedRef(uuid)
     }
 }
@@ -257,7 +257,7 @@ impl Simple {
     /// [`Uuid`]: ../struct.Uuid.html
     /// [`UuidSimple`]: struct.UuidSimple.html
     #[cfg(feature = "const_fn")]
-    pub fn from_uuid(uuid: Uuid) -> Self {
+    pub const fn from_uuid(uuid: Uuid) -> Self {
         Simple(uuid)
     }
 }
@@ -282,7 +282,7 @@ impl<'a> SimpleRef<'a> {
     /// [`Uuid`]: ../struct.Uuid.html
     /// [`UuidSimpleRef`]: struct.UuidSimpleRef.html
     #[cfg(feature = "const_fn")]
-    pub fn from_uuid_ref(uuid: &'a Uuid) -> Self {
+    pub const fn from_uuid_ref(uuid: &'a Uuid) -> Self {
         SimpleRef(uuid)
     }
 }
@@ -307,7 +307,7 @@ impl Urn {
     /// [`Uuid`]: ../struct.Uuid.html
     /// [`UuidUrn`]: struct.UuidUrn.html
     #[cfg(feature = "const_fn")]
-    pub fn from_uuid(uuid: Uuid) -> Self {
+    pub const fn from_uuid(uuid: Uuid) -> Self {
         Urn(uuid)
     }
 }
@@ -332,7 +332,7 @@ impl<'a> UrnRef<'a> {
     /// [`Uuid`]: ../struct.Uuid.html
     /// [`UuidUrnRef`]: struct.UuidUrnRef.html
     #[cfg(feature = "const_fn")]
-    pub fn from_uuid_ref(uuid: &'a Uuid) -> Self {
+    pub const fn from_uuid_ref(uuid: &'a Uuid) -> Self {
         UrnRef(&uuid)
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -568,7 +568,6 @@ impl Uuid {
     ///
     /// assert_eq!(expected_uuid, uuid);
     /// ```
-    ///
     pub fn from_random_bytes(bytes: Bytes) -> Uuid {
         let mut uuid = Uuid::from_bytes(bytes);
         uuid.set_variant(Variant::RFC4122);


### PR DESCRIPTION
**I'm submitting a(n)** bug fix

# Description
Fixes `const_fn` functions actually `const fn`

# Motivation
Incorrect behavior see #309

# Tests
N/A

# Related Issue(s)
closes #309 
