### PR TITLE
Is it ok to increase version of rand from "0.5" to "0.6.0-pre.1" for wasm-bindgen support ?

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,12 @@ version = "0.5"
 
 [dependencies.rand]
 optional = true
-version = "0.5"
+version = "0.6.0-pre.1"
+
+[target.wasm32-unknown-unknown.dependencies.rand]
+optional = true
+version = "0.6.0-pre.1"
+features = ["wasm-bindgen"]
 
 [dependencies.serde]
 default-features = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ homepage = "https://github.com/uuid-rs/uuid"
 name = "uuid"
 readme = "README.md"
 repository = "https://github.com/uuid-rs/uuid"
-version = "0.7.1" # remember to update html_root_url in lib.rs
+version = "0.7.2" # remember to update html_root_url in lib.rs
 
 [package.metadata.docs.rs]
 all-features = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,7 +114,7 @@
 #![doc(
     html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
     html_favicon_url = "https://www.rust-lang.org/favicon.ico",
-    html_root_url = "https://docs.rs/uuid/0.7.1"
+    html_root_url = "https://docs.rs/uuid/0.7.2"
 )]
 
 #[cfg(feature = "byteorder")]


### PR DESCRIPTION
I wish you can merge this.
I need to use uuid on wasm.