### PR TITLE
remove the u128 feature

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,7 +34,7 @@ matrix:
     - rustup component add clippy-preview
     - rustup target add wasm32-unknown-unknown
     script:
-    - cargo clippy --features "u128 v1 v3 v4 v5 slog"
+    - cargo clippy --features "v1 v3 v4 v5 slog"
     - cargo build --target wasm32-unknown-unknown --features "v3 wasm-bindgen"
     - cargo build --target wasm32-unknown-unknown --features "v4 wasm-bindgen"
     - cargo build --target wasm32-unknown-unknown --features "v5 wasm-bindgen"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -46,7 +46,6 @@ repository = "uuid-rs/uuid"
 [dependencies.byteorder]
 default-features = false
 features = ["i128"]
-optional = true
 version = "1"
 
 [dependencies.md5]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,7 +26,7 @@ features = [ "guid", "serde", "slog", "v1", "v3", "v4", "v5" ]
 default-target = "x86_64-pc-windows-msvc"
 
 [package.metadata.playground]
-features = ["serde", "u128", "v1", "v3", "v4", "v5"]
+features = ["serde", "v1", "v3", "v4", "v5"]
 
 [badges.appveyor]
 repository = "uuid-rs/uuid"
@@ -93,9 +93,6 @@ v3 = ["md5"]
 v4 = ["rand"]
 v5 = ["sha1"]
 wasm-bindgen = ["rand/wasm-bindgen"]
-
-# since rust 1.26.0
-u128 = ["byteorder"]
 
 [target.'cfg(windows)'.dependencies.winapi]
 optional = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -145,7 +145,6 @@ mod slog_support;
 mod std_support;
 #[cfg(test)]
 mod test_util;
-#[cfg(feature = "u128")]
 mod u128_support;
 #[cfg(all(
     feature = "v3",


### PR DESCRIPTION
**I'm submitting a(n)** refactor|removal

# Description
Removes the `u128` feature. `u128` related API is available as is now. Did not 

# Motivation
`2018` edition now supports `u128`s out of the box

# Tests
Current tests should pass. No need for new tests

# Related Issue(s)
closes #366 
