### PR TITLE
Add Uuid Builder

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,0 +1,241 @@
+use super::Bytes;
+use super::BytesError;
+use super::Uuid;
+use super::Variant;
+use super::Version;
+
+/// A builder struct for creating a [`Uuid`]
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct UuidBuilder {
+    uuid: Uuid,
+}
+
+impl UuidBuilder {
+    /// Creates a `UuidBuilder` using the supplied big-endian bytes.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// use uuid::Bytes;
+    /// use uuid::UuidBuilder;
+    ///
+    /// let bytes: Bytes = [
+    ///     70, 235, 208, 238, 14, 109, 67, 201, 185, 13, 204, 195, 90, 145, 63,
+    ///     62,
+    /// ];
+    ///
+    /// let builder = UuidBuilder::from_bytes_be(bytes);
+    /// let uuid = builder.build().to_hyphenated().to_string();
+    ///
+    /// let expected_uuid = String::from("46ebd0ee-0e6d-43c9-b90d-ccc35a913f3e");
+    ///
+    /// assert_eq!(expected_uuid, uuid);
+    /// ```
+    ///
+    /// An incorrect number of bytes:
+    ///
+    /// ```compile_fail
+    /// use uuid::Bytes;
+    /// use uuid::UuidBuilder;
+    ///
+    /// let bytes: Bytes = [4, 54, 67, 12, 43, 2, 98, 76]; // doesn't compile
+    ///
+    /// let uuid = UuidBuilder::from_bytes_le(bytes);
+    /// ```
+    pub fn from_bytes_be(b: Bytes) -> Self {
+        UuidBuilder {
+            uuid: Uuid::from_bytes_be(b),
+        }
+    }
+
+    /// Creates a `UuidBuilder` using the supplied little-endian bytes.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// use uuid::Bytes;
+    /// use uuid::UuidBuilder;
+    ///
+    /// let bytes: Bytes = [
+    ///     70, 235, 208, 238, 14, 109, 67, 201, 185, 13, 204, 195, 90, 145, 63,
+    ///     62,
+    /// ];
+    ///
+    /// let builder = UuidBuilder::from_bytes_le(bytes);
+    /// let uuid = builder.build().to_hyphenated().to_string();
+    ///
+    /// let expected_uuid = String::from("eed0eb46-6d0e-c943-b90d-ccc35a913f3e");
+    ///
+    /// assert_eq!(expected_uuid, uuid);
+    /// ```
+    ///
+    /// An incorrect number of bytes:
+    ///
+    /// ```compile_fail
+    /// use uuid::Bytes;
+    /// use uuid::UuidBuilder;
+    ///
+    /// let bytes: Bytes = [4, 54, 67, 12, 43, 2, 98, 76]; // doesn't compile
+    ///
+    /// let uuid = UuidBuilder::from_bytes_le(bytes);
+    /// ```
+    pub fn from_bytes_le(b: Bytes) -> Self {
+        UuidBuilder {
+            uuid: Uuid::from_bytes_le(b),
+        }
+    }
+
+    /// Creates a `UuidBuilder` using the supplied bytes.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if `b` has any length other than 16.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// use uuid::UuidBuilder;
+    ///
+    /// let bytes = [4, 54, 67, 12, 43, 2, 98, 76, 32, 50, 87, 5, 1, 33, 43, 87];
+    ///
+    /// let builder = UuidBuilder::from_slice(&bytes);
+    /// let uuid =
+    ///     builder.map(|builder| builder.build().to_hyphenated().to_string());
+    ///
+    /// let expected_uuid =
+    ///     Ok(String::from("0436430c-2b02-624c-2032-570501212b57"));
+    ///
+    /// assert_eq!(expected_uuid, uuid);
+    /// ```
+    ///
+    /// An incorrect number of bytes:
+    ///
+    /// ```
+    /// use uuid::prelude::*;
+    /// use uuid::UuidBuilder;
+    ///
+    /// let bytes = [4, 54, 67, 12, 43, 2, 98, 76];
+    ///
+    /// let builder = UuidBuilder::from_slice(&bytes);
+    ///
+    /// let expected_err = Err(uuid::BytesError::new(16, 8));
+    ///
+    /// assert_eq!(expected_err, builder);
+    /// ```
+    pub fn from_slice(b: &[u8]) -> Result<Self, BytesError> {
+        const BYTES_LEN: usize = 16;
+
+        let len = b.len();
+
+        if len != BYTES_LEN {
+            return Err(BytesError::new(BYTES_LEN, len));
+        }
+
+        let mut bytes: Bytes = [0; 16];
+        bytes.copy_from_slice(b);
+        Ok(Self::from_bytes_be(bytes))
+    }
+
+    /// Creates a `UuidBuilder` from four field values.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if `d4`'s length is not 8 bytes.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// use uuid::UuidBuilder;
+    ///
+    /// let d4 = [12, 3, 9, 56, 54, 43, 8, 9];
+    ///
+    /// let builder = UuidBuilder::from_fields(42, 12, 5, &d4);
+    /// let uuid =
+    ///     builder.map(|builder| builder.build().to_hyphenated().to_string());
+    ///
+    /// let expected_uuid =
+    ///     Ok(String::from("0000002a-000c-0005-0c03-0938362b0809"));
+    ///
+    /// assert_eq!(expected_uuid, uuid);
+    /// ```
+    ///
+    /// An invalid length:
+    ///
+    /// ```
+    /// use uuid::prelude::*;
+    ///
+    /// let d4 = [12];
+    ///
+    /// let builder = uuid::UuidBuilder::from_fields(42, 12, 5, &d4);
+    ///
+    /// let expected_err = Err(uuid::BytesError::new(8, d4.len()));
+    ///
+    /// assert_eq!(expected_err, builder);
+    /// ```
+    pub fn from_fields(
+        d1: u32,
+        d2: u16,
+        d3: u16,
+        d4: &[u8],
+    ) -> Result<Self, BytesError> {
+        Uuid::from_fields(d1, d2, d3, d4).map(|uuid| UuidBuilder { uuid })
+    }
+
+    /// Creates a `UuidBuilder` with an initial [`Uuid::nil`]
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// use uuid::UuidBuilder;
+    ///
+    /// let builder = UuidBuilder::nil();
+    ///
+    /// assert_eq!(
+    ///     builder.build().to_hyphenated().to_string(),
+    ///     "00000000-0000-0000-0000-000000000000"
+    /// );
+    /// ```
+    pub fn nil() -> Self {
+        UuidBuilder { uuid: Uuid::nil() }
+    }
+
+    /// Specifies the variant of the internal [`Uuid`].
+    pub fn set_variant(&mut self, v: Variant) -> &mut Self {
+        self.uuid.set_variant(v);
+        self
+    }
+
+    /// Specifies the version number of the internal [`Uuid`].
+    pub fn set_version(&mut self, v: Version) -> &mut Self {
+        self.uuid.set_version(v);
+        self
+    }
+
+    /// Hands over the internal constructed [`Uuid`]
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// use uuid::UuidBuilder;
+    ///
+    /// let uuid = UuidBuilder::nil().build();
+    ///
+    /// assert_eq!(
+    ///     uuid.to_hyphenated().to_string(),
+    ///     "00000000-0000-0000-0000-000000000000"
+    /// );
+    /// ```
+    pub fn build(&self) -> Uuid {
+        self.uuid
+    }
+}

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -38,7 +38,7 @@ impl Builder {
     ///     62,
     /// ];
     ///
-    /// let builder = Builder::from_bytes_be(bytes);
+    /// let mut builder = Builder::from_bytes_be(bytes);
     /// let uuid = builder.build().to_hyphenated().to_string();
     ///
     /// let expected_uuid = String::from("46ebd0ee-0e6d-43c9-b90d-ccc35a913f3e");
@@ -75,7 +75,7 @@ impl Builder {
     ///     62,
     /// ];
     ///
-    /// let builder = Builder::from_bytes_le(bytes);
+    /// let mut builder = Builder::from_bytes_le(bytes);
     /// let uuid = builder.build().to_hyphenated().to_string();
     ///
     /// let expected_uuid = String::from("eed0eb46-6d0e-c943-b90d-ccc35a913f3e");
@@ -114,7 +114,7 @@ impl Builder {
     ///
     /// let builder = Builder::from_slice_be(&bytes);
     /// let uuid =
-    ///     builder.map(|builder| builder.build().to_hyphenated().to_string());
+    ///     builder.map(|mut builder| builder.build().to_hyphenated().to_string());
     ///
     /// let expected_uuid =
     ///     Ok(String::from("0436430c-2b02-624c-2032-570501212b57"));
@@ -165,7 +165,7 @@ impl Builder {
     ///
     /// let builder = Builder::from_slice_le(&bytes);
     /// let uuid =
-    ///     builder.map(|builder| builder.build().to_hyphenated().to_string());
+    ///     builder.map(|mut builder| builder.build().to_hyphenated().to_string());
     ///
     /// let expected_uuid =
     ///     Ok(String::from("0c433604-022b-4c62-2032-570501212b57"));
@@ -216,7 +216,7 @@ impl Builder {
     ///
     /// let builder = Builder::from_fields(42, 12, 5, &d4);
     /// let uuid =
-    ///     builder.map(|builder| builder.build().to_hyphenated().to_string());
+    ///     builder.map(|mut builder| builder.build().to_hyphenated().to_string());
     ///
     /// let expected_uuid =
     ///     Ok(String::from("0000002a-000c-0005-0c03-0938362b0809"));
@@ -252,7 +252,7 @@ impl Builder {
     /// ```
     /// use uuid::Builder;
     ///
-    /// let builder = Builder::nil();
+    /// let mut builder = Builder::nil();
     ///
     /// assert_eq!(
     ///     builder.build().to_hyphenated().to_string(),

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -290,7 +290,7 @@ impl Builder {
     ///     "00000000-0000-0000-0000-000000000000"
     /// );
     /// ```
-    pub fn build(&self) -> Uuid {
+    pub fn build(&mut self) -> Uuid {
         self.0
     }
 }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,18 +1,29 @@
-use super::Bytes;
-use super::BytesError;
-use super::Uuid;
-use super::Variant;
-use super::Version;
+// Copyright 2013-2014 The Rust Project Developers.
+// Copyright 2018 The Uuid Project Developers.
+//
+// See the COPYRIGHT file at the top-level directory of this distribution.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+
+//! A Builder type for [`Uuid`]s.
+//!
+//! [`Uuid`]: ../struct.Uuid.html
+
+use prelude::*;
+use BytesError;
 
 /// A builder struct for creating a [`Uuid`]
 #[allow(missing_copy_implementations)]
 #[derive(Debug)]
-pub struct UuidBuilder {
-    uuid: Uuid,
-}
+pub struct Builder(Uuid);
 
-impl UuidBuilder {
-    /// Creates a `UuidBuilder` using the supplied big-endian bytes.
+impl Builder {
+    /// Creates a `Builder` using the supplied big-endian bytes.
     ///
     /// # Examples
     ///
@@ -20,14 +31,14 @@ impl UuidBuilder {
     ///
     /// ```
     /// use uuid::Bytes;
-    /// use uuid::UuidBuilder;
+    /// use uuid::Builder;
     ///
     /// let bytes: Bytes = [
     ///     70, 235, 208, 238, 14, 109, 67, 201, 185, 13, 204, 195, 90, 145, 63,
     ///     62,
     /// ];
     ///
-    /// let builder = UuidBuilder::from_bytes_be(bytes);
+    /// let builder = Builder::from_bytes_be(bytes);
     /// let uuid = builder.build().to_hyphenated().to_string();
     ///
     /// let expected_uuid = String::from("46ebd0ee-0e6d-43c9-b90d-ccc35a913f3e");
@@ -39,19 +50,17 @@ impl UuidBuilder {
     ///
     /// ```compile_fail
     /// use uuid::Bytes;
-    /// use uuid::UuidBuilder;
+    /// use uuid::Builder;
     ///
     /// let bytes: Bytes = [4, 54, 67, 12, 43, 2, 98, 76]; // doesn't compile
     ///
-    /// let uuid = UuidBuilder::from_bytes_le(bytes);
+    /// let uuid = Builder::from_bytes_le(bytes);
     /// ```
     pub fn from_bytes_be(b: Bytes) -> Self {
-        UuidBuilder {
-            uuid: Uuid::from_bytes_be(b),
-        }
+        Builder(Uuid::from_bytes_be(b))
     }
 
-    /// Creates a `UuidBuilder` using the supplied little-endian bytes.
+    /// Creates a `Builder` using the supplied little-endian bytes.
     ///
     /// # Examples
     ///
@@ -59,14 +68,14 @@ impl UuidBuilder {
     ///
     /// ```
     /// use uuid::Bytes;
-    /// use uuid::UuidBuilder;
+    /// use uuid::Builder;
     ///
     /// let bytes: Bytes = [
     ///     70, 235, 208, 238, 14, 109, 67, 201, 185, 13, 204, 195, 90, 145, 63,
     ///     62,
     /// ];
     ///
-    /// let builder = UuidBuilder::from_bytes_le(bytes);
+    /// let builder = Builder::from_bytes_le(bytes);
     /// let uuid = builder.build().to_hyphenated().to_string();
     ///
     /// let expected_uuid = String::from("eed0eb46-6d0e-c943-b90d-ccc35a913f3e");
@@ -78,19 +87,17 @@ impl UuidBuilder {
     ///
     /// ```compile_fail
     /// use uuid::Bytes;
-    /// use uuid::UuidBuilder;
+    /// use uuid::Builder;
     ///
     /// let bytes: Bytes = [4, 54, 67, 12, 43, 2, 98, 76]; // doesn't compile
     ///
-    /// let uuid = UuidBuilder::from_bytes_le(bytes);
+    /// let uuid = Builder::from_bytes_le(bytes);
     /// ```
     pub fn from_bytes_le(b: Bytes) -> Self {
-        UuidBuilder {
-            uuid: Uuid::from_bytes_le(b),
-        }
+        Builder(Uuid::from_bytes_le(b))
     }
 
-    /// Creates a `UuidBuilder` using the supplied bytes.
+    /// Creates a `Builder` using the supplied big-endian bytes.
     ///
     /// # Errors
     ///
@@ -101,11 +108,11 @@ impl UuidBuilder {
     /// Basic usage:
     ///
     /// ```
-    /// use uuid::UuidBuilder;
+    /// use uuid::Builder;
     ///
     /// let bytes = [4, 54, 67, 12, 43, 2, 98, 76, 32, 50, 87, 5, 1, 33, 43, 87];
     ///
-    /// let builder = UuidBuilder::from_slice(&bytes);
+    /// let builder = Builder::from_slice_be(&bytes);
     /// let uuid =
     ///     builder.map(|builder| builder.build().to_hyphenated().to_string());
     ///
@@ -119,15 +126,15 @@ impl UuidBuilder {
     ///
     /// ```
     /// use uuid::prelude::*;
-    /// use uuid::UuidBuilder;
+    /// use uuid::Builder;
     ///
     /// let bytes = [4, 54, 67, 12, 43, 2, 98, 76];
     ///
-    /// let builder = UuidBuilder::from_slice(&bytes);
+    /// let builder = Builder::from_slice_be(&bytes);
     ///
     /// assert!(builder.is_err());
     /// ```
-    pub fn from_slice(b: &[u8]) -> Result<Self, BytesError> {
+    pub fn from_slice_be(b: &[u8]) -> Result<Self, BytesError> {
         const BYTES_LEN: usize = 16;
 
         let len = b.len();
@@ -141,7 +148,58 @@ impl UuidBuilder {
         Ok(Self::from_bytes_be(bytes))
     }
 
-    /// Creates a `UuidBuilder` from four field values.
+    /// Creates a `Builder` using the supplied little-endian bytes.
+    ///
+    /// # Errors
+    ///
+    /// This function will return an error if `b` has any length other than 16.
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// use uuid::Builder;
+    ///
+    /// let bytes = [4, 54, 67, 12, 43, 2, 98, 76, 32, 50, 87, 5, 1, 33, 43, 87];
+    ///
+    /// let builder = Builder::from_slice_le(&bytes);
+    /// let uuid =
+    ///     builder.map(|builder| builder.build().to_hyphenated().to_string());
+    ///
+    /// let expected_uuid =
+    ///     Ok(String::from("0c433604-022b-4c62-2032-570501212b57"));
+    ///
+    /// assert_eq!(expected_uuid, uuid);
+    /// ```
+    ///
+    /// An incorrect number of bytes:
+    ///
+    /// ```
+    /// use uuid::prelude::*;
+    /// use uuid::Builder;
+    ///
+    /// let bytes = [4, 54, 67, 12, 43, 2, 98, 76];
+    ///
+    /// let builder = Builder::from_slice_le(&bytes);
+    ///
+    /// assert!(builder.is_err());
+    /// ```
+    pub fn from_slice_le(b: &[u8]) -> Result<Self, BytesError> {
+        const BYTES_LEN: usize = 16;
+
+        let len = b.len();
+
+        if len != BYTES_LEN {
+            return Err(BytesError::new(BYTES_LEN, len));
+        }
+
+        let mut bytes: Bytes = [0; 16];
+        bytes.copy_from_slice(b);
+        Ok(Self::from_bytes_le(bytes))
+    }
+
+    /// Creates a `Builder` from four field values.
     ///
     /// # Errors
     ///
@@ -152,11 +210,11 @@ impl UuidBuilder {
     /// Basic usage:
     ///
     /// ```
-    /// use uuid::UuidBuilder;
+    /// use uuid::Builder;
     ///
     /// let d4 = [12, 3, 9, 56, 54, 43, 8, 9];
     ///
-    /// let builder = UuidBuilder::from_fields(42, 12, 5, &d4);
+    /// let builder = Builder::from_fields(42, 12, 5, &d4);
     /// let uuid =
     ///     builder.map(|builder| builder.build().to_hyphenated().to_string());
     ///
@@ -173,7 +231,7 @@ impl UuidBuilder {
     ///
     /// let d4 = [12];
     ///
-    /// let builder = uuid::UuidBuilder::from_fields(42, 12, 5, &d4);
+    /// let builder = uuid::Builder::from_fields(42, 12, 5, &d4);
     ///
     /// assert!(builder.is_err());
     /// ```
@@ -183,18 +241,18 @@ impl UuidBuilder {
         d3: u16,
         d4: &[u8],
     ) -> Result<Self, BytesError> {
-        Uuid::from_fields(d1, d2, d3, d4).map(|uuid| UuidBuilder { uuid })
+        Uuid::from_fields(d1, d2, d3, d4).map(|uuid| Builder(uuid))
     }
 
-    /// Creates a `UuidBuilder` with an initial [`Uuid::nil`]
+    /// Creates a `Builder` with an initial [`Uuid::nil`]
     /// # Examples
     ///
     /// Basic usage:
     ///
     /// ```
-    /// use uuid::UuidBuilder;
+    /// use uuid::Builder;
     ///
-    /// let builder = UuidBuilder::nil();
+    /// let builder = Builder::nil();
     ///
     /// assert_eq!(
     ///     builder.build().to_hyphenated().to_string(),
@@ -202,18 +260,18 @@ impl UuidBuilder {
     /// );
     /// ```
     pub fn nil() -> Self {
-        UuidBuilder { uuid: Uuid::nil() }
+        Builder(Uuid::nil())
     }
 
     /// Specifies the variant of the internal [`Uuid`].
     pub fn set_variant(&mut self, v: Variant) -> &mut Self {
-        self.uuid.set_variant(v);
+        self.0.set_variant(v);
         self
     }
 
     /// Specifies the version number of the internal [`Uuid`].
     pub fn set_version(&mut self, v: Version) -> &mut Self {
-        self.uuid.set_version(v);
+        self.0.set_version(v);
         self
     }
 
@@ -223,9 +281,9 @@ impl UuidBuilder {
     /// Basic usage:
     ///
     /// ```
-    /// use uuid::UuidBuilder;
+    /// use uuid::Builder;
     ///
-    /// let uuid = UuidBuilder::nil().build();
+    /// let uuid = Builder::nil().build();
     ///
     /// assert_eq!(
     ///     uuid.to_hyphenated().to_string(),
@@ -233,6 +291,6 @@ impl UuidBuilder {
     /// );
     /// ```
     pub fn build(&self) -> Uuid {
-        self.uuid
+        self.0
     }
 }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -125,9 +125,7 @@ impl UuidBuilder {
     ///
     /// let builder = UuidBuilder::from_slice(&bytes);
     ///
-    /// let expected_err = Err(uuid::BytesError::new(16, 8));
-    ///
-    /// assert_eq!(expected_err, builder);
+    /// assert!(builder.is_err());
     /// ```
     pub fn from_slice(b: &[u8]) -> Result<Self, BytesError> {
         const BYTES_LEN: usize = 16;
@@ -177,9 +175,7 @@ impl UuidBuilder {
     ///
     /// let builder = uuid::UuidBuilder::from_fields(42, 12, 5, &d4);
     ///
-    /// let expected_err = Err(uuid::BytesError::new(8, d4.len()));
-    ///
-    /// assert_eq!(expected_err, builder);
+    /// assert!(builder.is_err());
     /// ```
     pub fn from_fields(
         d1: u32,

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -9,7 +9,6 @@
 // option. This file may not be copied, modified, or distributed
 // except according to those terms.
 
-
 //! A Builder type for [`Uuid`]s.
 //!
 //! [`Uuid`]: ../struct.Uuid.html
@@ -30,8 +29,8 @@ impl Builder {
     /// Basic usage:
     ///
     /// ```
-    /// use uuid::Bytes;
     /// use uuid::Builder;
+    /// use uuid::Bytes;
     ///
     /// let bytes: Bytes = [
     ///     70, 235, 208, 238, 14, 109, 67, 201, 185, 13, 204, 195, 90, 145, 63,
@@ -49,8 +48,8 @@ impl Builder {
     /// An incorrect number of bytes:
     ///
     /// ```compile_fail
-    /// use uuid::Bytes;
     /// use uuid::Builder;
+    /// use uuid::Bytes;
     ///
     /// let bytes: Bytes = [4, 54, 67, 12, 43, 2, 98, 76]; // doesn't compile
     ///
@@ -67,8 +66,8 @@ impl Builder {
     /// Basic usage:
     ///
     /// ```
-    /// use uuid::Bytes;
     /// use uuid::Builder;
+    /// use uuid::Bytes;
     ///
     /// let bytes: Bytes = [
     ///     70, 235, 208, 238, 14, 109, 67, 201, 185, 13, 204, 195, 90, 145, 63,
@@ -86,8 +85,8 @@ impl Builder {
     /// An incorrect number of bytes:
     ///
     /// ```compile_fail
-    /// use uuid::Bytes;
     /// use uuid::Builder;
+    /// use uuid::Bytes;
     ///
     /// let bytes: Bytes = [4, 54, 67, 12, 43, 2, 98, 76]; // doesn't compile
     ///

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -5,7 +5,8 @@ use super::Variant;
 use super::Version;
 
 /// A builder struct for creating a [`Uuid`]
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[allow(missing_copy_implementations)]
+#[derive(Debug)]
 pub struct UuidBuilder {
     uuid: Uuid,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -140,7 +140,6 @@ extern crate sha1;
 #[cfg_attr(test, macro_use)]
 extern crate slog;
 
-
 pub mod adapter;
 pub mod builder;
 pub mod parser;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,14 +137,15 @@ extern crate sha1;
 #[cfg_attr(test, macro_use)]
 extern crate slog;
 
-mod builder;
-pub use builder::UuidBuilder;
 
 pub mod adapter;
+pub mod builder;
 pub mod parser;
 pub mod prelude;
 #[cfg(feature = "v1")]
 pub mod v1;
+
+pub use builder::Builder;
 
 mod core_support;
 #[cfg(feature = "serde")]
@@ -624,7 +625,7 @@ impl Uuid {
     /// ```
     #[deprecated(
         since = "0.7.2",
-        note = "please use the `UuidBuilder` instead"
+        note = "please use the `uuid::Builder` instead"
     )]
     pub fn from_random_bytes(bytes: Bytes) -> Uuid {
         let mut uuid = Uuid::from_bytes(bytes);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -622,7 +622,10 @@ impl Uuid {
     ///
     /// assert_eq!(expected_uuid, uuid);
     /// ```
-    #[deprecated(since="0.7.2", note="please use the `UuidBuilder` instead")]
+    #[deprecated(
+        since = "0.7.2",
+        note = "please use the `UuidBuilder` instead"
+    )]
     pub fn from_random_bytes(bytes: Bytes) -> Uuid {
         let mut uuid = Uuid::from_bytes(bytes);
         uuid.set_variant(Variant::RFC4122);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -622,6 +622,7 @@ impl Uuid {
     ///
     /// assert_eq!(expected_uuid, uuid);
     /// ```
+    #[deprecated(since="0.7.2", note="please use the `UuidBuilder` instead")]
     pub fn from_random_bytes(bytes: Bytes) -> Uuid {
         let mut uuid = Uuid::from_bytes(bytes);
         uuid.set_variant(Variant::RFC4122);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,6 +137,9 @@ extern crate sha1;
 #[cfg_attr(test, macro_use)]
 extern crate slog;
 
+mod builder;
+pub use builder::UuidBuilder;
+
 pub mod adapter;
 pub mod parser;
 pub mod prelude;
@@ -584,14 +587,14 @@ impl Uuid {
     }
 
     /// Creates a `Uuid` using the supplied big-endian bytes.
-    /// This method wraps [`from_bytes_be`]: #method.from_bytes_be
+    /// This method wraps [`Uuid::from_bytes_be`]
     #[cfg(not(feature = "const_fn"))]
     pub fn from_bytes(bytes: Bytes) -> Uuid {
         Self::from_bytes_be(bytes)
     }
 
     /// Creates a `Uuid` using the supplied big-endian bytes.
-    /// This method wraps [`from_bytes_be`]: #method.from_bytes_be
+    /// This method wraps [`Uuid::from_bytes_be`]
     #[cfg(feature = "const_fn")]
     pub const fn from_bytes(bytes: Bytes) -> Uuid {
         Self::from_bytes_be(bytes)
@@ -804,7 +807,7 @@ impl Uuid {
     }
 
     /// Returns the four field values of the UUID in big-endian order.
-    /// This method wraps [`as_bytes_be`]: #method.as_bytes_be
+    /// This method wraps [`Uuid::as_bytes_be`]
     pub fn as_fields(&self) -> (u32, u16, u16, &[u8; 8]) {
         self.as_fields_be()
     }
@@ -883,14 +886,14 @@ impl Uuid {
     }
 
     /// Returns an array of 16 octets containing the UUID data.
-    /// This method wraps [`to_bytes_be`]: #method.to_bytes_be
+    /// This method wraps [`Uuid::as_bytes_be`]
     #[cfg(feature = "const_fn")]
     pub const fn as_bytes(&self) -> &Bytes {
         self.as_bytes_be()
     }
 
     /// Returns an array of 16 octets containing the UUID data.
-    /// This method wraps [`to_bytes_be`]: #method.to_bytes_be
+    /// This method wraps [`Uuid::as_bytes_be`]
     #[cfg(not(feature = "const_fn"))]
     pub fn as_bytes(&self) -> &Bytes {
         self.as_bytes_be()

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -29,8 +29,8 @@
 //!
 //! Currently the prelude reexports the following:
 //!
-//! [`uuid`]`::{`[`Uuid`], [`Variant`], [`Version`], builder::[`Builder`]`}`: The fundamental
-//! types used in [`uuid`] crate.
+//! [`uuid`]`::{`[`Uuid`], [`Variant`], [`Version`], builder::[`Builder`]`}`:
+//! The fundamental types used in [`uuid`] crate.
 //!
 //! [`uuid`]: ../index.html
 //! [`Uuid`]: ../struct.Uuid.html
@@ -47,6 +47,6 @@ handling uuid version 1. Requires feature `v1`.
 [`Context`]: ../v1/struct.Context.html
 [`ClockSequence`]: ../v1/trait.ClockSequence.html")]
 
-pub use super::{Bytes, Uuid, Variant, Version, builder::Builder};
+pub use super::{Builder, Bytes, Uuid, Variant, Version};
 #[cfg(feature = "v1")]
 pub use v1::{ClockSequence, Context};

--- a/src/prelude.rs
+++ b/src/prelude.rs
@@ -29,13 +29,14 @@
 //!
 //! Currently the prelude reexports the following:
 //!
-//! [`uuid`]`::{`[`Uuid`], [`Variant`], [`Version`]`}`: The fundamental
+//! [`uuid`]`::{`[`Uuid`], [`Variant`], [`Version`], builder::[`Builder`]`}`: The fundamental
 //! types used in [`uuid`] crate.
 //!
 //! [`uuid`]: ../index.html
 //! [`Uuid`]: ../struct.Uuid.html
 //! [`Variant`]: ../enum.Variant.html
 //! [`Version`]: ../enum.Version.html
+//! [`Builder`]: ../builder/struct.Builder.html
 //!
 #![cfg_attr(feature = "v1",
 doc = "
@@ -46,6 +47,6 @@ handling uuid version 1. Requires feature `v1`.
 [`Context`]: ../v1/struct.Context.html
 [`ClockSequence`]: ../v1/trait.ClockSequence.html")]
 
-pub use super::{Bytes, Uuid, Variant, Version};
+pub use super::{Bytes, Uuid, Variant, Version, builder::Builder};
 #[cfg(feature = "v1")]
 pub use v1::{ClockSequence, Context};


### PR DESCRIPTION
**I'm submitting a feature**

# Description
This PR implements a basic UuidBuilder that takes itself by `&mut` instead of `self` as shown in the issue #171 description.

# Motivation
Issue #171

# Tests
Through Doctests

# Related Issue(s)
#171