### PR TITLE
don't inline the prelude items.

### DIFF
--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -46,8 +46,6 @@ handling uuid version 1. Requires feature `v1`.
 [`Context`]: ../v1/struct.Context.html
 [`ClockSequence`]: ../v1/trait.ClockSequence.html")]
 
-#[doc(inline)]
 pub use super::{Bytes, Uuid, Variant, Version};
 #[cfg(feature = "v1")]
-#[doc(inline)]
 pub use v1::{ClockSequence, Context};


### PR DESCRIPTION
**I'm submitting a(n)** bug fix

# Description
The `prelude` does not contain inlined items anymore

# Motivation
The doc links were directing the users to the prelude items instead
of the actual items

# Tests
N/A
