### PR TITLE
make Debug output for Uuid as hyphenated uuid instead of raw bytes

### DIFF
--- a/src/core_support.rs
+++ b/src/core_support.rs
@@ -13,6 +13,13 @@ use core::{fmt, str};
 use parser;
 use prelude::*;
 
+impl fmt::Debug for Uuid {
+    #[inline]
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        fmt::LowerHex::fmt(self, f)
+    }
+}
+
 impl fmt::Display for Uuid {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         fmt::LowerHex::fmt(self, f)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -253,7 +253,7 @@ pub enum Variant {
 }
 
 /// A Universally Unique Identifier (UUID).
-#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(Clone, Copy, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Uuid(Bytes);
 
 impl BytesError {


### PR DESCRIPTION
**I'm submitting a(n)** refactor


# Description
Use `fmt::LowerHex` as the base for `fmt::Debug`

# Motivation
#356 indicates that reading raw byte values for the uuid bytes is not easy for debugging purposes.

# Tests
N/A

# Related Issue(s)
#356 