### PR TITLE
enable the encode_{lower,upper} methods

### DIFF
--- a/benches/format_str.rs
+++ b/benches/format_str.rs
@@ -41,7 +41,7 @@ fn bench_encode_hyphen(b: &mut Bencher) {
     let uuid = Uuid::parse_str("F9168C5E-CEB2-4faa-B6BF-329BF39FA1E4").unwrap();
     b.iter(|| {
         let mut buffer = [0_u8; 36];
-        // uuid.to_hyphenated().encode_lower(&mut buffer);
+        uuid.to_hyphenated().encode_lower(&mut buffer);
         test::black_box(buffer);
     });
 }
@@ -51,7 +51,7 @@ fn bench_encode_simple(b: &mut Bencher) {
     let uuid = Uuid::parse_str("F9168C5E-CEB2-4faa-B6BF-329BF39FA1E4").unwrap();
     b.iter(|| {
         let mut buffer = [0_u8; 32];
-        // uuid.to_simple().encode_lower(&mut buffer);
+        uuid.to_simple().encode_lower(&mut buffer);
         test::black_box(buffer);
     })
 }
@@ -61,7 +61,7 @@ fn bench_encode_urn(b: &mut Bencher) {
     let uuid = Uuid::parse_str("F9168C5E-CEB2-4faa-B6BF-329BF39FA1E4").unwrap();
     b.iter(|| {
         let mut buffer = [0_u8; 36 + 9];
-        // uuid.to_urn().encode_lower(&mut buffer);
+        uuid.to_urn().encode_lower(&mut buffer);
         test::black_box(buffer);
     })
 }

--- a/src/adapter/mod.rs
+++ b/src/adapter/mod.rs
@@ -278,36 +278,36 @@ impl Hyphenated {
     /// Writes the [`Uuid`] as a lower-case hyphenated string to
     /// `buffer`, and returns the subslice of the buffer that contains the
     /// encoded UUID.
-    /// 
+    ///
     /// This is slightly more efficient than using the formatting
     /// infrastructure as it avoids virtual calls, and may avoid
     /// double buffering.
-    /// 
+    ///
     /// [`Uuid`]: ../struct.Uuid.html
-    /// 
+    ///
     /// # Panics
-    /// 
+    ///
     /// Panics if the buffer is not large enough: it must have length at least
     /// [`LENGTH`]. [`Uuid::encode_buffer`] can be used to get a
     /// sufficiently-large temporary buffer.
-    /// 
+    ///
     /// [`LENGTH`]: #associatedconstant.LENGTH
     /// [`Uuid::encode_buffer`]: ../struct.Uuid.html#method.encode_buffer
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```rust
     /// use uuid::Uuid;
-    /// 
+    ///
     /// let uuid = Uuid::parse_str("936DA01f9abd4d9d80c702af85c822a8").unwrap();
-    /// 
+    ///
     /// // the encoded portion is returned
     /// assert_eq!(
     ///     uuid.to_hyphenated()
     ///         .encode_lower(&mut Uuid::encode_buffer()),
     ///     "936da01f-9abd-4d9d-80c7-02af85c822a8"
     /// );
-    /// 
+    ///
     /// // the buffer is mutated directly, and trailing contents remains
     /// let mut buf = [b'!'; 40];
     /// uuid.to_hyphenated().encode_lower(&mut buf);
@@ -317,10 +317,7 @@ impl Hyphenated {
     /// );
     /// ```
     /// */
-    pub fn encode_lower<'buf>(
-        &self,
-        buffer: &'buf mut [u8],
-    ) -> &'buf mut str {
+    pub fn encode_lower<'buf>(&self, buffer: &'buf mut [u8]) -> &'buf mut str {
         encode(buffer, 0, &self.0, true, false)
     }
 
@@ -344,7 +341,7 @@ impl Hyphenated {
     /// [`Uuid::encode_buffer`]: ../struct.Uuid.html#method.encode_buffer
     ///
     /// # Examples
-    /// 
+    ///
     /// ```rust
     /// use uuid::Uuid;
     ///
@@ -366,10 +363,7 @@ impl Hyphenated {
     /// );
     /// ```
     /// */
-    pub fn encode_upper<'buf>(
-        &self,
-        buffer: &'buf mut [u8],
-    ) -> &'buf mut str {
+    pub fn encode_upper<'buf>(&self, buffer: &'buf mut [u8]) -> &'buf mut str {
         encode(buffer, 0, &self.0, true, true)
     }
 }
@@ -444,10 +438,7 @@ impl<'a> HyphenatedRef<'a> {
     /// );
     /// ```
     /// */
-    pub fn encode_lower<'buf>(
-        &self,
-        buffer: &'buf mut [u8],
-    ) -> &'buf mut str {
+    pub fn encode_lower<'buf>(&self, buffer: &'buf mut [u8]) -> &'buf mut str {
         encode(buffer, 0, self.0, true, false)
     }
 
@@ -496,10 +487,7 @@ impl<'a> HyphenatedRef<'a> {
     /// );
     /// ```
     /// */
-    pub fn encode_upper<'buf>(
-        &self,
-        buffer: &'buf mut [u8],
-    ) -> &'buf mut str {
+    pub fn encode_upper<'buf>(&self, buffer: &'buf mut [u8]) -> &'buf mut str {
         encode(buffer, 0, self.0, true, true)
     }
 }
@@ -530,35 +518,35 @@ impl Simple {
 
     /// Writes the [`Uuid`] as a lower-case simple string to `buffer`,
     /// and returns the subslice of the buffer that contains the encoded UUID.
-    /// 
+    ///
     /// This is slightly more efficient than using the formatting
     /// infrastructure as it avoids virtual calls, and may avoid
     /// double buffering.
-    /// 
+    ///
     /// [`Uuid`]: ../struct.Uuid.html
-    /// 
+    ///
     /// # Panics
-    /// 
+    ///
     /// Panics if the buffer is not large enough: it must have length at least
     /// [`LENGTH`]. [`Uuid::encode_buffer`] can be used to get a
     /// sufficiently-large temporary buffer.
-    /// 
+    ///
     /// [`LENGTH`]: #associatedconstant.LENGTH
     /// [`Uuid::encode_buffer`]: ../struct.Uuid.html#method.encode_buffer
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```rust
     /// use uuid::Uuid;
-    /// 
+    ///
     /// let uuid = Uuid::parse_str("936DA01f9abd4d9d80c702af85c822a8").unwrap();
-    /// 
+    ///
     /// // the encoded portion is returned
     /// assert_eq!(
     ///     uuid.to_simple().encode_lower(&mut Uuid::encode_buffer()),
     ///     "936da01f9abd4d9d80c702af85c822a8"
     /// );
-    /// 
+    ///
     /// // the buffer is mutated directly, and trailing contents remains
     /// let mut buf = [b'!'; 36];
     /// assert_eq!(
@@ -571,40 +559,37 @@ impl Simple {
     /// );
     /// ```
     /// */
-    pub fn encode_lower<'buf>(
-        &self,
-        buffer: &'buf mut [u8],
-    ) -> &'buf mut str {
+    pub fn encode_lower<'buf>(&self, buffer: &'buf mut [u8]) -> &'buf mut str {
         encode(buffer, 0, &self.0, false, false)
     }
 
     /// Writes the [`Uuid`] as an upper-case simple string to `buffer`,
     /// and returns the subslice of the buffer that contains the encoded UUID.
-    /// 
+    ///
     /// [`Uuid`]: ../struct.Uuid.html
-    /// 
+    ///
     /// # Panics
-    /// 
+    ///
     /// Panics if the buffer is not large enough: it must have length at least
     /// [`LENGTH`]. [`Uuid::encode_buffer`] can be used to get a
     /// sufficiently-large temporary buffer.
-    /// 
+    ///
     /// [`LENGTH`]: #associatedconstant.LENGTH
     /// [`Uuid::encode_buffer`]: ../struct.Uuid.html#method.encode_buffer
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```rust
     /// use uuid::Uuid;
-    /// 
+    ///
     /// let uuid = Uuid::parse_str("936da01f9abd4d9d80c702af85c822a8").unwrap();
-    /// 
+    ///
     /// // the encoded portion is returned
     /// assert_eq!(
     ///     uuid.to_simple().encode_upper(&mut Uuid::encode_buffer()),
     ///     "936DA01F9ABD4D9D80C702AF85C822A8"
     /// );
-    /// 
+    ///
     /// // the buffer is mutated directly, and trailing contents remains
     /// let mut buf = [b'!'; 36];
     /// assert_eq!(
@@ -617,10 +602,7 @@ impl Simple {
     /// );
     /// ```
     /// */
-    pub fn encode_upper<'buf>(
-        &self,
-        buffer: &'buf mut [u8],
-    ) -> &'buf mut str {
+    pub fn encode_upper<'buf>(&self, buffer: &'buf mut [u8]) -> &'buf mut str {
         encode(buffer, 0, &self.0, false, true)
     }
 }
@@ -651,35 +633,35 @@ impl<'a> SimpleRef<'a> {
 
     /// Writes the [`Uuid`] as a lower-case simple string to `buffer`,
     /// and returns the subslice of the buffer that contains the encoded UUID.
-    /// 
+    ///
     /// This is slightly more efficient than using the formatting
     /// infrastructure as it avoids virtual calls, and may avoid
     /// double buffering.
-    /// 
+    ///
     /// [`Uuid`]: ../struct.Uuid.html
-    /// 
+    ///
     /// # Panics
-    /// 
+    ///
     /// Panics if the buffer is not large enough: it must have length at least
     /// [`LENGTH`]. [`Uuid::encode_buffer`] can be used to get a
     /// sufficiently-large temporary buffer.
-    /// 
+    ///
     /// [`LENGTH`]: #associatedconstant.LENGTH
     /// [`Uuid::encode_buffer`]: ../struct.Uuid.html#method.encode_buffer
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```rust
     /// use uuid::Uuid;
-    /// 
+    ///
     /// let uuid = Uuid::parse_str("936DA01f9abd4d9d80c702af85c822a8").unwrap();
-    /// 
+    ///
     /// // the encoded portion is returned
     /// assert_eq!(
     ///     uuid.to_simple().encode_lower(&mut Uuid::encode_buffer()),
     ///     "936da01f9abd4d9d80c702af85c822a8"
     /// );
-    /// 
+    ///
     /// // the buffer is mutated directly, and trailing contents remains
     /// let mut buf = [b'!'; 36];
     /// assert_eq!(
@@ -692,40 +674,37 @@ impl<'a> SimpleRef<'a> {
     /// );
     /// ```
     /// */
-    pub fn encode_lower<'buf>(
-        &self,
-        buffer: &'buf mut [u8],
-    ) -> &'buf mut str {
+    pub fn encode_lower<'buf>(&self, buffer: &'buf mut [u8]) -> &'buf mut str {
         encode(buffer, 0, self.0, false, false)
     }
 
     /// Writes the [`Uuid`] as an upper-case simple string to `buffer`,
     /// and returns the subslice of the buffer that contains the encoded UUID.
-    /// 
+    ///
     /// [`Uuid`]: ../struct.Uuid.html
-    /// 
+    ///
     /// # Panics
-    /// 
+    ///
     /// Panics if the buffer is not large enough: it must have length at least
     /// [`LENGTH`]. [`Uuid::encode_buffer`] can be used to get a
     /// sufficiently-large temporary buffer.
-    /// 
+    ///
     /// [`LENGTH`]: #associatedconstant.LENGTH
     /// [`Uuid::encode_buffer`]: ../struct.Uuid.html#method.encode_buffer
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```rust
     /// use uuid::Uuid;
-    /// 
+    ///
     /// let uuid = Uuid::parse_str("936da01f9abd4d9d80c702af85c822a8").unwrap();
-    /// 
+    ///
     /// // the encoded portion is returned
     /// assert_eq!(
     ///     uuid.to_simple().encode_upper(&mut Uuid::encode_buffer()),
     ///     "936DA01F9ABD4D9D80C702AF85C822A8"
     /// );
-    /// 
+    ///
     /// // the buffer is mutated directly, and trailing contents remains
     /// let mut buf = [b'!'; 36];
     /// assert_eq!(
@@ -738,10 +717,7 @@ impl<'a> SimpleRef<'a> {
     /// );
     /// ```
     /// */
-    pub fn encode_upper<'buf>(
-        &self,
-        buffer: &'buf mut [u8],
-    ) -> &'buf mut str {
+    pub fn encode_upper<'buf>(&self, buffer: &'buf mut [u8]) -> &'buf mut str {
         encode(buffer, 0, self.0, false, true)
     }
 }
@@ -773,35 +749,35 @@ impl Urn {
     /// Writes the [`Uuid`] as a lower-case URN string to
     /// `buffer`, and returns the subslice of the buffer that contains the
     /// encoded UUID.
-    /// 
+    ///
     /// This is slightly more efficient than using the formatting
     /// infrastructure as it avoids virtual calls, and may avoid
     /// double buffering.
-    /// 
+    ///
     /// [`Uuid`]: ../struct.Uuid.html
-    /// 
+    ///
     /// # Panics
-    /// 
+    ///
     /// Panics if the buffer is not large enough: it must have length at least
     /// [`LENGTH`]. [`Uuid::encode_buffer`] can be used to get a
     /// sufficiently-large temporary buffer.
-    /// 
+    ///
     /// [`LENGTH`]: #associatedconstant.LENGTH
     /// [`Uuid::encode_buffer`]: ../struct.Uuid.html#method.encode_buffer
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```rust
     /// use uuid::Uuid;
-    /// 
+    ///
     /// let uuid = Uuid::parse_str("936DA01f9abd4d9d80c702af85c822a8").unwrap();
-    /// 
+    ///
     /// // the encoded portion is returned
     /// assert_eq!(
     ///     uuid.to_urn().encode_lower(&mut Uuid::encode_buffer()),
     ///     "urn:uuid:936da01f-9abd-4d9d-80c7-02af85c822a8"
     /// );
-    /// 
+    ///
     /// // the buffer is mutated directly, and trailing contents remains
     /// let mut buf = [b'!'; 49];
     /// uuid.to_urn().encode_lower(&mut buf);
@@ -815,10 +791,7 @@ impl Urn {
     /// );
     /// ```
     /// */
-    pub fn encode_lower<'buf>(
-        &self,
-        buffer: &'buf mut [u8],
-    ) -> &'buf mut str {
+    pub fn encode_lower<'buf>(&self, buffer: &'buf mut [u8]) -> &'buf mut str {
         buffer[..9].copy_from_slice(b"urn:uuid:");
         encode(buffer, 9, &self.0, true, false)
     }
@@ -826,35 +799,35 @@ impl Urn {
     /// Writes the [`Uuid`] as an upper-case URN string to
     /// `buffer`, and returns the subslice of the buffer that contains the
     /// encoded UUID.
-    /// 
+    ///
     /// This is slightly more efficient than using the formatting
     /// infrastructure as it avoids virtual calls, and may avoid
     /// double buffering.
-    /// 
+    ///
     /// [`Uuid`]: ../struct.Uuid.html
-    /// 
+    ///
     /// # Panics
-    /// 
+    ///
     /// Panics if the buffer is not large enough: it must have length at least
     /// [`LENGTH`]. [`Uuid::encode_buffer`] can be used to get a
     /// sufficiently-large temporary buffer.
-    /// 
+    ///
     /// [`LENGTH`]: #associatedconstant.LENGTH
     /// [`Uuid::encode_buffer`]: ../struct.Uuid.html#method.encode_buffer
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```rust
     /// use uuid::Uuid;
-    /// 
+    ///
     /// let uuid = Uuid::parse_str("936da01f9abd4d9d80c702af85c822a8").unwrap();
-    /// 
+    ///
     /// // the encoded portion is returned
     /// assert_eq!(
     ///     uuid.to_urn().encode_upper(&mut Uuid::encode_buffer()),
     ///     "urn:uuid:936DA01F-9ABD-4D9D-80C7-02AF85C822A8"
     /// );
-    /// 
+    ///
     /// // the buffer is mutated directly, and trailing contents remains
     /// let mut buf = [b'!'; 49];
     /// assert_eq!(
@@ -867,10 +840,7 @@ impl Urn {
     /// );
     /// ```
     /// */
-    pub fn encode_upper<'buf>(
-        &self,
-        buffer: &'buf mut [u8],
-    ) -> &'buf mut str {
+    pub fn encode_upper<'buf>(&self, buffer: &'buf mut [u8]) -> &'buf mut str {
         buffer[..9].copy_from_slice(b"urn:uuid:");
         encode(buffer, 9, &self.0, true, true)
     }
@@ -903,35 +873,35 @@ impl<'a> UrnRef<'a> {
     /// Writes the [`Uuid`] as a lower-case URN string to
     /// `buffer`, and returns the subslice of the buffer that contains the
     /// encoded UUID.
-    /// 
+    ///
     /// This is slightly more efficient than using the formatting
     /// infrastructure as it avoids virtual calls, and may avoid
     /// double buffering.
-    /// 
+    ///
     /// [`Uuid`]: ../struct.Uuid.html
-    /// 
+    ///
     /// # Panics
-    /// 
+    ///
     /// Panics if the buffer is not large enough: it must have length at least
     /// [`LENGTH`]. [`Uuid::encode_buffer`] can be used to get a
     /// sufficiently-large temporary buffer.
-    /// 
+    ///
     /// [`LENGTH`]: #associatedconstant.LENGTH
     /// [`Uuid::encode_buffer`]: ../struct.Uuid.html#method.encode_buffer
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```rust
     /// use uuid::Uuid;
-    /// 
+    ///
     /// let uuid = Uuid::parse_str("936DA01f9abd4d9d80c702af85c822a8").unwrap();
-    /// 
+    ///
     /// // the encoded portion is returned
     /// assert_eq!(
     ///     uuid.to_urn().encode_lower(&mut Uuid::encode_buffer()),
     ///     "urn:uuid:936da01f-9abd-4d9d-80c7-02af85c822a8"
     /// );
-    /// 
+    ///
     /// // the buffer is mutated directly, and trailing contents remains
     /// let mut buf = [b'!'; 49];
     /// uuid.to_urn().encode_lower(&mut buf);
@@ -945,10 +915,7 @@ impl<'a> UrnRef<'a> {
     /// );
     /// ```
     /// */
-    pub fn encode_lower<'buf>(
-        &self,
-        buffer: &'buf mut [u8],
-    ) -> &'buf mut str {
+    pub fn encode_lower<'buf>(&self, buffer: &'buf mut [u8]) -> &'buf mut str {
         buffer[..9].copy_from_slice(b"urn:uuid:");
         encode(buffer, 9, self.0, true, false)
     }
@@ -956,35 +923,35 @@ impl<'a> UrnRef<'a> {
     /// Writes the [`Uuid`] as an upper-case URN string to
     /// `buffer`, and returns the subslice of the buffer that contains the
     /// encoded UUID.
-    /// 
+    ///
     /// This is slightly more efficient than using the formatting
     /// infrastructure as it avoids virtual calls, and may avoid
     /// double buffering.
-    /// 
+    ///
     /// [`Uuid`]: ../struct.Uuid.html
-    /// 
+    ///
     /// # Panics
-    /// 
+    ///
     /// Panics if the buffer is not large enough: it must have length at least
     /// [`LENGTH`]. [`Uuid::encode_buffer`] can be used to get a
     /// sufficiently-large temporary buffer.
-    /// 
+    ///
     /// [`LENGTH`]: #associatedconstant.LENGTH
     /// [`Uuid::encode_buffer`]: ../struct.Uuid.html#method.encode_buffer
-    /// 
+    ///
     /// # Examples
-    /// 
+    ///
     /// ```rust
     /// use uuid::Uuid;
-    /// 
+    ///
     /// let uuid = Uuid::parse_str("936da01f9abd4d9d80c702af85c822a8").unwrap();
-    /// 
+    ///
     /// // the encoded portion is returned
     /// assert_eq!(
     ///     uuid.to_urn().encode_upper(&mut Uuid::encode_buffer()),
     ///     "urn:uuid:936DA01F-9ABD-4D9D-80C7-02AF85C822A8"
     /// );
-    /// 
+    ///
     /// // the buffer is mutated directly, and trailing contents remains
     /// let mut buf = [b'!'; 49];
     /// assert_eq!(
@@ -997,10 +964,7 @@ impl<'a> UrnRef<'a> {
     /// );
     /// ```
     /// */
-    pub fn encode_upper<'buf>(
-        &self,
-        buffer: &'buf mut [u8],
-    ) -> &'buf mut str {
+    pub fn encode_upper<'buf>(&self, buffer: &'buf mut [u8]) -> &'buf mut str {
         buffer[..9].copy_from_slice(b"urn:uuid:");
         encode(buffer, 9, self.0, true, true)
     }

--- a/src/adapter/mod.rs
+++ b/src/adapter/mod.rs
@@ -233,13 +233,8 @@ fn encode<'a>(
             // before this point. That's exactly the (0-indexed) group
             // number.
             let hyphens_before = if hyphens { group } else { 0 };
-
-            for (idx, b) in bytes
-                .iter()
-                .enumerate()
-                .take(BYTE_POSITIONS[group + 1])
-                .skip(BYTE_POSITIONS[group])
-            {
+            for idx in BYTE_POSITIONS[group]..BYTE_POSITIONS[group + 1] {
+                let b = bytes[idx];
                 let out_idx = hyphens_before + 2 * idx;
 
                 buffer[out_idx] = hex[(b >> 4) as usize];
@@ -280,98 +275,98 @@ impl Hyphenated {
         Hyphenated(uuid)
     }
 
-    // Writes the [`Uuid`] as a lower-case hyphenated string to
-    // `buffer`, and returns the subslice of the buffer that contains the
-    // encoded UUID.
-    //
-    // This is slightly more efficient than using the formatting
-    // infrastructure as it avoids virtual calls, and may avoid
-    // double buffering.
-    //
-    // [`Uuid`]: ../struct.Uuid.html
-    //
-    // # Panics
-    //
-    // Panics if the buffer is not large enough: it must have length at least
-    // [`LENGTH`]. [`Uuid::encode_buffer`] can be used to get a
-    // sufficiently-large temporary buffer.
-    //
-    // [`LENGTH`]: #associatedconstant.LENGTH
-    // [`Uuid::encode_buffer`]: ../struct.Uuid.html#method.encode_buffer
-    //
-    // # Examples
-    //
-    // ```rust
-    // use uuid::Uuid;
-    //
-    // let uuid = Uuid::parse_str("936DA01f9abd4d9d80c702af85c822a8").unwrap();
-    //
-    // // the encoded portion is returned
-    // assert_eq!(
-    //     uuid.to_hyphenated()
-    //         .encode_lower(&mut Uuid::encode_buffer()),
-    //     "936da01f-9abd-4d9d-80c7-02af85c822a8"
-    // );
-    //
-    // // the buffer is mutated directly, and trailing contents remains
-    // let mut buf = [b'!'; 40];
-    // uuid.to_hyphenated().encode_lower(&mut buf);
-    // assert_eq!(
-    //     &buf as &[_],
-    //     b"936da01f-9abd-4d9d-80c7-02af85c822a8!!!!" as &[_]
-    // );
-    // ```
-    // */
-    pub(crate) fn encode_lower<'buf>(
+    /// Writes the [`Uuid`] as a lower-case hyphenated string to
+    /// `buffer`, and returns the subslice of the buffer that contains the
+    /// encoded UUID.
+    /// 
+    /// This is slightly more efficient than using the formatting
+    /// infrastructure as it avoids virtual calls, and may avoid
+    /// double buffering.
+    /// 
+    /// [`Uuid`]: ../struct.Uuid.html
+    /// 
+    /// # Panics
+    /// 
+    /// Panics if the buffer is not large enough: it must have length at least
+    /// [`LENGTH`]. [`Uuid::encode_buffer`] can be used to get a
+    /// sufficiently-large temporary buffer.
+    /// 
+    /// [`LENGTH`]: #associatedconstant.LENGTH
+    /// [`Uuid::encode_buffer`]: ../struct.Uuid.html#method.encode_buffer
+    /// 
+    /// # Examples
+    /// 
+    /// ```rust
+    /// use uuid::Uuid;
+    /// 
+    /// let uuid = Uuid::parse_str("936DA01f9abd4d9d80c702af85c822a8").unwrap();
+    /// 
+    /// // the encoded portion is returned
+    /// assert_eq!(
+    ///     uuid.to_hyphenated()
+    ///         .encode_lower(&mut Uuid::encode_buffer()),
+    ///     "936da01f-9abd-4d9d-80c7-02af85c822a8"
+    /// );
+    /// 
+    /// // the buffer is mutated directly, and trailing contents remains
+    /// let mut buf = [b'!'; 40];
+    /// uuid.to_hyphenated().encode_lower(&mut buf);
+    /// assert_eq!(
+    ///     &buf as &[_],
+    ///     b"936da01f-9abd-4d9d-80c7-02af85c822a8!!!!" as &[_]
+    /// );
+    /// ```
+    /// */
+    pub fn encode_lower<'buf>(
         &self,
         buffer: &'buf mut [u8],
     ) -> &'buf mut str {
         encode(buffer, 0, &self.0, true, false)
     }
 
-    // Writes the [`Uuid`] as an upper-case hyphenated string to
-    // `buffer`, and returns the subslice of the buffer that contains the
-    // encoded UUID.
-    //
-    // This is slightly more efficient than using the formatting
-    // infrastructure as it avoids virtual calls, and may avoid
-    // double buffering.
-    //
-    // [`Uuid`]: ../struct.Uuid.html
-    //
-    // # Panics
-    //
-    // Panics if the buffer is not large enough: it must have length at least
-    // [`LENGTH`]. [`Uuid::encode_buffer`] can be used to get a
-    // sufficiently-large temporary buffer.
-    //
-    // [`LENGTH`]: #associatedconstant.LENGTH
-    // [`Uuid::encode_buffer`]: ../struct.Uuid.html#method.encode_buffer
-    //
-    // # Examples
-    //
-    // ```rust
-    // use uuid::Uuid;
-    //
-    // let uuid = Uuid::parse_str("936da01f9abd4d9d80c702af85c822a8").unwrap();
-    //
-    // // the encoded portion is returned
-    // assert_eq!(
-    //     uuid.to_hyphenated()
-    //         .encode_upper(&mut Uuid::encode_buffer()),
-    //     "936DA01F-9ABD-4D9D-80C7-02AF85C822A8"
-    // );
-    //
-    // // the buffer is mutated directly, and trailing contents remains
-    // let mut buf = [b'!'; 40];
-    // uuid.to_hyphenated().encode_upper(&mut buf);
-    // assert_eq!(
-    //     &buf as &[_],
-    //     b"936DA01F-9ABD-4D9D-80C7-02AF85C822A8!!!!" as &[_]
-    // );
-    // ```
-    // */
-    pub(crate) fn encode_upper<'buf>(
+    /// Writes the [`Uuid`] as an upper-case hyphenated string to
+    /// `buffer`, and returns the subslice of the buffer that contains the
+    /// encoded UUID.
+    ///
+    /// This is slightly more efficient than using the formatting
+    /// infrastructure as it avoids virtual calls, and may avoid
+    /// double buffering.
+    ///
+    /// [`Uuid`]: ../struct.Uuid.html
+    ///
+    /// # Panics
+    ///
+    /// Panics if the buffer is not large enough: it must have length at least
+    /// [`LENGTH`]. [`Uuid::encode_buffer`] can be used to get a
+    /// sufficiently-large temporary buffer.
+    ///
+    /// [`LENGTH`]: #associatedconstant.LENGTH
+    /// [`Uuid::encode_buffer`]: ../struct.Uuid.html#method.encode_buffer
+    ///
+    /// # Examples
+    /// 
+    /// ```rust
+    /// use uuid::Uuid;
+    ///
+    /// let uuid = Uuid::parse_str("936da01f9abd4d9d80c702af85c822a8").unwrap();
+    ///
+    /// // the encoded portion is returned
+    /// assert_eq!(
+    ///     uuid.to_hyphenated()
+    ///         .encode_upper(&mut Uuid::encode_buffer()),
+    ///     "936DA01F-9ABD-4D9D-80C7-02AF85C822A8"
+    /// );
+    ///
+    /// // the buffer is mutated directly, and trailing contents remains
+    /// let mut buf = [b'!'; 40];
+    /// uuid.to_hyphenated().encode_upper(&mut buf);
+    /// assert_eq!(
+    ///     &buf as &[_],
+    ///     b"936DA01F-9ABD-4D9D-80C7-02AF85C822A8!!!!" as &[_]
+    /// );
+    /// ```
+    /// */
+    pub fn encode_upper<'buf>(
         &self,
         buffer: &'buf mut [u8],
     ) -> &'buf mut str {
@@ -403,105 +398,105 @@ impl<'a> HyphenatedRef<'a> {
         HyphenatedRef(uuid)
     }
 
-    // Writes the [`Uuid`] as a lower-case hyphenated string to
-    // `buffer`, and returns the subslice of the buffer that contains the
-    // encoded UUID.
-    //
-    // This is slightly more efficient than using the formatting
-    // infrastructure as it avoids virtual calls, and may avoid
-    // double buffering.
-    //
-    // [`Uuid`]: ../struct.Uuid.html
-    //
-    // # Panics
-    //
-    // Panics if the buffer is not large enough: it must have length at least
-    // [`LENGTH`]. [`Uuid::encode_buffer`] can be used to get a
-    // sufficiently-large temporary buffer.
-    //
-    // [`LENGTH`]: #associatedconstant.LENGTH
-    // [`Uuid::encode_buffer`]: ../struct.Uuid.html#method.encode_buffer
-    //
-    // # Examples
-    //
-    // ```rust
-    // use uuid::Uuid;
-    //
-    // let uuid = Uuid::parse_str("936DA01f9abd4d9d80c702af85c822a8").unwrap();
-    //
-    // // the encoded portion is returned
-    // assert_eq!(
-    //     uuid.to_hyphenated()
-    //         .encode_lower(&mut Uuid::encode_buffer()),
-    //     "936da01f-9abd-4d9d-80c7-02af85c822a8"
-    // );
-    //
-    // // the buffer is mutated directly, and trailing contents remains
-    // let mut buf = [b'!'; 40];
-    // uuid.to_hyphenated().encode_lower(&mut buf);
-    // assert_eq!(
-    //     uuid.to_hyphenated().encode_lower(&mut buf),
-    //     "936da01f-9abd-4d9d-80c7-02af85c822a8"
-    // );
-    // assert_eq!(
-    //     &buf as &[_],
-    //     b"936da01f-9abd-4d9d-80c7-02af85c822a8!!!!" as &[_]
-    // );
-    // ```
-    // */
-    pub(crate) fn encode_lower<'buf>(
+    /// Writes the [`Uuid`] as a lower-case hyphenated string to
+    /// `buffer`, and returns the subslice of the buffer that contains the
+    /// encoded UUID.
+    ///
+    /// This is slightly more efficient than using the formatting
+    /// infrastructure as it avoids virtual calls, and may avoid
+    /// double buffering.
+    ///
+    /// [`Uuid`]: ../struct.Uuid.html
+    ///
+    /// # Panics
+    ///
+    /// Panics if the buffer is not large enough: it must have length at least
+    /// [`LENGTH`]. [`Uuid::encode_buffer`] can be used to get a
+    /// sufficiently-large temporary buffer.
+    ///
+    /// [`LENGTH`]: #associatedconstant.LENGTH
+    /// [`Uuid::encode_buffer`]: ../struct.Uuid.html#method.encode_buffer
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use uuid::Uuid;
+    ///
+    /// let uuid = Uuid::parse_str("936DA01f9abd4d9d80c702af85c822a8").unwrap();
+    ///
+    /// // the encoded portion is returned
+    /// assert_eq!(
+    ///     uuid.to_hyphenated()
+    ///         .encode_lower(&mut Uuid::encode_buffer()),
+    ///     "936da01f-9abd-4d9d-80c7-02af85c822a8"
+    /// );
+    ///
+    /// // the buffer is mutated directly, and trailing contents remains
+    /// let mut buf = [b'!'; 40];
+    /// uuid.to_hyphenated().encode_lower(&mut buf);
+    /// assert_eq!(
+    ///     uuid.to_hyphenated().encode_lower(&mut buf),
+    ///     "936da01f-9abd-4d9d-80c7-02af85c822a8"
+    /// );
+    /// assert_eq!(
+    ///     &buf as &[_],
+    ///     b"936da01f-9abd-4d9d-80c7-02af85c822a8!!!!" as &[_]
+    /// );
+    /// ```
+    /// */
+    pub fn encode_lower<'buf>(
         &self,
         buffer: &'buf mut [u8],
     ) -> &'buf mut str {
         encode(buffer, 0, self.0, true, false)
     }
 
-    // Writes the [`Uuid`] as an upper-case hyphenated string to
-    // `buffer`, and returns the subslice of the buffer that contains the
-    // encoded UUID.
-    //
-    // This is slightly more efficient than using the formatting
-    // infrastructure as it avoids virtual calls, and may avoid
-    // double buffering.
-    //
-    // [`Uuid`]: ../struct.Uuid.html
-    //
-    // # Panics
-    //
-    // Panics if the buffer is not large enough: it must have length at least
-    // [`LENGTH`]. [`Uuid::encode_buffer`] can be used to get a
-    // sufficiently-large temporary buffer.
-    //
-    // [`LENGTH`]: #associatedconstant.LENGTH
-    // [`Uuid::encode_buffer`]: ../struct.Uuid.html#method.encode_buffer
-    //
-    // # Examples
-    //
-    // ```rust
-    // use uuid::Uuid;
-    //
-    // let uuid = Uuid::parse_str("936da01f9abd4d9d80c702af85c822a8").unwrap();
-    //
-    // // the encoded portion is returned
-    // assert_eq!(
-    //     uuid.to_hyphenated()
-    //         .encode_upper(&mut Uuid::encode_buffer()),
-    //     "936DA01F-9ABD-4D9D-80C7-02AF85C822A8"
-    // );
-    //
-    // // the buffer is mutated directly, and trailing contents remains
-    // let mut buf = [b'!'; 40];
-    // assert_eq!(
-    //     uuid.to_hyphenated().encode_upper(&mut buf),
-    //     "936DA01F-9ABD-4D9D-80C7-02AF85C822A8"
-    // );
-    // assert_eq!(
-    //     &buf as &[_],
-    //     b"936DA01F-9ABD-4D9D-80C7-02AF85C822A8!!!!" as &[_]
-    // );
-    // ```
-    // */
-    pub(crate) fn encode_upper<'buf>(
+    /// Writes the [`Uuid`] as an upper-case hyphenated string to
+    /// `buffer`, and returns the subslice of the buffer that contains the
+    /// encoded UUID.
+    ///
+    /// This is slightly more efficient than using the formatting
+    /// infrastructure as it avoids virtual calls, and may avoid
+    /// double buffering.
+    ///
+    /// [`Uuid`]: ../struct.Uuid.html
+    ///
+    /// # Panics
+    ///
+    /// Panics if the buffer is not large enough: it must have length at least
+    /// [`LENGTH`]. [`Uuid::encode_buffer`] can be used to get a
+    /// sufficiently-large temporary buffer.
+    ///
+    /// [`LENGTH`]: #associatedconstant.LENGTH
+    /// [`Uuid::encode_buffer`]: ../struct.Uuid.html#method.encode_buffer
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use uuid::Uuid;
+    ///
+    /// let uuid = Uuid::parse_str("936da01f9abd4d9d80c702af85c822a8").unwrap();
+    ///
+    /// // the encoded portion is returned
+    /// assert_eq!(
+    ///     uuid.to_hyphenated()
+    ///         .encode_upper(&mut Uuid::encode_buffer()),
+    ///     "936DA01F-9ABD-4D9D-80C7-02AF85C822A8"
+    /// );
+    ///
+    /// // the buffer is mutated directly, and trailing contents remains
+    /// let mut buf = [b'!'; 40];
+    /// assert_eq!(
+    ///     uuid.to_hyphenated().encode_upper(&mut buf),
+    ///     "936DA01F-9ABD-4D9D-80C7-02AF85C822A8"
+    /// );
+    /// assert_eq!(
+    ///     &buf as &[_],
+    ///     b"936DA01F-9ABD-4D9D-80C7-02AF85C822A8!!!!" as &[_]
+    /// );
+    /// ```
+    /// */
+    pub fn encode_upper<'buf>(
         &self,
         buffer: &'buf mut [u8],
     ) -> &'buf mut str {
@@ -533,96 +528,96 @@ impl Simple {
         Simple(uuid)
     }
 
-    // Writes the [`Uuid`] as a lower-case simple string to `buffer`,
-    // and returns the subslice of the buffer that contains the encoded UUID.
-    //
-    // This is slightly more efficient than using the formatting
-    // infrastructure as it avoids virtual calls, and may avoid
-    // double buffering.
-    //
-    // [`Uuid`]: ../struct.Uuid.html
-    //
-    // # Panics
-    //
-    // Panics if the buffer is not large enough: it must have length at least
-    // [`LENGTH`]. [`Uuid::encode_buffer`] can be used to get a
-    // sufficiently-large temporary buffer.
-    //
-    // [`LENGTH`]: #associatedconstant.LENGTH
-    // [`Uuid::encode_buffer`]: ../struct.Uuid.html#method.encode_buffer
-    //
-    // # Examples
-    //
-    // ```rust
-    // use uuid::Uuid;
-    //
-    // let uuid = Uuid::parse_str("936DA01f9abd4d9d80c702af85c822a8").unwrap();
-    //
-    // // the encoded portion is returned
-    // assert_eq!(
-    //     uuid.to_simple().encode_lower(&mut Uuid::encode_buffer()),
-    //     "936da01f9abd4d9d80c702af85c822a8"
-    // );
-    //
-    // // the buffer is mutated directly, and trailing contents remains
-    // let mut buf = [b'!'; 36];
-    // assert_eq!(
-    //     uuid.to_simple().encode_lower(&mut buf),
-    //     "936da01f9abd4d9d80c702af85c822a8"
-    // );
-    // assert_eq!(
-    //     &buf as &[_],
-    //     b"936da01f9abd4d9d80c702af85c822a8!!!!" as &[_]
-    // );
-    // ```
-    // */
-    pub(crate) fn encode_lower<'buf>(
+    /// Writes the [`Uuid`] as a lower-case simple string to `buffer`,
+    /// and returns the subslice of the buffer that contains the encoded UUID.
+    /// 
+    /// This is slightly more efficient than using the formatting
+    /// infrastructure as it avoids virtual calls, and may avoid
+    /// double buffering.
+    /// 
+    /// [`Uuid`]: ../struct.Uuid.html
+    /// 
+    /// # Panics
+    /// 
+    /// Panics if the buffer is not large enough: it must have length at least
+    /// [`LENGTH`]. [`Uuid::encode_buffer`] can be used to get a
+    /// sufficiently-large temporary buffer.
+    /// 
+    /// [`LENGTH`]: #associatedconstant.LENGTH
+    /// [`Uuid::encode_buffer`]: ../struct.Uuid.html#method.encode_buffer
+    /// 
+    /// # Examples
+    /// 
+    /// ```rust
+    /// use uuid::Uuid;
+    /// 
+    /// let uuid = Uuid::parse_str("936DA01f9abd4d9d80c702af85c822a8").unwrap();
+    /// 
+    /// // the encoded portion is returned
+    /// assert_eq!(
+    ///     uuid.to_simple().encode_lower(&mut Uuid::encode_buffer()),
+    ///     "936da01f9abd4d9d80c702af85c822a8"
+    /// );
+    /// 
+    /// // the buffer is mutated directly, and trailing contents remains
+    /// let mut buf = [b'!'; 36];
+    /// assert_eq!(
+    ///     uuid.to_simple().encode_lower(&mut buf),
+    ///     "936da01f9abd4d9d80c702af85c822a8"
+    /// );
+    /// assert_eq!(
+    ///     &buf as &[_],
+    ///     b"936da01f9abd4d9d80c702af85c822a8!!!!" as &[_]
+    /// );
+    /// ```
+    /// */
+    pub fn encode_lower<'buf>(
         &self,
         buffer: &'buf mut [u8],
     ) -> &'buf mut str {
         encode(buffer, 0, &self.0, false, false)
     }
 
-    // Writes the [`Uuid`] as an upper-case simple string to `buffer`,
-    // and returns the subslice of the buffer that contains the encoded UUID.
-    //
-    // [`Uuid`]: ../struct.Uuid.html
-    //
-    // # Panics
-    //
-    // Panics if the buffer is not large enough: it must have length at least
-    // [`LENGTH`]. [`Uuid::encode_buffer`] can be used to get a
-    // sufficiently-large temporary buffer.
-    //
-    // [`LENGTH`]: #associatedconstant.LENGTH
-    // [`Uuid::encode_buffer`]: ../struct.Uuid.html#method.encode_buffer
-    //
-    // # Examples
-    //
-    // ```rust
-    // use uuid::Uuid;
-    //
-    // let uuid = Uuid::parse_str("936da01f9abd4d9d80c702af85c822a8").unwrap();
-    //
-    // // the encoded portion is returned
-    // assert_eq!(
-    //     uuid.to_simple().encode_upper(&mut Uuid::encode_buffer()),
-    //     "936DA01F9ABD4D9D80C702AF85C822A8"
-    // );
-    //
-    // // the buffer is mutated directly, and trailing contents remains
-    // let mut buf = [b'!'; 36];
-    // assert_eq!(
-    //     uuid.to_simple().encode_upper(&mut buf),
-    //     "936DA01F9ABD4D9D80C702AF85C822A8"
-    // );
-    // assert_eq!(
-    //     &buf as &[_],
-    //     b"936DA01F9ABD4D9D80C702AF85C822A8!!!!" as &[_]
-    // );
-    // ```
-    // */
-    pub(crate) fn encode_upper<'buf>(
+    /// Writes the [`Uuid`] as an upper-case simple string to `buffer`,
+    /// and returns the subslice of the buffer that contains the encoded UUID.
+    /// 
+    /// [`Uuid`]: ../struct.Uuid.html
+    /// 
+    /// # Panics
+    /// 
+    /// Panics if the buffer is not large enough: it must have length at least
+    /// [`LENGTH`]. [`Uuid::encode_buffer`] can be used to get a
+    /// sufficiently-large temporary buffer.
+    /// 
+    /// [`LENGTH`]: #associatedconstant.LENGTH
+    /// [`Uuid::encode_buffer`]: ../struct.Uuid.html#method.encode_buffer
+    /// 
+    /// # Examples
+    /// 
+    /// ```rust
+    /// use uuid::Uuid;
+    /// 
+    /// let uuid = Uuid::parse_str("936da01f9abd4d9d80c702af85c822a8").unwrap();
+    /// 
+    /// // the encoded portion is returned
+    /// assert_eq!(
+    ///     uuid.to_simple().encode_upper(&mut Uuid::encode_buffer()),
+    ///     "936DA01F9ABD4D9D80C702AF85C822A8"
+    /// );
+    /// 
+    /// // the buffer is mutated directly, and trailing contents remains
+    /// let mut buf = [b'!'; 36];
+    /// assert_eq!(
+    ///     uuid.to_simple().encode_upper(&mut buf),
+    ///     "936DA01F9ABD4D9D80C702AF85C822A8"
+    /// );
+    /// assert_eq!(
+    ///     &buf as &[_],
+    ///     b"936DA01F9ABD4D9D80C702AF85C822A8!!!!" as &[_]
+    /// );
+    /// ```
+    /// */
+    pub fn encode_upper<'buf>(
         &self,
         buffer: &'buf mut [u8],
     ) -> &'buf mut str {
@@ -654,96 +649,96 @@ impl<'a> SimpleRef<'a> {
         SimpleRef(uuid)
     }
 
-    // Writes the [`Uuid`] as a lower-case simple string to `buffer`,
-    // and returns the subslice of the buffer that contains the encoded UUID.
-    //
-    // This is slightly more efficient than using the formatting
-    // infrastructure as it avoids virtual calls, and may avoid
-    // double buffering.
-    //
-    // [`Uuid`]: ../struct.Uuid.html
-    //
-    // # Panics
-    //
-    // Panics if the buffer is not large enough: it must have length at least
-    // [`LENGTH`]. [`Uuid::encode_buffer`] can be used to get a
-    // sufficiently-large temporary buffer.
-    //
-    // [`LENGTH`]: #associatedconstant.LENGTH
-    // [`Uuid::encode_buffer`]: ../struct.Uuid.html#method.encode_buffer
-    //
-    // # Examples
-    //
-    // ```rust
-    // use uuid::Uuid;
-    //
-    // let uuid = Uuid::parse_str("936DA01f9abd4d9d80c702af85c822a8").unwrap();
-    //
-    // // the encoded portion is returned
-    // assert_eq!(
-    //     uuid.to_simple().encode_lower(&mut Uuid::encode_buffer()),
-    //     "936da01f9abd4d9d80c702af85c822a8"
-    // );
-    //
-    // // the buffer is mutated directly, and trailing contents remains
-    // let mut buf = [b'!'; 36];
-    // assert_eq!(
-    //     uuid.to_simple().encode_lower(&mut buf),
-    //     "936da01f9abd4d9d80c702af85c822a8"
-    // );
-    // assert_eq!(
-    //     &buf as &[_],
-    //     b"936da01f9abd4d9d80c702af85c822a8!!!!" as &[_]
-    // );
-    // ```
-    // */
-    pub(crate) fn encode_lower<'buf>(
+    /// Writes the [`Uuid`] as a lower-case simple string to `buffer`,
+    /// and returns the subslice of the buffer that contains the encoded UUID.
+    /// 
+    /// This is slightly more efficient than using the formatting
+    /// infrastructure as it avoids virtual calls, and may avoid
+    /// double buffering.
+    /// 
+    /// [`Uuid`]: ../struct.Uuid.html
+    /// 
+    /// # Panics
+    /// 
+    /// Panics if the buffer is not large enough: it must have length at least
+    /// [`LENGTH`]. [`Uuid::encode_buffer`] can be used to get a
+    /// sufficiently-large temporary buffer.
+    /// 
+    /// [`LENGTH`]: #associatedconstant.LENGTH
+    /// [`Uuid::encode_buffer`]: ../struct.Uuid.html#method.encode_buffer
+    /// 
+    /// # Examples
+    /// 
+    /// ```rust
+    /// use uuid::Uuid;
+    /// 
+    /// let uuid = Uuid::parse_str("936DA01f9abd4d9d80c702af85c822a8").unwrap();
+    /// 
+    /// // the encoded portion is returned
+    /// assert_eq!(
+    ///     uuid.to_simple().encode_lower(&mut Uuid::encode_buffer()),
+    ///     "936da01f9abd4d9d80c702af85c822a8"
+    /// );
+    /// 
+    /// // the buffer is mutated directly, and trailing contents remains
+    /// let mut buf = [b'!'; 36];
+    /// assert_eq!(
+    ///     uuid.to_simple().encode_lower(&mut buf),
+    ///     "936da01f9abd4d9d80c702af85c822a8"
+    /// );
+    /// assert_eq!(
+    ///     &buf as &[_],
+    ///     b"936da01f9abd4d9d80c702af85c822a8!!!!" as &[_]
+    /// );
+    /// ```
+    /// */
+    pub fn encode_lower<'buf>(
         &self,
         buffer: &'buf mut [u8],
     ) -> &'buf mut str {
         encode(buffer, 0, self.0, false, false)
     }
 
-    // Writes the [`Uuid`] as an upper-case simple string to `buffer`,
-    // and returns the subslice of the buffer that contains the encoded UUID.
-    //
-    // [`Uuid`]: ../struct.Uuid.html
-    //
-    // # Panics
-    //
-    // Panics if the buffer is not large enough: it must have length at least
-    // [`LENGTH`]. [`Uuid::encode_buffer`] can be used to get a
-    // sufficiently-large temporary buffer.
-    //
-    // [`LENGTH`]: #associatedconstant.LENGTH
-    // [`Uuid::encode_buffer`]: ../struct.Uuid.html#method.encode_buffer
-    //
-    // # Examples
-    //
-    // ```rust
-    // use uuid::Uuid;
-    //
-    // let uuid = Uuid::parse_str("936da01f9abd4d9d80c702af85c822a8").unwrap();
-    //
-    // // the encoded portion is returned
-    // assert_eq!(
-    //     uuid.to_simple().encode_upper(&mut Uuid::encode_buffer()),
-    //     "936DA01F9ABD4D9D80C702AF85C822A8"
-    // );
-    //
-    // // the buffer is mutated directly, and trailing contents remains
-    // let mut buf = [b'!'; 36];
-    // assert_eq!(
-    //     uuid.to_simple().encode_upper(&mut buf),
-    //     "936DA01F9ABD4D9D80C702AF85C822A8"
-    // );
-    // assert_eq!(
-    //     &buf as &[_],
-    //     b"936DA01F9ABD4D9D80C702AF85C822A8!!!!" as &[_]
-    // );
-    // ```
-    // */
-    pub(crate) fn encode_upper<'buf>(
+    /// Writes the [`Uuid`] as an upper-case simple string to `buffer`,
+    /// and returns the subslice of the buffer that contains the encoded UUID.
+    /// 
+    /// [`Uuid`]: ../struct.Uuid.html
+    /// 
+    /// # Panics
+    /// 
+    /// Panics if the buffer is not large enough: it must have length at least
+    /// [`LENGTH`]. [`Uuid::encode_buffer`] can be used to get a
+    /// sufficiently-large temporary buffer.
+    /// 
+    /// [`LENGTH`]: #associatedconstant.LENGTH
+    /// [`Uuid::encode_buffer`]: ../struct.Uuid.html#method.encode_buffer
+    /// 
+    /// # Examples
+    /// 
+    /// ```rust
+    /// use uuid::Uuid;
+    /// 
+    /// let uuid = Uuid::parse_str("936da01f9abd4d9d80c702af85c822a8").unwrap();
+    /// 
+    /// // the encoded portion is returned
+    /// assert_eq!(
+    ///     uuid.to_simple().encode_upper(&mut Uuid::encode_buffer()),
+    ///     "936DA01F9ABD4D9D80C702AF85C822A8"
+    /// );
+    /// 
+    /// // the buffer is mutated directly, and trailing contents remains
+    /// let mut buf = [b'!'; 36];
+    /// assert_eq!(
+    ///     uuid.to_simple().encode_upper(&mut buf),
+    ///     "936DA01F9ABD4D9D80C702AF85C822A8"
+    /// );
+    /// assert_eq!(
+    ///     &buf as &[_],
+    ///     b"936DA01F9ABD4D9D80C702AF85C822A8!!!!" as &[_]
+    /// );
+    /// ```
+    /// */
+    pub fn encode_upper<'buf>(
         &self,
         buffer: &'buf mut [u8],
     ) -> &'buf mut str {
@@ -775,52 +770,52 @@ impl Urn {
         Urn(uuid)
     }
 
-    // Writes the [`Uuid`] as a lower-case URN string to
-    // `buffer`, and returns the subslice of the buffer that contains the
-    // encoded UUID.
-    //
-    // This is slightly more efficient than using the formatting
-    // infrastructure as it avoids virtual calls, and may avoid
-    // double buffering.
-    //
-    // [`Uuid`]: ../struct.Uuid.html
-    //
-    // # Panics
-    //
-    // Panics if the buffer is not large enough: it must have length at least
-    // [`LENGTH`]. [`Uuid::encode_buffer`] can be used to get a
-    // sufficiently-large temporary buffer.
-    //
-    // [`LENGTH`]: #associatedconstant.LENGTH
-    // [`Uuid::encode_buffer`]: ../struct.Uuid.html#method.encode_buffer
-    //
-    // # Examples
-    //
-    // ```rust
-    // use uuid::Uuid;
-    //
-    // let uuid = Uuid::parse_str("936DA01f9abd4d9d80c702af85c822a8").unwrap();
-    //
-    // // the encoded portion is returned
-    // assert_eq!(
-    //     uuid.to_urn().encode_lower(&mut Uuid::encode_buffer()),
-    //     "urn:uuid:936da01f-9abd-4d9d-80c7-02af85c822a8"
-    // );
-    //
-    // // the buffer is mutated directly, and trailing contents remains
-    // let mut buf = [b'!'; 49];
-    // uuid.to_urn().encode_lower(&mut buf);
-    // assert_eq!(
-    //     uuid.to_urn().encode_lower(&mut buf),
-    //     "urn:uuid:936da01f-9abd-4d9d-80c7-02af85c822a8"
-    // );
-    // assert_eq!(
-    //     &buf as &[_],
-    //     b"urn:uuid:936da01f-9abd-4d9d-80c7-02af85c822a8!!!!" as &[_]
-    // );
-    // ```
-    // */
-    pub(crate) fn encode_lower<'buf>(
+    /// Writes the [`Uuid`] as a lower-case URN string to
+    /// `buffer`, and returns the subslice of the buffer that contains the
+    /// encoded UUID.
+    /// 
+    /// This is slightly more efficient than using the formatting
+    /// infrastructure as it avoids virtual calls, and may avoid
+    /// double buffering.
+    /// 
+    /// [`Uuid`]: ../struct.Uuid.html
+    /// 
+    /// # Panics
+    /// 
+    /// Panics if the buffer is not large enough: it must have length at least
+    /// [`LENGTH`]. [`Uuid::encode_buffer`] can be used to get a
+    /// sufficiently-large temporary buffer.
+    /// 
+    /// [`LENGTH`]: #associatedconstant.LENGTH
+    /// [`Uuid::encode_buffer`]: ../struct.Uuid.html#method.encode_buffer
+    /// 
+    /// # Examples
+    /// 
+    /// ```rust
+    /// use uuid::Uuid;
+    /// 
+    /// let uuid = Uuid::parse_str("936DA01f9abd4d9d80c702af85c822a8").unwrap();
+    /// 
+    /// // the encoded portion is returned
+    /// assert_eq!(
+    ///     uuid.to_urn().encode_lower(&mut Uuid::encode_buffer()),
+    ///     "urn:uuid:936da01f-9abd-4d9d-80c7-02af85c822a8"
+    /// );
+    /// 
+    /// // the buffer is mutated directly, and trailing contents remains
+    /// let mut buf = [b'!'; 49];
+    /// uuid.to_urn().encode_lower(&mut buf);
+    /// assert_eq!(
+    ///     uuid.to_urn().encode_lower(&mut buf),
+    ///     "urn:uuid:936da01f-9abd-4d9d-80c7-02af85c822a8"
+    /// );
+    /// assert_eq!(
+    ///     &buf as &[_],
+    ///     b"urn:uuid:936da01f-9abd-4d9d-80c7-02af85c822a8!!!!" as &[_]
+    /// );
+    /// ```
+    /// */
+    pub fn encode_lower<'buf>(
         &self,
         buffer: &'buf mut [u8],
     ) -> &'buf mut str {
@@ -828,51 +823,51 @@ impl Urn {
         encode(buffer, 9, &self.0, true, false)
     }
 
-    // Writes the [`Uuid`] as an upper-case URN string to
-    // `buffer`, and returns the subslice of the buffer that contains the
-    // encoded UUID.
-    //
-    // This is slightly more efficient than using the formatting
-    // infrastructure as it avoids virtual calls, and may avoid
-    // double buffering.
-    //
-    // [`Uuid`]: ../struct.Uuid.html
-    //
-    // # Panics
-    //
-    // Panics if the buffer is not large enough: it must have length at least
-    // [`LENGTH`]. [`Uuid::encode_buffer`] can be used to get a
-    // sufficiently-large temporary buffer.
-    //
-    // [`LENGTH`]: #associatedconstant.LENGTH
-    // [`Uuid::encode_buffer`]: ../struct.Uuid.html#method.encode_buffer
-    //
-    // # Examples
-    //
-    // ```rust
-    // use uuid::Uuid;
-    //
-    // let uuid = Uuid::parse_str("936da01f9abd4d9d80c702af85c822a8").unwrap();
-    //
-    // // the encoded portion is returned
-    // assert_eq!(
-    //     uuid.to_urn().encode_upper(&mut Uuid::encode_buffer()),
-    //     "urn:uuid:936DA01F-9ABD-4D9D-80C7-02AF85C822A8"
-    // );
-    //
-    // // the buffer is mutated directly, and trailing contents remains
-    // let mut buf = [b'!'; 49];
-    // assert_eq!(
-    //     uuid.to_urn().encode_upper(&mut buf),
-    //     "urn:uuid:936DA01F-9ABD-4D9D-80C7-02AF85C822A8"
-    // );
-    // assert_eq!(
-    //     &buf as &[_],
-    //     b"urn:uuid:936DA01F-9ABD-4D9D-80C7-02AF85C822A8!!!!" as &[_]
-    // );
-    // ```
-    // */
-    pub(crate) fn encode_upper<'buf>(
+    /// Writes the [`Uuid`] as an upper-case URN string to
+    /// `buffer`, and returns the subslice of the buffer that contains the
+    /// encoded UUID.
+    /// 
+    /// This is slightly more efficient than using the formatting
+    /// infrastructure as it avoids virtual calls, and may avoid
+    /// double buffering.
+    /// 
+    /// [`Uuid`]: ../struct.Uuid.html
+    /// 
+    /// # Panics
+    /// 
+    /// Panics if the buffer is not large enough: it must have length at least
+    /// [`LENGTH`]. [`Uuid::encode_buffer`] can be used to get a
+    /// sufficiently-large temporary buffer.
+    /// 
+    /// [`LENGTH`]: #associatedconstant.LENGTH
+    /// [`Uuid::encode_buffer`]: ../struct.Uuid.html#method.encode_buffer
+    /// 
+    /// # Examples
+    /// 
+    /// ```rust
+    /// use uuid::Uuid;
+    /// 
+    /// let uuid = Uuid::parse_str("936da01f9abd4d9d80c702af85c822a8").unwrap();
+    /// 
+    /// // the encoded portion is returned
+    /// assert_eq!(
+    ///     uuid.to_urn().encode_upper(&mut Uuid::encode_buffer()),
+    ///     "urn:uuid:936DA01F-9ABD-4D9D-80C7-02AF85C822A8"
+    /// );
+    /// 
+    /// // the buffer is mutated directly, and trailing contents remains
+    /// let mut buf = [b'!'; 49];
+    /// assert_eq!(
+    ///     uuid.to_urn().encode_upper(&mut buf),
+    ///     "urn:uuid:936DA01F-9ABD-4D9D-80C7-02AF85C822A8"
+    /// );
+    /// assert_eq!(
+    ///     &buf as &[_],
+    ///     b"urn:uuid:936DA01F-9ABD-4D9D-80C7-02AF85C822A8!!!!" as &[_]
+    /// );
+    /// ```
+    /// */
+    pub fn encode_upper<'buf>(
         &self,
         buffer: &'buf mut [u8],
     ) -> &'buf mut str {
@@ -905,52 +900,52 @@ impl<'a> UrnRef<'a> {
         UrnRef(&uuid)
     }
 
-    // Writes the [`Uuid`] as a lower-case URN string to
-    // `buffer`, and returns the subslice of the buffer that contains the
-    // encoded UUID.
-    //
-    // This is slightly more efficient than using the formatting
-    // infrastructure as it avoids virtual calls, and may avoid
-    // double buffering.
-    //
-    // [`Uuid`]: ../struct.Uuid.html
-    //
-    // # Panics
-    //
-    // Panics if the buffer is not large enough: it must have length at least
-    // [`LENGTH`]. [`Uuid::encode_buffer`] can be used to get a
-    // sufficiently-large temporary buffer.
-    //
-    // [`LENGTH`]: #associatedconstant.LENGTH
-    // [`Uuid::encode_buffer`]: ../struct.Uuid.html#method.encode_buffer
-    //
-    // # Examples
-    //
-    // ```rust
-    // use uuid::Uuid;
-    //
-    // let uuid = Uuid::parse_str("936DA01f9abd4d9d80c702af85c822a8").unwrap();
-    //
-    // // the encoded portion is returned
-    // assert_eq!(
-    //     uuid.to_urn().encode_lower(&mut Uuid::encode_buffer()),
-    //     "urn:uuid:936da01f-9abd-4d9d-80c7-02af85c822a8"
-    // );
-    //
-    // // the buffer is mutated directly, and trailing contents remains
-    // let mut buf = [b'!'; 49];
-    // uuid.to_urn().encode_lower(&mut buf);
-    // assert_eq!(
-    //     uuid.to_urn().encode_lower(&mut buf),
-    //     "urn:uuid:936da01f-9abd-4d9d-80c7-02af85c822a8"
-    // );
-    // assert_eq!(
-    //     &buf as &[_],
-    //     b"urn:uuid:936da01f-9abd-4d9d-80c7-02af85c822a8!!!!" as &[_]
-    // );
-    // ```
-    // */
-    pub(crate) fn encode_lower<'buf>(
+    /// Writes the [`Uuid`] as a lower-case URN string to
+    /// `buffer`, and returns the subslice of the buffer that contains the
+    /// encoded UUID.
+    /// 
+    /// This is slightly more efficient than using the formatting
+    /// infrastructure as it avoids virtual calls, and may avoid
+    /// double buffering.
+    /// 
+    /// [`Uuid`]: ../struct.Uuid.html
+    /// 
+    /// # Panics
+    /// 
+    /// Panics if the buffer is not large enough: it must have length at least
+    /// [`LENGTH`]. [`Uuid::encode_buffer`] can be used to get a
+    /// sufficiently-large temporary buffer.
+    /// 
+    /// [`LENGTH`]: #associatedconstant.LENGTH
+    /// [`Uuid::encode_buffer`]: ../struct.Uuid.html#method.encode_buffer
+    /// 
+    /// # Examples
+    /// 
+    /// ```rust
+    /// use uuid::Uuid;
+    /// 
+    /// let uuid = Uuid::parse_str("936DA01f9abd4d9d80c702af85c822a8").unwrap();
+    /// 
+    /// // the encoded portion is returned
+    /// assert_eq!(
+    ///     uuid.to_urn().encode_lower(&mut Uuid::encode_buffer()),
+    ///     "urn:uuid:936da01f-9abd-4d9d-80c7-02af85c822a8"
+    /// );
+    /// 
+    /// // the buffer is mutated directly, and trailing contents remains
+    /// let mut buf = [b'!'; 49];
+    /// uuid.to_urn().encode_lower(&mut buf);
+    /// assert_eq!(
+    ///     uuid.to_urn().encode_lower(&mut buf),
+    ///     "urn:uuid:936da01f-9abd-4d9d-80c7-02af85c822a8"
+    /// );
+    /// assert_eq!(
+    ///     &buf as &[_],
+    ///     b"urn:uuid:936da01f-9abd-4d9d-80c7-02af85c822a8!!!!" as &[_]
+    /// );
+    /// ```
+    /// */
+    pub fn encode_lower<'buf>(
         &self,
         buffer: &'buf mut [u8],
     ) -> &'buf mut str {
@@ -958,51 +953,51 @@ impl<'a> UrnRef<'a> {
         encode(buffer, 9, self.0, true, false)
     }
 
-    // Writes the [`Uuid`] as an upper-case URN string to
-    // `buffer`, and returns the subslice of the buffer that contains the
-    // encoded UUID.
-    //
-    // This is slightly more efficient than using the formatting
-    // infrastructure as it avoids virtual calls, and may avoid
-    // double buffering.
-    //
-    // [`Uuid`]: ../struct.Uuid.html
-    //
-    // # Panics
-    //
-    // Panics if the buffer is not large enough: it must have length at least
-    // [`LENGTH`]. [`Uuid::encode_buffer`] can be used to get a
-    // sufficiently-large temporary buffer.
-    //
-    // [`LENGTH`]: #associatedconstant.LENGTH
-    // [`Uuid::encode_buffer`]: ../struct.Uuid.html#method.encode_buffer
-    //
-    // # Examples
-    //
-    // ```rust
-    // use uuid::Uuid;
-    //
-    // let uuid = Uuid::parse_str("936da01f9abd4d9d80c702af85c822a8").unwrap();
-    //
-    // // the encoded portion is returned
-    // assert_eq!(
-    //     uuid.to_urn().encode_upper(&mut Uuid::encode_buffer()),
-    //     "urn:uuid:936DA01F-9ABD-4D9D-80C7-02AF85C822A8"
-    // );
-    //
-    // // the buffer is mutated directly, and trailing contents remains
-    // let mut buf = [b'!'; 49];
-    // assert_eq!(
-    //     uuid.to_urn().encode_upper(&mut buf),
-    //     "urn:uuid:936DA01F-9ABD-4D9D-80C7-02AF85C822A8"
-    // );
-    // assert_eq!(
-    //     &buf as &[_],
-    //     b"urn:uuid:936DA01F-9ABD-4D9D-80C7-02AF85C822A8!!!!" as &[_]
-    // );
-    // ```
-    // */
-    pub(crate) fn encode_upper<'buf>(
+    /// Writes the [`Uuid`] as an upper-case URN string to
+    /// `buffer`, and returns the subslice of the buffer that contains the
+    /// encoded UUID.
+    /// 
+    /// This is slightly more efficient than using the formatting
+    /// infrastructure as it avoids virtual calls, and may avoid
+    /// double buffering.
+    /// 
+    /// [`Uuid`]: ../struct.Uuid.html
+    /// 
+    /// # Panics
+    /// 
+    /// Panics if the buffer is not large enough: it must have length at least
+    /// [`LENGTH`]. [`Uuid::encode_buffer`] can be used to get a
+    /// sufficiently-large temporary buffer.
+    /// 
+    /// [`LENGTH`]: #associatedconstant.LENGTH
+    /// [`Uuid::encode_buffer`]: ../struct.Uuid.html#method.encode_buffer
+    /// 
+    /// # Examples
+    /// 
+    /// ```rust
+    /// use uuid::Uuid;
+    /// 
+    /// let uuid = Uuid::parse_str("936da01f9abd4d9d80c702af85c822a8").unwrap();
+    /// 
+    /// // the encoded portion is returned
+    /// assert_eq!(
+    ///     uuid.to_urn().encode_upper(&mut Uuid::encode_buffer()),
+    ///     "urn:uuid:936DA01F-9ABD-4D9D-80C7-02AF85C822A8"
+    /// );
+    /// 
+    /// // the buffer is mutated directly, and trailing contents remains
+    /// let mut buf = [b'!'; 49];
+    /// assert_eq!(
+    ///     uuid.to_urn().encode_upper(&mut buf),
+    ///     "urn:uuid:936DA01F-9ABD-4D9D-80C7-02AF85C822A8"
+    /// );
+    /// assert_eq!(
+    ///     &buf as &[_],
+    ///     b"urn:uuid:936DA01F-9ABD-4D9D-80C7-02AF85C822A8!!!!" as &[_]
+    /// );
+    /// ```
+    /// */
+    pub fn encode_upper<'buf>(
         &self,
         buffer: &'buf mut [u8],
     ) -> &'buf mut str {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -995,34 +995,34 @@ impl Uuid {
     pub fn is_nil(&self) -> bool {
         self.as_bytes().iter().all(|&b| b == 0)
     }
-    // A buffer that can be used for `encode_...` calls, that is
-    // guaranteed to be long enough for any of the adapters.
-    //
-    // # Examples
-    //
-    // ```rust
-    // use uuid::Uuid;
-    //
-    // let uuid = Uuid::nil();
-    //
-    // assert_eq!(
-    //     uuid.to_simple().encode_lower(&mut Uuid::encode_buffer()),
-    //     "00000000000000000000000000000000"
-    // );
-    //
-    // assert_eq!(
-    //     uuid.to_hyphenated()
-    //         .encode_lower(&mut Uuid::encode_buffer()),
-    //     "00000000-0000-0000-0000-000000000000"
-    // );
-    //
-    // assert_eq!(
-    //     uuid.to_urn().encode_lower(&mut Uuid::encode_buffer()),
-    //     "urn:uuid:00000000-0000-0000-0000-000000000000"
-    // );
-    // ```
-    #[allow(dead_code)]
-    pub(crate) fn encode_buffer() -> [u8; adapter::Urn::LENGTH] {
+
+    /// A buffer that can be used for `encode_...` calls, that is
+    /// guaranteed to be long enough for any of the adapters.
+    ///
+    /// # Examples
+    ///
+    /// ```rust
+    /// use uuid::Uuid;
+    ///
+    /// let uuid = Uuid::nil();
+    ///
+    /// assert_eq!(
+    ///     uuid.to_simple().encode_lower(&mut Uuid::encode_buffer()),
+    ///     "00000000000000000000000000000000"
+    /// );
+    ///
+    /// assert_eq!(
+    ///     uuid.to_hyphenated()
+    ///         .encode_lower(&mut Uuid::encode_buffer()),
+    ///     "00000000-0000-0000-0000-000000000000"
+    /// );
+    ///
+    /// assert_eq!(
+    ///     uuid.to_urn().encode_lower(&mut Uuid::encode_buffer()),
+    ///     "urn:uuid:00000000-0000-0000-0000-000000000000"
+    /// );
+    /// ```
+    pub fn encode_buffer() -> [u8; adapter::Urn::LENGTH] {
         [0; adapter::Urn::LENGTH]
     }
 }


### PR DESCRIPTION
**I'm submitting a(n)** bug fix

# Description
Make optimized versions of encode* functions available.

# Motivation
Previously made crate public, allow faster than rust fmt conversion.

# Tests
Bench tests show improvement. See #343 

# Related Issue(s)
closes #343 