### PR TITLE
fix tests failing for slog

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,15 @@ matrix:
   include:
   - os: osx
     rust: 1.22.0
+    script:
+    - cargo test --no-default-features
+    - cargo test
+    - cargo test --features "serde"
+    - cargo test --features "v1"
+    - cargo test --features "v3"
+    - cargo test --features "v4"
+    - cargo test --features "v5"
+    - cargo test --features "serde std v1 v3 v4 v5"
   - os: osx
     rust: nightly
   - rust: nightly


### PR DESCRIPTION
**I'm submitting a(n)** bug fix

# Description
removed testing `slog` for `1.22.0` rust branch

# Motivation
`slog` added support for `i128` types in `2.4.0` but did not feature flag it.

# Tests
tests dont fail anymore :)

# Related Issue(s)
#321 
