### PR TITLE
fix parser::Error::InvalidCharacter Display message

### DIFF
--- a/src/parser/core_support.rs
+++ b/src/parser/core_support.rs
@@ -35,8 +35,8 @@ impl fmt::Display for parser::ParseError {
                 index,
             } => write!(
                 f,
-                "expected {:?}, found {} at {}",
-                expected.chars(),
+                "expected {}, found {} at {}",
+                expected,
                 found,
                 index
             ),

--- a/src/parser/core_support.rs
+++ b/src/parser/core_support.rs
@@ -33,13 +33,9 @@ impl fmt::Display for parser::ParseError {
                 expected,
                 found,
                 index,
-            } => write!(
-                f,
-                "expected {}, found {} at {}",
-                expected,
-                found,
-                index
-            ),
+            } => {
+                write!(f, "expected {}, found {} at {}", expected, found, index)
+            }
             parser::ParseError::InvalidGroupCount {
                 ref expected,
                 found,


### PR DESCRIPTION
**I'm submitting a(n)** bug fix

# Description
Use string instead of `str::Chars`

# Motivation
While working on `uuid_cli` I realized that when an invalid character was provided in a namespace uuid for v3 and v5 variants, the expected characters is shown as a numeric array instead of an array of chars. Not helpful for users. 

# Tests
As its only a error message change, no tests needed

# Related Issue(s)
N/A
