### PR TITLE
add guid feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,10 +26,6 @@ all-features = true
 [package.metadata.playground]
 features = ["serde", "u128", "v1", "v3", "v4", "v5"]
 
-[dependencies.winapi]
-version = "0.3"
-optional = true
-
 [dependencies.byteorder]
 default-features = false
 features = ["i128"]
@@ -57,20 +53,25 @@ version = "0.6"
 optional = true
 version = "2"
 
-[dev-dependencies]
-serde_derive = "1.0.79"
-
-[dev-dependencies.serde_test]
-version = "1.0.56"
-
-[dev-dependencies.serde_json]
-version = "1.0"
+[dependencies.winapi]
+version = "0.3"
+optional = true
 
 [dev-dependencies.bincode]
 version = "1.0"
 
+[dev-dependencies.serde_derive]
+version = "1.0.79"
+
+[dev-dependencies.serde_json]
+version = "1.0"
+
+[dev-dependencies.serde_test]
+version = "1.0.56"
+
 [features]
 default = ["std"]
+guid = ["winapi"]
 std = []
 v1 = []
 v3 = ["md5", "rand"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,7 +139,6 @@ extern crate sha1;
 #[cfg(feature = "slog")]
 #[cfg_attr(test, macro_use)]
 extern crate slog;
-
 #[cfg(feature = "winapi")]
 extern crate winapi;
 

--- a/src/winapi_support.rs
+++ b/src/winapi_support.rs
@@ -4,6 +4,7 @@ use BytesError;
 
 use winapi::shared::guiddef;
 
+#[cfg(feature = "guid")]
 impl Uuid {
     /// Attempts to create a [`Uuid`] from a winapi `GUID`
     ///
@@ -32,6 +33,7 @@ impl Uuid {
     }
 }
 
+#[cfg(feature = "guid")]
 #[cfg(test)]
 mod tests {
     use prelude::*;


### PR DESCRIPTION
**I'm submitting a(n)** feature

# Description
Adds `guid` feature which is now used to enable windows GUID support.

# Motivation
`guid` is a better name for guid support than just `winapi`

# Tests
No changes

# Related Issue(s)
#333, #336
