### PR TITLE
fix the value of html_root_url in lib.rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ homepage = "https://github.com/uuid-rs/uuid"
 name = "uuid"
 readme = "README.md"
 repository = "https://github.com/uuid-rs/uuid"
-version = "0.7.1"
+version = "0.7.1" # remember to update html_root_url in lib.rs
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -116,7 +116,7 @@
 #![doc(
     html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
     html_favicon_url = "https://www.rust-lang.org/favicon.ico",
-    html_root_url = "https://docs.rs/uuid"
+    html_root_url = "https://docs.rs/uuid/0.7.1"
 )]
 
 #[cfg(feature = "byteorder")]


### PR DESCRIPTION
**I'm submitting a(n)** bug fix

# Description
Fix the value of `#![doc(html_root_url)]` in `lib.rs`.
See also: https://rust-lang-nursery.github.io/api-guidelines/documentation.html#crate-sets-html_root_url-attribute-c-html-root