### PR TITLE
stabilize const_fn

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,6 +88,5 @@ const_fn = []
 
 # nightly rust
 #------------------------
-# Allow using `const fn`s
 # Nightly marker feature gate
 nightly = []

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -83,9 +83,11 @@ wasm-bindgen = ["rand/wasm-bindgen"]
 # since rust 1.26.0
 u128 = ["byteorder"]
 
+# since rust 1.31.0
+const_fn = []
+
 # nightly rust
 #------------------------
 # Allow using `const fn`s
-const_fn = ["nightly"]
 # Nightly marker feature gate
 nightly = []

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,7 +115,6 @@
 //! [`wasm-bindgen`]: https://github.com/rustwasm/wasm-bindgen
 
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(feature = "const_fn", feature(const_fn))]
 #![deny(
     missing_copy_implementations,
     missing_debug_implementations,


### PR DESCRIPTION
**I'm submitting a(n)** other

# Description
Mark the `const_fn` as a stable feature and remove the compiler feature gate switch.

# Motivation
`const fn $name()` is now stable as of Rust 1.31.0

# Tests
All tests pass

# Related Issue(s)
closes #363 