### PR TITLE
Make functions that can be const, const

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -71,7 +71,7 @@ impl Builder {
     ///
     /// let uuid = Builder::from_bytes(bytes);
     /// ```
-    pub fn from_bytes(b: Bytes) -> Self {
+    pub const fn from_bytes(b: Bytes) -> Self {
         Builder(crate::Uuid::from_bytes(b))
     }
 
@@ -186,7 +186,7 @@ impl Builder {
     ///     "00000000-0000-0000-0000-000000000000"
     /// );
     /// ```
-    pub fn nil() -> Self {
+    pub const fn nil() -> Self {
         Builder(crate::Uuid::nil())
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -115,7 +115,6 @@
 //! [`wasm-bindgen`]: https://github.com/rustwasm/wasm-bindgen
 
 #![cfg_attr(not(feature = "std"), no_std)]
-#![cfg_attr(feature = "const_fn", feature(const_fn))]
 #![deny(
     missing_copy_implementations,
     missing_debug_implementations,
@@ -603,7 +602,7 @@ impl Uuid {
     /// details.
     ///
     /// * [Version Reference](http://tools.ietf.org/html/rfc4122#section-4.1.3)
-    pub fn get_version_num(&self) -> usize {
+    pub const fn get_version_num(&self) -> usize {
         (self.as_bytes()[6] >> 4) as usize
     }
 
@@ -930,7 +929,7 @@ impl Uuid {
     ///     "urn:uuid:00000000-0000-0000-0000-000000000000"
     /// );
     /// ```
-    pub fn encode_buffer() -> [u8; adapter::Urn::LENGTH] {
+    pub const fn encode_buffer() -> [u8; adapter::Urn::LENGTH] {
         [0; adapter::Urn::LENGTH]
     }
 }

--- a/src/v1.rs
+++ b/src/v1.rs
@@ -139,7 +139,7 @@ impl Context {
     /// process.
     ///
     /// [`Uuid`]: ../struct.Uuid.html
-    pub fn new(count: u16) -> Self {
+    pub const fn new(count: u16) -> Self {
         Self {
             count: atomic::AtomicUsize::new(count as usize),
         }


### PR DESCRIPTION
**I'm submitting a(n)** feature|refactor

# Description

Add `const fn` in a few more places than #389. Used `clippy` and its nursery lint to detect them.

# Motivation

More `const fn` the better. 

# Tests

Current tests should pass. No new tests added

# Related Issue(s)
