### PR TITLE
Update md5 0.5 to 0.6

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ version = "1"
 
 [dependencies.md5]
 optional = true
-version = "0.5"
+version = "0.6"
 
 [dependencies.rand]
 optional = true


### PR DESCRIPTION
# Description
This patch updates the `md5` dependency from 0.5 to 0.6. The API of the `md5` crate is not exposed in `uuid`, just used in one single method which uses it internally, so this is not a semver breaking change.