### PR TITLE
fix a tiny mistake in the README generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,8 @@ Examples of string representations:
 
 [`wasm-bindgen`]: https://github.com/rustwasm/wasm-bindgen
 
+[`Uuid`]: https://docs.rs/uuid/0.7.2/uuid/struct.Uuid.html
+
 ---
 # License
 

--- a/README.tpl
+++ b/README.tpl
@@ -10,6 +10,8 @@
 
 {{readme}}
 
+[`Uuid`]: https://docs.rs/uuid/{{version}}/uuid/struct.Uuid.html
+
 ---
 # License
 


### PR DESCRIPTION
**I'm submitting a(n)** other

# Description
The way the generation will work is that it will use the link according to local Cargo.toml uuid version. So hopefully it will always use the reference to the docs.rs uuid

# Motivation
The Uuid struct wasn't being linked.
