### PR TITLE
Add encode_{lower,upper} to formatting adapters for core::fmt-less rendering.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,12 @@ version = "2"
 [dev-dependencies.serde_test]
 version = "1.0.56"
 
+[dev-dependencies.serde_json]
+version = "1.0"
+
+[dev-dependencies.bincode]
+version = "1.0"
+
 [features]
 default = ["std"]
 std = []

--- a/benches/format_str.rs
+++ b/benches/format_str.rs
@@ -35,3 +35,33 @@ fn bench_urn(b: &mut Bencher) {
         test::black_box(buffer);
     })
 }
+
+#[bench]
+fn bench_encode_hyphen(b: &mut Bencher) {
+    let uuid = Uuid::parse_str("F9168C5E-CEB2-4faa-B6BF-329BF39FA1E4").unwrap();
+    b.iter(|| {
+        let mut buffer = [0_u8; 36];
+        uuid.to_hyphenated().encode_lower(&mut buffer);
+        test::black_box(buffer);
+    });
+}
+
+#[bench]
+fn bench_encode_simple(b: &mut Bencher) {
+    let uuid = Uuid::parse_str("F9168C5E-CEB2-4faa-B6BF-329BF39FA1E4").unwrap();
+    b.iter(|| {
+        let mut buffer = [0_u8; 32];
+        uuid.to_simple().encode_lower(&mut buffer);
+        test::black_box(buffer);
+    })
+}
+
+#[bench]
+fn bench_encode_urn(b: &mut Bencher) {
+    let uuid = Uuid::parse_str("F9168C5E-CEB2-4faa-B6BF-329BF39FA1E4").unwrap();
+    b.iter(|| {
+        let mut buffer = [0_u8; 36 + 9];
+        uuid.to_urn().encode_lower(&mut buffer);
+        test::black_box(buffer);
+    })
+}

--- a/benches/serde_support.rs
+++ b/benches/serde_support.rs
@@ -1,0 +1,49 @@
+#![cfg(feature = "serde")]
+#![feature(test)]
+
+extern crate bincode;
+extern crate serde_json;
+extern crate test;
+extern crate uuid;
+
+use test::Bencher;
+use uuid::prelude::*;
+
+#[bench]
+fn bench_json_encode(b: &mut Bencher) {
+    let uuid = Uuid::parse_str("F9168C5E-CEB2-4faa-B6BF-329BF39FA1E4").unwrap();
+    let mut buffer = [0_u8; 38];
+    b.iter(|| {
+        serde_json::to_writer(&mut buffer as &mut [u8], &uuid).unwrap();
+        test::black_box(buffer);
+    });
+    b.bytes = buffer.len() as u64;
+}
+
+#[bench]
+fn bench_json_decode(b: &mut Bencher) {
+    let s = "\"F9168C5E-CEB2-4faa-B6BF-329BF39FA1E4\"";
+    b.iter(|| serde_json::from_str::<Uuid>(s).unwrap());
+    b.bytes = s.len() as u64;
+}
+
+#[bench]
+fn bench_bincode_encode(b: &mut Bencher) {
+    let uuid = Uuid::parse_str("F9168C5E-CEB2-4faa-B6BF-329BF39FA1E4").unwrap();
+    let mut buffer = [0_u8; 24];
+    b.iter(|| {
+        bincode::serialize_into(&mut buffer as &mut [u8], &uuid).unwrap();
+        test::black_box(buffer);
+    });
+    b.bytes = buffer.len() as u64;
+}
+
+#[bench]
+fn bench_bincode_decode(b: &mut Bencher) {
+    let bytes = [
+        16, 0, 0, 0, 0, 0, 0, 0, 249, 22, 140, 94, 206, 178, 79, 170, 182, 191,
+        50, 155, 243, 159, 161, 228,
+    ];
+    b.iter(|| bincode::deserialize::<Uuid>(&bytes).unwrap());
+    b.bytes = bytes.len() as u64;
+}

--- a/src/adapter/core_support/mod.rs
+++ b/src/adapter/core_support/mod.rs
@@ -10,7 +10,6 @@
 // except according to those terms.
 
 use core::fmt;
-use core::str;
 use prelude::*;
 
 impl fmt::Display for super::Hyphenated {
@@ -55,121 +54,81 @@ impl<'a> fmt::Display for super::UrnRef<'a> {
     }
 }
 
-fn format(
-    f: &mut fmt::Formatter,
-    uuid: &Uuid,
-    hyphens: bool,
-    upper: bool,
-) -> fmt::Result {
-    const UPPER: [u8; 16] = [
-        b'0', b'1', b'2', b'3', b'4', b'5', b'6', b'7', b'8', b'9', b'A', b'B',
-        b'C', b'D', b'E', b'F',
-    ];
-    const LOWER: [u8; 16] = [
-        b'0', b'1', b'2', b'3', b'4', b'5', b'6', b'7', b'8', b'9', b'a', b'b',
-        b'c', b'd', b'e', b'f',
-    ];
-
-    let mut buffer = [b'-'; 36];
-    let mut idx = 0;
-
-    let characters = if upper { &UPPER } else { &LOWER };
-
-    for b in uuid.as_bytes() {
-        buffer[idx] = characters[(b >> 4) as usize];
-        buffer[idx + 1] = characters[(b & 0b1111) as usize];
-
-        // Now skip forward to the place to write the next two
-        // characters.  We need to skip forward an extra one to leave
-        // a hyphen when we've just written the two bytes before it
-        // (but only if hyphens are turned on):
-        //
-        // uuid: 00000000-0000-0000-0000-000000000000
-        //             ^    ^    ^    ^
-        // idx:            111111111122
-        //       0123456789012345678901
-        match idx {
-            6 | 11 | 16 | 21 if hyphens => idx += 3,
-            _ => idx += 2,
-        }
-    }
-    let len = if hyphens { 36 } else { 32 };
-    f.write_str(str::from_utf8(&buffer[..len]).unwrap())
-}
-
 impl fmt::LowerHex for super::Hyphenated {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        format(f, &self.0, true, false)
+        f.write_str(self.encode_lower(&mut [0; Self::LENGTH]))
     }
 }
 
 impl<'a> fmt::LowerHex for super::HyphenatedRef<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        format(f, self.0, true, false)
+        // TODO: Self doesn't work https://github.com/rust-lang/rust/issues/52808
+        f.write_str(self.encode_lower(&mut [0; super::HyphenatedRef::LENGTH]))
     }
 }
 
 impl fmt::LowerHex for super::Simple {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        format(f, &self.0, false, false)
+        f.write_str(self.encode_lower(&mut [0; Self::LENGTH]))
     }
 }
 
 impl<'a> fmt::LowerHex for super::SimpleRef<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        format(f, self.0, false, false)
+        // TODO: Self doesn't work https://github.com/rust-lang/rust/issues/52808
+        f.write_str(self.encode_lower(&mut [0; super::SimpleRef::LENGTH]))
     }
 }
 
 impl fmt::LowerHex for super::Urn {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str("urn:uuid:")?;
-        format(f, &self.0, true, false)
+        f.write_str(self.encode_lower(&mut [0; Self::LENGTH]))
     }
 }
 
 impl<'a> fmt::LowerHex for super::UrnRef<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str("urn:uuid:")?;
-        format(f, self.0, true, false)
+        // TODO: Self doesn't work https://github.com/rust-lang/rust/issues/52808
+        f.write_str(self.encode_lower(&mut [0; super::UrnRef::LENGTH]))
     }
 }
 
 impl fmt::UpperHex for super::Hyphenated {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        format(f, &self.0, true, true)
+        f.write_str(self.encode_upper(&mut [0; Self::LENGTH]))
     }
 }
 
 impl<'a> fmt::UpperHex for super::HyphenatedRef<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        format(f, self.0, true, true)
+        // TODO: Self doesn't work https://github.com/rust-lang/rust/issues/52808
+        f.write_str(self.encode_upper(&mut [0; super::HyphenatedRef::LENGTH]))
     }
 }
 
 impl fmt::UpperHex for super::Simple {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        format(f, &self.0, false, true)
+        f.write_str(self.encode_upper(&mut [0; Self::LENGTH]))
     }
 }
 
 impl<'a> fmt::UpperHex for super::SimpleRef<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        format(f, self.0, false, true)
+        // TODO: Self doesn't work https://github.com/rust-lang/rust/issues/52808
+        f.write_str(self.encode_upper(&mut [0; super::SimpleRef::LENGTH]))
     }
 }
 
 impl fmt::UpperHex for super::Urn {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str("urn:uuid:")?;
-        format(f, &self.0, true, true)
+        f.write_str(self.encode_upper(&mut [0; Self::LENGTH]))
     }
 }
 
 impl<'a> fmt::UpperHex for super::UrnRef<'a> {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str("urn:uuid:")?;
-        format(f, self.0, true, true)
+        // TODO: Self doesn't work https://github.com/rust-lang/rust/issues/52808
+        f.write_str(self.encode_upper(&mut [0; super::UrnRef::LENGTH]))
     }
 }
 

--- a/src/adapter/mod.rs
+++ b/src/adapter/mod.rs
@@ -13,6 +13,7 @@
 //!
 //! [`Uuid`]: ../struct.Uuid.html
 
+use core::str;
 use prelude::*;
 
 mod core_support;
@@ -187,6 +188,67 @@ impl Uuid {
     }
 }
 
+const UPPER: [u8; 16] = [
+    b'0', b'1', b'2', b'3', b'4', b'5', b'6', b'7', b'8', b'9', b'A', b'B',
+    b'C', b'D', b'E', b'F',
+];
+const LOWER: [u8; 16] = [
+    b'0', b'1', b'2', b'3', b'4', b'5', b'6', b'7', b'8', b'9', b'a', b'b',
+    b'c', b'd', b'e', b'f',
+];
+/// The segments of a UUID's [u8; 16] corresponding to each group.
+const BYTE_POSITIONS: [usize; 6] = [0, 4, 6, 8, 10, 16];
+/// The locations that hyphens are written into the buffer, after each
+/// group.
+const HYPHEN_POSITIONS: [usize; 4] = [8, 13, 18, 23];
+
+/// Encodes the `uuid` possibly with hyphens, and possibly in upper
+/// case, to full_buffer[start..] and returns the str sliced from
+/// full_buffer[..start + encoded_length].
+///
+/// The `start` parameter allows writing a prefix (such as
+/// "urn:uuid:") to the buffer that's included in the final encoded
+/// UUID.
+fn encode<'a>(
+    full_buffer: &'a mut [u8],
+    start: usize,
+    uuid: &Uuid,
+    hyphens: bool,
+    upper: bool,
+) -> &'a mut str {
+    let len = if hyphens { 36 } else { 32 };
+
+    {
+        let buffer = &mut full_buffer[start..start + len];
+        let bytes = uuid.as_bytes();
+
+        let hex = if upper { &UPPER } else { &LOWER };
+
+        for group in 0..5 {
+            // If we're writing hyphens, we need to shift the output
+            // location along by how many of them have been written
+            // before this point. That's exactly the (0-indexed) group
+            // number.
+            let hyphens_before = if hyphens { group } else { 0 };
+
+            for idx in BYTE_POSITIONS[group]..BYTE_POSITIONS[group + 1] {
+                let b = bytes[idx];
+                let out_idx = hyphens_before + 2 * idx;
+
+                buffer[out_idx + 0] = hex[(b >> 4) as usize];
+                buffer[out_idx + 1] = hex[(b & 0b1111) as usize];
+            }
+
+            if group != 4 && hyphens {
+                buffer[HYPHEN_POSITIONS[group]] = b'-';
+            }
+        }
+    }
+
+    str::from_utf8_mut(&mut full_buffer[..start + len])
+        .expect("found non-ASCII output characters while encoding a UUID")
+}
+
 impl Hyphenated {
     /// The length of a hyphenated [`Uuid`] string.
     ///
@@ -209,6 +271,96 @@ impl Hyphenated {
     #[cfg(feature = "const_fn")]
     pub fn from_uuid(uuid: Uuid) -> Self {
         Hyphenated(uuid)
+    }
+
+    /// Writes the [`UUID`] as a lower-case hyphenated string to
+    /// `buffer`, and returns the subslice of the buffer that contains the
+    /// encoded UUID.
+    ///
+    /// This is slightly more efficient than using the formatting
+    /// infrastructure as it avoids virtual calls, and may avoid
+    /// double buffering.
+    ///
+    /// [`Uuid`]: ../struct.Uuid.html
+    ///
+    /// # Panics
+    ///
+    /// Panics if the buffer is not large enough: it must have length at least
+    /// [`LENGTH`]. [`Uuid::encode_buffer`] can be used to get a
+    /// sufficiently-large temporary buffer.
+    ///
+    /// [`LENGTH`]: #associatedconstant.LENGTH
+    /// [`Uuid::encode_buffer`]: ../struct.Uuid.html#method.encode_buffer
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use uuid::Uuid;
+    ///
+    /// let uuid = Uuid::parse_str("936DA01f9abd4d9d80c702af85c822a8").unwrap();
+    ///
+    /// // the encoded portion is returned
+    /// assert_eq!(
+    ///     uuid.to_hyphenated()
+    ///         .encode_lower(&mut Uuid::encode_buffer()),
+    ///     "936da01f-9abd-4d9d-80c7-02af85c822a8"
+    /// );
+    ///
+    /// // the buffer is mutated directly, and trailing contents remains
+    /// let mut buf = [b'!'; 40];
+    /// uuid.to_hyphenated().encode_lower(&mut buf);
+    /// assert_eq!(
+    ///     &buf as &[_],
+    ///     b"936da01f-9abd-4d9d-80c7-02af85c822a8!!!!" as &[_]
+    /// );
+    /// ```
+    pub fn encode_lower<'buf>(&self, buffer: &'buf mut [u8]) -> &'buf mut str {
+        encode(buffer, 0, &self.0, true, false)
+    }
+
+    /// Writes the [`UUID`] as an upper-case hyphenated string to
+    /// `buffer`, and returns the subslice of the buffer that contains the
+    /// encoded UUID.
+    ///
+    /// This is slightly more efficient than using the formatting
+    /// infrastructure as it avoids virtual calls, and may avoid
+    /// double buffering.
+    ///
+    /// [`Uuid`]: ../struct.Uuid.html
+    ///
+    /// # Panics
+    ///
+    /// Panics if the buffer is not large enough: it must have length at least
+    /// [`LENGTH`]. [`Uuid::encode_buffer`] can be used to get a
+    /// sufficiently-large temporary buffer.
+    ///
+    /// [`LENGTH`]: #associatedconstant.LENGTH
+    /// [`Uuid::encode_buffer`]: ../struct.Uuid.html#method.encode_buffer
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use uuid::Uuid;
+    ///
+    /// let uuid = Uuid::parse_str("936da01f9abd4d9d80c702af85c822a8").unwrap();
+    ///
+    /// // the encoded portion is returned
+    /// assert_eq!(
+    ///     uuid.to_hyphenated()
+    ///         .encode_upper(&mut Uuid::encode_buffer()),
+    ///     "936DA01F-9ABD-4D9D-80C7-02AF85C822A8"
+    /// );
+    ///
+    /// // the buffer is mutated directly, and trailing contents remains
+    /// let mut buf = [b'!'; 40];
+    /// uuid.to_hyphenated().encode_upper(&mut buf);
+    /// assert_eq!(
+    ///     &buf as &[_],
+    ///     b"936DA01F-9ABD-4D9D-80C7-02AF85C822A8!!!!" as &[_]
+    /// );
+    /// ```
+    pub fn encode_upper<'buf>(&self, buffer: &'buf mut [u8]) -> &'buf mut str {
+        encode(buffer, 0, &self.0, true, true)
     }
 }
 
@@ -235,6 +387,103 @@ impl<'a> HyphenatedRef<'a> {
     pub fn from_uuid_ref(uuid: &'a Uuid) -> Self {
         HyphenatedRef(uuid)
     }
+
+    /// Writes the [`UUID`] as a lower-case hyphenated string to
+    /// `buffer`, and returns the subslice of the buffer that contains the
+    /// encoded UUID.
+    ///
+    /// This is slightly more efficient than using the formatting
+    /// infrastructure as it avoids virtual calls, and may avoid
+    /// double buffering.
+    ///
+    /// [`Uuid`]: ../struct.Uuid.html
+    ///
+    /// # Panics
+    ///
+    /// Panics if the buffer is not large enough: it must have length at least
+    /// [`LENGTH`]. [`Uuid::encode_buffer`] can be used to get a
+    /// sufficiently-large temporary buffer.
+    ///
+    /// [`LENGTH`]: #associatedconstant.LENGTH
+    /// [`Uuid::encode_buffer`]: ../struct.Uuid.html#method.encode_buffer
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use uuid::Uuid;
+    ///
+    /// let uuid = Uuid::parse_str("936DA01f9abd4d9d80c702af85c822a8").unwrap();
+    ///
+    /// // the encoded portion is returned
+    /// assert_eq!(
+    ///     uuid.to_hyphenated()
+    ///         .encode_lower(&mut Uuid::encode_buffer()),
+    ///     "936da01f-9abd-4d9d-80c7-02af85c822a8"
+    /// );
+    ///
+    /// // the buffer is mutated directly, and trailing contents remains
+    /// let mut buf = [b'!'; 40];
+    /// uuid.to_hyphenated().encode_lower(&mut buf);
+    /// assert_eq!(
+    ///     uuid.to_hyphenated().encode_lower(&mut buf),
+    ///     "936da01f-9abd-4d9d-80c7-02af85c822a8"
+    /// );
+    /// assert_eq!(
+    ///     &buf as &[_],
+    ///     b"936da01f-9abd-4d9d-80c7-02af85c822a8!!!!" as &[_]
+    /// );
+    /// ```
+    pub fn encode_lower<'buf>(&self, buffer: &'buf mut [u8]) -> &'buf mut str {
+        encode(buffer, 0, self.0, true, false)
+    }
+
+    /// Writes the [`UUID`] as an upper-case hyphenated string to
+    /// `buffer`, and returns the subslice of the buffer that contains the
+    /// encoded UUID.
+    ///
+    /// This is slightly more efficient than using the formatting
+    /// infrastructure as it avoids virtual calls, and may avoid
+    /// double buffering.
+    ///
+    /// [`Uuid`]: ../struct.Uuid.html
+    ///
+    /// # Panics
+    ///
+    /// Panics if the buffer is not large enough: it must have length at least
+    /// [`LENGTH`]. [`Uuid::encode_buffer`] can be used to get a
+    /// sufficiently-large temporary buffer.
+    ///
+    /// [`LENGTH`]: #associatedconstant.LENGTH
+    /// [`Uuid::encode_buffer`]: ../struct.Uuid.html#method.encode_buffer
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use uuid::Uuid;
+    ///
+    /// let uuid = Uuid::parse_str("936da01f9abd4d9d80c702af85c822a8").unwrap();
+    ///
+    /// // the encoded portion is returned
+    /// assert_eq!(
+    ///     uuid.to_hyphenated()
+    ///         .encode_upper(&mut Uuid::encode_buffer()),
+    ///     "936DA01F-9ABD-4D9D-80C7-02AF85C822A8"
+    /// );
+    ///
+    /// // the buffer is mutated directly, and trailing contents remains
+    /// let mut buf = [b'!'; 40];
+    /// assert_eq!(
+    ///     uuid.to_hyphenated().encode_upper(&mut buf),
+    ///     "936DA01F-9ABD-4D9D-80C7-02AF85C822A8"
+    /// );
+    /// assert_eq!(
+    ///     &buf as &[_],
+    ///     b"936DA01F-9ABD-4D9D-80C7-02AF85C822A8!!!!" as &[_]
+    /// );
+    /// ```
+    pub fn encode_upper<'buf>(&self, buffer: &'buf mut [u8]) -> &'buf mut str {
+        encode(buffer, 0, self.0, true, true)
+    }
 }
 
 impl Simple {
@@ -259,6 +508,94 @@ impl Simple {
     #[cfg(feature = "const_fn")]
     pub fn from_uuid(uuid: Uuid) -> Self {
         Simple(uuid)
+    }
+
+    /// Writes the [`UUID`] as a lower-case simple string to `buffer`,
+    /// and returns the subslice of the buffer that contains the encoded UUID.
+    ///
+    /// This is slightly more efficient than using the formatting
+    /// infrastructure as it avoids virtual calls, and may avoid
+    /// double buffering.
+    ///
+    /// [`Uuid`]: ../struct.Uuid.html
+    ///
+    /// # Panics
+    ///
+    /// Panics if the buffer is not large enough: it must have length at least
+    /// [`LENGTH`]. [`Uuid::encode_buffer`] can be used to get a
+    /// sufficiently-large temporary buffer.
+    ///
+    /// [`LENGTH`]: #associatedconstant.LENGTH
+    /// [`Uuid::encode_buffer`]: ../struct.Uuid.html#method.encode_buffer
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use uuid::Uuid;
+    ///
+    /// let uuid = Uuid::parse_str("936DA01f9abd4d9d80c702af85c822a8").unwrap();
+    ///
+    /// // the encoded portion is returned
+    /// assert_eq!(
+    ///     uuid.to_simple().encode_lower(&mut Uuid::encode_buffer()),
+    ///     "936da01f9abd4d9d80c702af85c822a8"
+    /// );
+    ///
+    /// // the buffer is mutated directly, and trailing contents remains
+    /// let mut buf = [b'!'; 36];
+    /// assert_eq!(
+    ///     uuid.to_simple().encode_lower(&mut buf),
+    ///     "936da01f9abd4d9d80c702af85c822a8"
+    /// );
+    /// assert_eq!(
+    ///     &buf as &[_],
+    ///     b"936da01f9abd4d9d80c702af85c822a8!!!!" as &[_]
+    /// );
+    /// ```
+    pub fn encode_lower<'buf>(&self, buffer: &'buf mut [u8]) -> &'buf mut str {
+        encode(buffer, 0, &self.0, false, false)
+    }
+
+    /// Writes the [`UUID`] as an upper-case simple string to `buffer`,
+    /// and returns the subslice of the buffer that contains the encoded UUID.
+    ///
+    /// [`Uuid`]: ../struct.Uuid.html
+    ///
+    /// # Panics
+    ///
+    /// Panics if the buffer is not large enough: it must have length at least
+    /// [`LENGTH`]. [`Uuid::encode_buffer`] can be used to get a
+    /// sufficiently-large temporary buffer.
+    ///
+    /// [`LENGTH`]: #associatedconstant.LENGTH
+    /// [`Uuid::encode_buffer`]: ../struct.Uuid.html#method.encode_buffer
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use uuid::Uuid;
+    ///
+    /// let uuid = Uuid::parse_str("936da01f9abd4d9d80c702af85c822a8").unwrap();
+    ///
+    /// // the encoded portion is returned
+    /// assert_eq!(
+    ///     uuid.to_simple().encode_upper(&mut Uuid::encode_buffer()),
+    ///     "936DA01F9ABD4D9D80C702AF85C822A8"
+    /// );
+    ///
+    /// // the buffer is mutated directly, and trailing contents remains
+    /// let mut buf = [b'!'; 36];
+    /// assert_eq!(
+    ///     uuid.to_simple().encode_upper(&mut buf),
+    ///     "936DA01F9ABD4D9D80C702AF85C822A8"
+    /// );
+    /// assert_eq!(
+    ///     &buf as &[_],
+    ///     b"936DA01F9ABD4D9D80C702AF85C822A8!!!!" as &[_]
+    /// );
+    /// ```
+    pub fn encode_upper<'buf>(&self, buffer: &'buf mut [u8]) -> &'buf mut str {
+        encode(buffer, 0, &self.0, false, true)
     }
 }
 
@@ -285,6 +622,94 @@ impl<'a> SimpleRef<'a> {
     pub fn from_uuid_ref(uuid: &'a Uuid) -> Self {
         SimpleRef(uuid)
     }
+
+    /// Writes the [`UUID`] as a lower-case simple string to `buffer`,
+    /// and returns the subslice of the buffer that contains the encoded UUID.
+    ///
+    /// This is slightly more efficient than using the formatting
+    /// infrastructure as it avoids virtual calls, and may avoid
+    /// double buffering.
+    ///
+    /// [`Uuid`]: ../struct.Uuid.html
+    ///
+    /// # Panics
+    ///
+    /// Panics if the buffer is not large enough: it must have length at least
+    /// [`LENGTH`]. [`Uuid::encode_buffer`] can be used to get a
+    /// sufficiently-large temporary buffer.
+    ///
+    /// [`LENGTH`]: #associatedconstant.LENGTH
+    /// [`Uuid::encode_buffer`]: ../struct.Uuid.html#method.encode_buffer
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use uuid::Uuid;
+    ///
+    /// let uuid = Uuid::parse_str("936DA01f9abd4d9d80c702af85c822a8").unwrap();
+    ///
+    /// // the encoded portion is returned
+    /// assert_eq!(
+    ///     uuid.to_simple().encode_lower(&mut Uuid::encode_buffer()),
+    ///     "936da01f9abd4d9d80c702af85c822a8"
+    /// );
+    ///
+    /// // the buffer is mutated directly, and trailing contents remains
+    /// let mut buf = [b'!'; 36];
+    /// assert_eq!(
+    ///     uuid.to_simple().encode_lower(&mut buf),
+    ///     "936da01f9abd4d9d80c702af85c822a8"
+    /// );
+    /// assert_eq!(
+    ///     &buf as &[_],
+    ///     b"936da01f9abd4d9d80c702af85c822a8!!!!" as &[_]
+    /// );
+    /// ```
+    pub fn encode_lower<'buf>(&self, buffer: &'buf mut [u8]) -> &'buf mut str {
+        encode(buffer, 0, self.0, false, false)
+    }
+
+    /// Writes the [`UUID`] as an upper-case simple string to `buffer`,
+    /// and returns the subslice of the buffer that contains the encoded UUID.
+    ///
+    /// [`Uuid`]: ../struct.Uuid.html
+    ///
+    /// # Panics
+    ///
+    /// Panics if the buffer is not large enough: it must have length at least
+    /// [`LENGTH`]. [`Uuid::encode_buffer`] can be used to get a
+    /// sufficiently-large temporary buffer.
+    ///
+    /// [`LENGTH`]: #associatedconstant.LENGTH
+    /// [`Uuid::encode_buffer`]: ../struct.Uuid.html#method.encode_buffer
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use uuid::Uuid;
+    ///
+    /// let uuid = Uuid::parse_str("936da01f9abd4d9d80c702af85c822a8").unwrap();
+    ///
+    /// // the encoded portion is returned
+    /// assert_eq!(
+    ///     uuid.to_simple().encode_upper(&mut Uuid::encode_buffer()),
+    ///     "936DA01F9ABD4D9D80C702AF85C822A8"
+    /// );
+    ///
+    /// // the buffer is mutated directly, and trailing contents remains
+    /// let mut buf = [b'!'; 36];
+    /// assert_eq!(
+    ///     uuid.to_simple().encode_upper(&mut buf),
+    ///     "936DA01F9ABD4D9D80C702AF85C822A8"
+    /// );
+    /// assert_eq!(
+    ///     &buf as &[_],
+    ///     b"936DA01F9ABD4D9D80C702AF85C822A8!!!!" as &[_]
+    /// );
+    /// ```
+    pub fn encode_upper<'buf>(&self, buffer: &'buf mut [u8]) -> &'buf mut str {
+        encode(buffer, 0, self.0, false, true)
+    }
 }
 
 impl Urn {
@@ -310,6 +735,103 @@ impl Urn {
     pub fn from_uuid(uuid: Uuid) -> Self {
         Urn(uuid)
     }
+
+    /// Writes the [`UUID`] as a lower-case URN string to
+    /// `buffer`, and returns the subslice of the buffer that contains the
+    /// encoded UUID.
+    ///
+    /// This is slightly more efficient than using the formatting
+    /// infrastructure as it avoids virtual calls, and may avoid
+    /// double buffering.
+    ///
+    /// [`Uuid`]: ../struct.Uuid.html
+    ///
+    /// # Panics
+    ///
+    /// Panics if the buffer is not large enough: it must have length at least
+    /// [`LENGTH`]. [`Uuid::encode_buffer`] can be used to get a
+    /// sufficiently-large temporary buffer.
+    ///
+    /// [`LENGTH`]: #associatedconstant.LENGTH
+    /// [`Uuid::encode_buffer`]: ../struct.Uuid.html#method.encode_buffer
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use uuid::Uuid;
+    ///
+    /// let uuid = Uuid::parse_str("936DA01f9abd4d9d80c702af85c822a8").unwrap();
+    ///
+    /// // the encoded portion is returned
+    /// assert_eq!(
+    ///     uuid.to_urn().encode_lower(&mut Uuid::encode_buffer()),
+    ///     "urn:uuid:936da01f-9abd-4d9d-80c7-02af85c822a8"
+    /// );
+    ///
+    /// // the buffer is mutated directly, and trailing contents remains
+    /// let mut buf = [b'!'; 49];
+    /// uuid.to_urn().encode_lower(&mut buf);
+    /// assert_eq!(
+    ///     uuid.to_urn().encode_lower(&mut buf),
+    ///     "urn:uuid:936da01f-9abd-4d9d-80c7-02af85c822a8"
+    /// );
+    /// assert_eq!(
+    ///     &buf as &[_],
+    ///     b"urn:uuid:936da01f-9abd-4d9d-80c7-02af85c822a8!!!!" as &[_]
+    /// );
+    /// ```
+    pub fn encode_lower<'buf>(&self, buffer: &'buf mut [u8]) -> &'buf mut str {
+        buffer[..9].copy_from_slice(b"urn:uuid:");
+        encode(buffer, 9, &self.0, true, false)
+    }
+
+    /// Writes the [`UUID`] as an upper-case URN string to
+    /// `buffer`, and returns the subslice of the buffer that contains the
+    /// encoded UUID.
+    ///
+    /// This is slightly more efficient than using the formatting
+    /// infrastructure as it avoids virtual calls, and may avoid
+    /// double buffering.
+    ///
+    /// [`Uuid`]: ../struct.Uuid.html
+    ///
+    /// # Panics
+    ///
+    /// Panics if the buffer is not large enough: it must have length at least
+    /// [`LENGTH`]. [`Uuid::encode_buffer`] can be used to get a
+    /// sufficiently-large temporary buffer.
+    ///
+    /// [`LENGTH`]: #associatedconstant.LENGTH
+    /// [`Uuid::encode_buffer`]: ../struct.Uuid.html#method.encode_buffer
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use uuid::Uuid;
+    ///
+    /// let uuid = Uuid::parse_str("936da01f9abd4d9d80c702af85c822a8").unwrap();
+    ///
+    /// // the encoded portion is returned
+    /// assert_eq!(
+    ///     uuid.to_urn().encode_upper(&mut Uuid::encode_buffer()),
+    ///     "urn:uuid:936DA01F-9ABD-4D9D-80C7-02AF85C822A8"
+    /// );
+    ///
+    /// // the buffer is mutated directly, and trailing contents remains
+    /// let mut buf = [b'!'; 49];
+    /// assert_eq!(
+    ///     uuid.to_urn().encode_upper(&mut buf),
+    ///     "urn:uuid:936DA01F-9ABD-4D9D-80C7-02AF85C822A8"
+    /// );
+    /// assert_eq!(
+    ///     &buf as &[_],
+    ///     b"urn:uuid:936DA01F-9ABD-4D9D-80C7-02AF85C822A8!!!!" as &[_]
+    /// );
+    /// ```
+    pub fn encode_upper<'buf>(&self, buffer: &'buf mut [u8]) -> &'buf mut str {
+        buffer[..9].copy_from_slice(b"urn:uuid:");
+        encode(buffer, 9, &self.0, true, true)
+    }
 }
 
 impl<'a> UrnRef<'a> {
@@ -334,5 +856,184 @@ impl<'a> UrnRef<'a> {
     #[cfg(feature = "const_fn")]
     pub fn from_uuid_ref(uuid: &'a Uuid) -> Self {
         UrnRef(&uuid)
+    }
+
+    /// Writes the [`UUID`] as a lower-case URN string to
+    /// `buffer`, and returns the subslice of the buffer that contains the
+    /// encoded UUID.
+    ///
+    /// This is slightly more efficient than using the formatting
+    /// infrastructure as it avoids virtual calls, and may avoid
+    /// double buffering.
+    ///
+    /// [`Uuid`]: ../struct.Uuid.html
+    ///
+    /// # Panics
+    ///
+    /// Panics if the buffer is not large enough: it must have length at least
+    /// [`LENGTH`]. [`Uuid::encode_buffer`] can be used to get a
+    /// sufficiently-large temporary buffer.
+    ///
+    /// [`LENGTH`]: #associatedconstant.LENGTH
+    /// [`Uuid::encode_buffer`]: ../struct.Uuid.html#method.encode_buffer
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use uuid::Uuid;
+    ///
+    /// let uuid = Uuid::parse_str("936DA01f9abd4d9d80c702af85c822a8").unwrap();
+    ///
+    /// // the encoded portion is returned
+    /// assert_eq!(
+    ///     uuid.to_urn().encode_lower(&mut Uuid::encode_buffer()),
+    ///     "urn:uuid:936da01f-9abd-4d9d-80c7-02af85c822a8"
+    /// );
+    ///
+    /// // the buffer is mutated directly, and trailing contents remains
+    /// let mut buf = [b'!'; 49];
+    /// uuid.to_urn().encode_lower(&mut buf);
+    /// assert_eq!(
+    ///     uuid.to_urn().encode_lower(&mut buf),
+    ///     "urn:uuid:936da01f-9abd-4d9d-80c7-02af85c822a8"
+    /// );
+    /// assert_eq!(
+    ///     &buf as &[_],
+    ///     b"urn:uuid:936da01f-9abd-4d9d-80c7-02af85c822a8!!!!" as &[_]
+    /// );
+    /// ```
+    pub fn encode_lower<'buf>(&self, buffer: &'buf mut [u8]) -> &'buf mut str {
+        buffer[..9].copy_from_slice(b"urn:uuid:");
+        encode(buffer, 9, self.0, true, false)
+    }
+
+    /// Writes the [`UUID`] as an upper-case URN string to
+    /// `buffer`, and returns the subslice of the buffer that contains the
+    /// encoded UUID.
+    ///
+    /// This is slightly more efficient than using the formatting
+    /// infrastructure as it avoids virtual calls, and may avoid
+    /// double buffering.
+    ///
+    /// [`Uuid`]: ../struct.Uuid.html
+    ///
+    /// # Panics
+    ///
+    /// Panics if the buffer is not large enough: it must have length at least
+    /// [`LENGTH`]. [`Uuid::encode_buffer`] can be used to get a
+    /// sufficiently-large temporary buffer.
+    ///
+    /// [`LENGTH`]: #associatedconstant.LENGTH
+    /// [`Uuid::encode_buffer`]: ../struct.Uuid.html#method.encode_buffer
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use uuid::Uuid;
+    ///
+    /// let uuid = Uuid::parse_str("936da01f9abd4d9d80c702af85c822a8").unwrap();
+    ///
+    /// // the encoded portion is returned
+    /// assert_eq!(
+    ///     uuid.to_urn().encode_upper(&mut Uuid::encode_buffer()),
+    ///     "urn:uuid:936DA01F-9ABD-4D9D-80C7-02AF85C822A8"
+    /// );
+    ///
+    /// // the buffer is mutated directly, and trailing contents remains
+    /// let mut buf = [b'!'; 49];
+    /// assert_eq!(
+    ///     uuid.to_urn().encode_upper(&mut buf),
+    ///     "urn:uuid:936DA01F-9ABD-4D9D-80C7-02AF85C822A8"
+    /// );
+    /// assert_eq!(
+    ///     &buf as &[_],
+    ///     b"urn:uuid:936DA01F-9ABD-4D9D-80C7-02AF85C822A8!!!!" as &[_]
+    /// );
+    /// ```
+    pub fn encode_upper<'buf>(&self, buffer: &'buf mut [u8]) -> &'buf mut str {
+        buffer[..9].copy_from_slice(b"urn:uuid:");
+        encode(buffer, 9, self.0, true, true)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use Uuid;
+
+    #[test]
+    fn hyphenated_trailing() {
+        let mut buf = [b'x'; 100];
+        let len = Uuid::nil().to_hyphenated().encode_lower(&mut buf).len();
+        assert_eq!(len, super::Hyphenated::LENGTH);
+        assert!(buf[len..].iter().all(|x| *x == b'x'));
+    }
+    #[test]
+    fn hyphenated_ref_trailing() {
+        let mut buf = [b'x'; 100];
+        let len = Uuid::nil().to_hyphenated().encode_lower(&mut buf).len();
+        assert_eq!(len, super::HyphenatedRef::LENGTH);
+        assert!(buf[len..].iter().all(|x| *x == b'x'));
+    }
+
+    #[test]
+    fn simple_trailing() {
+        let mut buf = [b'x'; 100];
+        let len = Uuid::nil().to_simple().encode_lower(&mut buf).len();
+        assert_eq!(len, super::Simple::LENGTH);
+        assert!(buf[len..].iter().all(|x| *x == b'x'));
+    }
+    #[test]
+    fn simple_ref_trailing() {
+        let mut buf = [b'x'; 100];
+        let len = Uuid::nil().to_simple().encode_lower(&mut buf).len();
+        assert_eq!(len, super::SimpleRef::LENGTH);
+        assert!(buf[len..].iter().all(|x| *x == b'x'));
+    }
+
+    #[test]
+    fn urn_trailing() {
+        let mut buf = [b'x'; 100];
+        let len = Uuid::nil().to_urn().encode_lower(&mut buf).len();
+        assert_eq!(len, super::Urn::LENGTH);
+        assert!(buf[len..].iter().all(|x| *x == b'x'));
+    }
+    #[test]
+    fn urn_ref_trailing() {
+        let mut buf = [b'x'; 100];
+        let len = Uuid::nil().to_urn().encode_lower(&mut buf).len();
+        assert_eq!(len, super::UrnRef::LENGTH);
+        assert!(buf[len..].iter().all(|x| *x == b'x'));
+    }
+
+    #[test]
+    #[should_panic]
+    fn hyphenated_too_small() {
+        Uuid::nil().to_hyphenated().encode_lower(&mut [0; 35]);
+    }
+    #[test]
+    #[should_panic]
+    fn hyphenated_ref_too_small() {
+        Uuid::nil().to_hyphenated_ref().encode_lower(&mut [0; 35]);
+    }
+
+    #[test]
+    #[should_panic]
+    fn simple_too_small() {
+        Uuid::nil().to_simple().encode_lower(&mut [0; 31]);
+    }
+    #[test]
+    #[should_panic]
+    fn simple_ref_too_small() {
+        Uuid::nil().to_simple_ref().encode_lower(&mut [0; 31]);
+    }
+    #[test]
+    #[should_panic]
+    fn urn_too_small() {
+        Uuid::nil().to_urn().encode_lower(&mut [0; 44]);
+    }
+    #[test]
+    #[should_panic]
+    fn urn_ref_too_small() {
+        Uuid::nil().to_urn_ref().encode_lower(&mut [0; 44]);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -924,6 +924,36 @@ impl Uuid {
     pub fn is_nil(&self) -> bool {
         self.as_bytes().iter().all(|&b| b == 0)
     }
+
+    /// A buffer that can be used for `encode_...` calls, that is
+    /// guaranteed to be long enough for any of the adapters.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use uuid::Uuid;
+    ///
+    /// let uuid = Uuid::nil();
+    ///
+    /// assert_eq!(
+    ///     uuid.to_simple().encode_lower(&mut Uuid::encode_buffer()),
+    ///     "00000000000000000000000000000000"
+    /// );
+    ///
+    /// assert_eq!(
+    ///     uuid.to_hyphenated()
+    ///         .encode_lower(&mut Uuid::encode_buffer()),
+    ///     "00000000-0000-0000-0000-000000000000"
+    /// );
+    ///
+    /// assert_eq!(
+    ///     uuid.to_urn().encode_lower(&mut Uuid::encode_buffer()),
+    ///     "urn:uuid:00000000-0000-0000-0000-000000000000"
+    /// );
+    /// ```
+    pub fn encode_buffer() -> [u8; adapter::Urn::LENGTH] {
+        [0; adapter::Urn::LENGTH]
+    }
 }
 
 #[cfg(test)]

--- a/src/serde_support.rs
+++ b/src/serde_support.rs
@@ -19,7 +19,8 @@ impl Serialize for Uuid {
         serializer: S,
     ) -> Result<S::Ok, S::Error> {
         if serializer.is_human_readable() {
-            serializer.collect_str(&self.to_hyphenated())
+            serializer
+                .serialize_str(&self.to_hyphenated().encode_lower(&mut [0; 36]))
         } else {
             serializer.serialize_bytes(self.as_bytes())
         }


### PR DESCRIPTION
<!--
    If this PR is a breaking change, ensure that you are opening it against 
    the `breaking` branch.  If the pull request is incomplete, prepend the Title with WIP: 
-->

**I'm submitting a(n)** feature


# Description

Add encode_{lower,upper} to formatting adapters for core::fmt-less rendering.

# Motivation

These are noticably faster (20ns, ~50%) as they avoid all the virtual
call overhead of core::fmt/write! (etc.). This also improves the
performance of (human-readable) serde encoding, since that previously
went through core::fmt.

# Tests

Benchmark results both with LTO and without including a comparison
against crates.io/crates/uuidtoa:

```
test lto_bench_encode_hyphen ... bench:          16 ns/iter (+/- 1)
test lto_bench_encode_simple ... bench:          14 ns/iter (+/- 1)
test lto_bench_encode_urn    ... bench:          18 ns/iter (+/- 2)
test lto_bench_hyphen        ... bench:          36 ns/iter (+/- 1)
test lto_bench_simple        ... bench:          33 ns/iter (+/- 7)
test lto_bench_urn           ... bench:          40 ns/iter (+/- 4)
test lto_bench_uuidtoa       ... bench:          13 ns/iter (+/- 3)

test nolto_bench_encode_hyphen ... bench:          18 ns/iter (+/- 3)
test nolto_bench_encode_simple ... bench:          19 ns/iter (+/- 3)
test nolto_bench_encode_urn    ... bench:          21 ns/iter (+/- 2)
test nolto_bench_hyphen        ... bench:          41 ns/iter (+/- 11)
test nolto_bench_simple        ... bench:          39 ns/iter (+/- 3)
test nolto_bench_urn           ... bench:          48 ns/iter (+/- 6)
test nolto_bench_uuidtoa       ... bench:          41 ns/iter (+/- 5)
```

This is now essentially as fast as uuidtoa at its fastest (and
significantly faster than it, without LTO), and the remaining
difference is likely the use of the checked `str::from_utf8_mut`.

Benchcmp for the existing benchmarks using the existing APIs (only the
ones that changed):

```
 name                        before.txt ns/iter  after.txt ns/iter  diff ns/iter   diff %  speedup
 lto_bench_hyphen            43                  36                           -7  -16.28%   x 1.19
 lto_bench_json_encode       59 (644 MB/s)       35 (1085 MB/s)              -24  -40.68%   x 1.69
 lto_bench_urn               45                  40                           -5  -11.11%   x 1.12
 nolto_bench_hyphen          48                  41                           -7  -14.58%   x 1.17
 nolto_bench_json_encode     73 (520 MB/s)       45 (844 MB/s)               -28  -38.36%   x 1.62
 nolto_bench_urn             59                  48                          -11  -18.64%   x 1.23
```

That is, JSON encoding takes 40% less time, and even core::fmt
formatting for the formats that use hyphens got slightly faster too.

# Related Issue(s)

Closes #196.