### PR TITLE
enable adapter tests for encode_{lower, upper}

### DIFF
--- a/src/adapter/mod.rs
+++ b/src/adapter/mod.rs
@@ -844,85 +844,88 @@ impl<'a> UrnRef<'a> {
     }
 }
 
-// TODO: uncomment when we undo the pub(crate) change
-// #[cfg(test)]
-// mod tests {
-// use Uuid;
-//
-// #[test]
-// fn hyphenated_trailing() {
-// let mut buf = [b'x'; 100];
-// let len = Uuid::nil().to_hyphenated().encode_lower(&mut buf).len();
-// assert_eq!(len, super::Hyphenated::LENGTH);
-// assert!(buf[len..].iter().all(|x| *x == b'x'));
-// }
-// #[test]
-// fn hyphenated_ref_trailing() {
-// let mut buf = [b'x'; 100];
-// let len = Uuid::nil().to_hyphenated().encode_lower(&mut buf).len();
-// assert_eq!(len, super::HyphenatedRef::LENGTH);
-// assert!(buf[len..].iter().all(|x| *x == b'x'));
-// }
-//
-// #[test]
-// fn simple_trailing() {
-// let mut buf = [b'x'; 100];
-// let len = Uuid::nil().to_simple().encode_lower(&mut buf).len();
-// assert_eq!(len, super::Simple::LENGTH);
-// assert!(buf[len..].iter().all(|x| *x == b'x'));
-// }
-// #[test]
-// fn simple_ref_trailing() {
-// let mut buf = [b'x'; 100];
-// let len = Uuid::nil().to_simple().encode_lower(&mut buf).len();
-// assert_eq!(len, super::SimpleRef::LENGTH);
-// assert!(buf[len..].iter().all(|x| *x == b'x'));
-// }
-//
-// #[test]
-// fn urn_trailing() {
-// let mut buf = [b'x'; 100];
-// let len = Uuid::nil().to_urn().encode_lower(&mut buf).len();
-// assert_eq!(len, super::Urn::LENGTH);
-// assert!(buf[len..].iter().all(|x| *x == b'x'));
-// }
-// #[test]
-// fn urn_ref_trailing() {
-// let mut buf = [b'x'; 100];
-// let len = Uuid::nil().to_urn().encode_lower(&mut buf).len();
-// assert_eq!(len, super::UrnRef::LENGTH);
-// assert!(buf[len..].iter().all(|x| *x == b'x'));
-// }
-//
-// #[test]
-// #[should_panic]
-// fn hyphenated_too_small() {
-// Uuid::nil().to_hyphenated().encode_lower(&mut [0; 35]);
-// }
-// #[test]
-// #[should_panic]
-// fn hyphenated_ref_too_small() {
-// Uuid::nil().to_hyphenated_ref().encode_lower(&mut [0; 35]);
-// }
-//
-// #[test]
-// #[should_panic]
-// fn simple_too_small() {
-// Uuid::nil().to_simple().encode_lower(&mut [0; 31]);
-// }
-// #[test]
-// #[should_panic]
-// fn simple_ref_too_small() {
-// Uuid::nil().to_simple_ref().encode_lower(&mut [0; 31]);
-// }
-// #[test]
-// #[should_panic]
-// fn urn_too_small() {
-// Uuid::nil().to_urn().encode_lower(&mut [0; 44]);
-// }
-// #[test]
-// #[should_panic]
-// fn urn_ref_too_small() {
-// Uuid::nil().to_urn_ref().encode_lower(&mut [0; 44]);
-// }
-// }
+#[cfg(test)]
+mod tests {
+    use crate::prelude::*;
+
+    #[test]
+    fn hyphenated_trailing() {
+        let mut buf = [b'x'; 100];
+        let len = Uuid::nil().to_hyphenated().encode_lower(&mut buf).len();
+        assert_eq!(len, super::Hyphenated::LENGTH);
+        assert!(buf[len..].iter().all(|x| *x == b'x'));
+    }
+    
+    #[test]
+    fn hyphenated_ref_trailing() {
+        let mut buf = [b'x'; 100];
+        let len = Uuid::nil().to_hyphenated().encode_lower(&mut buf).len();
+        assert_eq!(len, super::HyphenatedRef::LENGTH);
+        assert!(buf[len..].iter().all(|x| *x == b'x'));
+    }
+
+    #[test]
+    fn simple_trailing() {
+        let mut buf = [b'x'; 100];
+        let len = Uuid::nil().to_simple().encode_lower(&mut buf).len();
+        assert_eq!(len, super::Simple::LENGTH);
+        assert!(buf[len..].iter().all(|x| *x == b'x'));
+    }
+    
+    #[test]
+    fn simple_ref_trailing() {
+        let mut buf = [b'x'; 100];
+        let len = Uuid::nil().to_simple().encode_lower(&mut buf).len();
+        assert_eq!(len, super::SimpleRef::LENGTH);
+        assert!(buf[len..].iter().all(|x| *x == b'x'));
+    }
+
+    #[test]
+    fn urn_trailing() {
+        let mut buf = [b'x'; 100];
+        let len = Uuid::nil().to_urn().encode_lower(&mut buf).len();
+        assert_eq!(len, super::Urn::LENGTH);
+        assert!(buf[len..].iter().all(|x| *x == b'x'));
+    }
+
+    #[test]
+    fn urn_ref_trailing() {
+        let mut buf = [b'x'; 100];
+        let len = Uuid::nil().to_urn().encode_lower(&mut buf).len();
+        assert_eq!(len, super::UrnRef::LENGTH);
+        assert!(buf[len..].iter().all(|x| *x == b'x'));
+    }
+
+    #[test]
+    #[should_panic]
+    fn hyphenated_too_small() {
+        Uuid::nil().to_hyphenated().encode_lower(&mut [0; 35]);
+    }
+
+    #[test]
+    #[should_panic]
+    fn hyphenated_ref_too_small() {
+        Uuid::nil().to_hyphenated_ref().encode_lower(&mut [0; 35]);
+    }
+
+    #[test]
+    #[should_panic]
+    fn simple_too_small() {
+        Uuid::nil().to_simple().encode_lower(&mut [0; 31]);
+    }
+    #[test]
+    #[should_panic]
+    fn simple_ref_too_small() {
+        Uuid::nil().to_simple_ref().encode_lower(&mut [0; 31]);
+    }
+    #[test]
+    #[should_panic]
+    fn urn_too_small() {
+        Uuid::nil().to_urn().encode_lower(&mut [0; 44]);
+    }
+    #[test]
+    #[should_panic]
+    fn urn_ref_too_small() {
+        Uuid::nil().to_urn_ref().encode_lower(&mut [0; 44]);
+    }
+}

--- a/src/adapter/mod.rs
+++ b/src/adapter/mod.rs
@@ -855,7 +855,7 @@ mod tests {
         assert_eq!(len, super::Hyphenated::LENGTH);
         assert!(buf[len..].iter().all(|x| *x == b'x'));
     }
-    
+
     #[test]
     fn hyphenated_ref_trailing() {
         let mut buf = [b'x'; 100];
@@ -871,7 +871,7 @@ mod tests {
         assert_eq!(len, super::Simple::LENGTH);
         assert!(buf[len..].iter().all(|x| *x == b'x'));
     }
-    
+
     #[test]
     fn simple_ref_trailing() {
         let mut buf = [b'x'; 100];

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -938,7 +938,7 @@ impl Uuid {
 
 #[cfg(test)]
 mod tests {
-    pub use std;
+    extern crate std;
 
     use super::test_util;
     use crate::prelude::*;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -938,7 +938,7 @@ impl Uuid {
 
 #[cfg(test)]
 mod tests {
-    pub extern crate std;
+    pub use std;
 
     use super::test_util;
     use crate::prelude::*;


### PR DESCRIPTION
**I'm submitting a(n)** other

# Description
`encode_{lower, upper}` tests were not enabled when we enabled the functions.

# Motivation
More tests

# Tests
New tests enabled

# Related Issue(s)
