### PR TITLE
remove slog test exclusion for 1.22.0 env

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,28 +6,6 @@ language: rust
 
 matrix:
   include:
-  - os: linux
-    rust: 1.22.0
-    script:
-    - cargo test --no-default-features
-    - cargo test
-    - cargo test --features "serde"
-    - cargo test --features "v1"
-    - cargo test --features "v3"
-    - cargo test --features "v4"
-    - cargo test --features "v5"
-    - cargo test --features "serde std v1 v3 v4 v5"
-  - os: osx
-    rust: 1.22.0
-    script:
-    - cargo test --no-default-features
-    - cargo test
-    - cargo test --features "serde"
-    - cargo test --features "v1"
-    - cargo test --features "v3"
-    - cargo test --features "v4"
-    - cargo test --features "v5"
-    - cargo test --features "serde std v1 v3 v4 v5"
   - os: osx
     rust: nightly
   - rust: nightly


### PR DESCRIPTION
**I'm submitting a(n)** other

# Description
Remove the builds for 1.22.0 not testing slog. Was introduced to prevent failing builds since slog introduced a bump of MSRV to 1.26.0 which broke our builds on 1.22.0

# Motivation
slog has released 2.4.1, which lowered the MSRV back to 1.15.0+

# Tests
Tests are passing. No new tests introduced.

# Related Issue(s)
closes #328 