### PR TITLE
Implementing adapter traits using macro

### DIFF
--- a/src/adapter/core_support/mod.rs
+++ b/src/adapter/core_support/mod.rs
@@ -12,164 +12,57 @@
 use crate::prelude::*;
 use core::fmt;
 
-impl fmt::Display for super::Hyphenated {
-    #[inline]
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::LowerHex::fmt(self, f)
-    }
+macro_rules! impl_adapter_traits {
+    ($($T:ident<$($a:lifetime),*>),+) => {$(
+        impl<$($a),*> fmt::Display for super::$T<$($a),*> {
+            #[inline]
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                fmt::LowerHex::fmt(self, f)
+            }
+        }
+
+        impl<$($a),*> fmt::LowerHex for super::$T<$($a),*> {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                // TODO: Self doesn't work https://github.com/rust-lang/rust/issues/52808
+                f.write_str(self.encode_lower(&mut [0; super::$T::LENGTH]))
+            }
+        }
+
+        impl<$($a),*> fmt::UpperHex for super::$T<$($a),*> {
+            fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+                // TODO: Self doesn't work https://github.com/rust-lang/rust/issues/52808
+                f.write_str(self.encode_upper(&mut [0; super::$T::LENGTH]))
+            }
+        }
+
+        impl_adapter_from!($T<$($a),*>);
+    )+}
 }
 
-impl<'a> fmt::Display for super::HyphenatedRef<'a> {
-    #[inline]
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::LowerHex::fmt(self, f)
-    }
+macro_rules! impl_adapter_from {
+    ($T:ident<>) => {
+        impl From<Uuid> for super::$T {
+            #[inline]
+            fn from(f: Uuid) -> Self {
+                super::$T::from_uuid(f)
+            }
+        }
+    };
+    ($T:ident<$a:lifetime>) => {
+        impl<$a> From<&$a Uuid> for super::$T<$a> {
+            #[inline]
+            fn from(f: &$a Uuid) -> Self {
+                super::$T::from_uuid_ref(f)
+            }
+        }
+    };
 }
 
-impl fmt::Display for super::Simple {
-    #[inline]
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::LowerHex::fmt(self, f)
-    }
-}
-
-impl<'a> fmt::Display for super::SimpleRef<'a> {
-    #[inline]
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::LowerHex::fmt(self, f)
-    }
-}
-
-impl fmt::Display for super::Urn {
-    #[inline]
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::LowerHex::fmt(self, f)
-    }
-}
-
-impl<'a> fmt::Display for super::UrnRef<'a> {
-    #[inline]
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        fmt::LowerHex::fmt(self, f)
-    }
-}
-
-impl fmt::LowerHex for super::Hyphenated {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(self.encode_lower(&mut [0; Self::LENGTH]))
-    }
-}
-
-impl<'a> fmt::LowerHex for super::HyphenatedRef<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // TODO: Self doesn't work https://github.com/rust-lang/rust/issues/52808
-        f.write_str(self.encode_lower(&mut [0; super::HyphenatedRef::LENGTH]))
-    }
-}
-
-impl fmt::LowerHex for super::Simple {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(self.encode_lower(&mut [0; Self::LENGTH]))
-    }
-}
-
-impl<'a> fmt::LowerHex for super::SimpleRef<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // TODO: Self doesn't work https://github.com/rust-lang/rust/issues/52808
-        f.write_str(self.encode_lower(&mut [0; super::SimpleRef::LENGTH]))
-    }
-}
-
-impl fmt::LowerHex for super::Urn {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(self.encode_lower(&mut [0; Self::LENGTH]))
-    }
-}
-
-impl<'a> fmt::LowerHex for super::UrnRef<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // TODO: Self doesn't work https://github.com/rust-lang/rust/issues/52808
-        f.write_str(self.encode_lower(&mut [0; super::UrnRef::LENGTH]))
-    }
-}
-
-impl fmt::UpperHex for super::Hyphenated {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(self.encode_upper(&mut [0; Self::LENGTH]))
-    }
-}
-
-impl<'a> fmt::UpperHex for super::HyphenatedRef<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // TODO: Self doesn't work https://github.com/rust-lang/rust/issues/52808
-        f.write_str(self.encode_upper(&mut [0; super::HyphenatedRef::LENGTH]))
-    }
-}
-
-impl fmt::UpperHex for super::Simple {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(self.encode_upper(&mut [0; Self::LENGTH]))
-    }
-}
-
-impl<'a> fmt::UpperHex for super::SimpleRef<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // TODO: Self doesn't work https://github.com/rust-lang/rust/issues/52808
-        f.write_str(self.encode_upper(&mut [0; super::SimpleRef::LENGTH]))
-    }
-}
-
-impl fmt::UpperHex for super::Urn {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        f.write_str(self.encode_upper(&mut [0; Self::LENGTH]))
-    }
-}
-
-impl<'a> fmt::UpperHex for super::UrnRef<'a> {
-    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        // TODO: Self doesn't work https://github.com/rust-lang/rust/issues/52808
-        f.write_str(self.encode_upper(&mut [0; super::UrnRef::LENGTH]))
-    }
-}
-
-impl From<Uuid> for super::Hyphenated {
-    #[inline]
-    fn from(f: Uuid) -> Self {
-        super::Hyphenated::from_uuid(f)
-    }
-}
-
-impl<'a> From<&'a Uuid> for super::HyphenatedRef<'a> {
-    #[inline]
-    fn from(f: &'a Uuid) -> Self {
-        super::HyphenatedRef::from_uuid_ref(f)
-    }
-}
-
-impl From<Uuid> for super::Simple {
-    #[inline]
-    fn from(f: Uuid) -> Self {
-        super::Simple::from_uuid(f)
-    }
-}
-
-impl<'a> From<&'a Uuid> for super::SimpleRef<'a> {
-    #[inline]
-    fn from(f: &'a Uuid) -> Self {
-        super::SimpleRef::from_uuid_ref(f)
-    }
-}
-
-impl From<Uuid> for super::Urn {
-    #[inline]
-    fn from(f: Uuid) -> Self {
-        super::Urn::from_uuid(f)
-    }
-}
-
-impl<'a> From<&'a Uuid> for super::UrnRef<'a> {
-    #[inline]
-    fn from(f: &'a Uuid) -> Self {
-        super::UrnRef::from_uuid_ref(f)
-    }
+impl_adapter_traits! {
+    Hyphenated<>,
+    HyphenatedRef<'a>,
+    Simple<>,
+    SimpleRef<'a>,
+    Urn<>,
+    UrnRef<'a>
 }


### PR DESCRIPTION
I'm submitting a refactor of trait implementations for adapter traits


# Description
As all the trait implementations are the same across all adapters, they can be implemented using a single macro.

# Motivation
Reducing code duplication and improving transparency of intent.

# Tests
As there are no code changes, this change is covered by existing tests