### PR TITLE
try to get wasm builds running

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,11 +28,11 @@ matrix:
     - cargo test --features "const_fn"
   - rust: beta
     before_script:
-      - rustup target add wasm32-unknown-unknown
+      - cargo install cargo-web
     script:
-      - cargo build --target wasm32-unknown-unknown --features "v3 wasm-bindgen"
-      - cargo build --target wasm32-unknown-unknown --features "v4 wasm-bindgen"
-      - cargo build --target wasm32-unknown-unknown --features "v5 wasm-bindgen"
+      - cargo web build --features "v3 wasm-bindgen"
+      - cargo web build --features "v4 wasm-bindgen"
+      - cargo web build --features "v5 wasm-bindgen"
   - rust: stable
     before_script:
     - rustup component add clippy-preview

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,17 +11,17 @@ matrix:
   - rust: nightly
     before_script:
     - rustup component add rustfmt-preview
-    - rustup target add wasm32-unknown-unknown
+    - cargo install cargo-web
     script:
     - cargo fmt --all -- --check
     - cargo test --features "serde std v1 v3 v4 v5"
     - cargo bench --features "serde std v1 v3 v4 v5"
-    - cargo build --target wasm32-unknown-unknown --features "v3 stdweb"
-    - cargo build --target wasm32-unknown-unknown --features "v4 stdweb"
-    - cargo build --target wasm32-unknown-unknown --features "v5 stdweb"
-    - cargo build --target wasm32-unknown-unknown --features "v3 wasm-bindgen"
-    - cargo build --target wasm32-unknown-unknown --features "v4 wasm-bindgen"
-    - cargo build --target wasm32-unknown-unknown --features "v5 wasm-bindgen"
+    - cargo web build --features "v3 stdweb"
+    - cargo web build --features "v4 stdweb"
+    - cargo web build --features "v5 stdweb"
+    - cargo web build --features "v3 wasm-bindgen"
+    - cargo web build --features "v4 wasm-bindgen"
+    - cargo web build --features "v5 wasm-bindgen"
   - os: linux
     rust: nightly
     script:


### PR DESCRIPTION
**I'm submitting a(n)** other

# Description
CI builds are failing because we are attempting to use `cargo build` for wasm builds. `cargo-web utility properly handles issues that are being caused

# Motivation
Failures while trying to pass #355 

# Tests
Current builds build in CI

# Related Issue(s)
N/A
