### PR TITLE
adjust ParseError for indicating if an urn format was expected

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -842,6 +842,7 @@ impl Uuid {
                             expected: "0123456789abcdefABCDEF-",
                             found: input[i_char..].chars().next().unwrap(),
                             index: i_char,
+                            urn: parser::UrnPrefix::Optional,
                         });
                     }
                 }
@@ -876,6 +877,7 @@ impl Uuid {
                             expected: "0123456789abcdefABCDEF-",
                             found: input[i_char..].chars().next().unwrap(),
                             index: i_char,
+                            urn: parser::UrnPrefix::Optional,
                         });
                     }
                 }
@@ -1067,6 +1069,7 @@ mod tests {
                 expected: EXPECTED_CHARS,
                 found: 'G',
                 index: 20,
+                urn: parser::UrnPrefix::Optional,
             })
         );
 
@@ -1108,6 +1111,7 @@ mod tests {
                 expected: EXPECTED_CHARS,
                 found: 'X',
                 index: 18,
+                urn: parser::UrnPrefix::Optional,
             })
         );
 
@@ -1160,6 +1164,7 @@ mod tests {
                 expected: EXPECTED_CHARS,
                 found: '%',
                 index: 15,
+                urn: parser::UrnPrefix::Optional,
             })
         );
 
@@ -1213,6 +1218,7 @@ mod tests {
                 expected: EXPECTED_CHARS,
                 found: 'X',
                 index: 6,
+                urn: parser::UrnPrefix::Optional,
             })
         );
         assert_eq!(

--- a/src/parser/core_support.rs
+++ b/src/parser/core_support.rs
@@ -39,8 +39,23 @@ impl fmt::Display for parser::ParseError {
                 expected,
                 found,
                 index,
+                urn,
             } => {
-                write!(f, "expected {}, found {} at {}", expected, found, index)
+                let urn_str = match urn {
+                    parser::UrnPrefix::None => "",
+                    parser::UrnPrefix::Optional => {
+                        " an optional prefix of `urn:uuid:` followed by"
+                    }
+                    parser::UrnPrefix::Required => {
+                        " a prefix of `urn:uuid` followed by"
+                    }
+                };
+
+                write!(
+                    f,
+                    "expected{} {}, found {} at {}",
+                    urn_str, expected, found, index
+                )
             }
             parser::ParseError::InvalidGroupCount {
                 ref expected,

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -33,6 +33,17 @@ pub enum Expected {
     },
 }
 
+/// Urn prefix value.
+#[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub enum UrnPrefix {
+    /// No `urn:uuid:` prefix should be provided.
+    None,
+    /// The `urn:uuid:` prefix should optionally provided.
+    Optional,
+    /// The `urn:uuid:` prefix is required.
+    Required,
+}
+
 /// An error that can occur while parsing a [`Uuid`] string.
 ///
 /// [`Uuid`]: ../struct.Uuid.html
@@ -48,6 +59,12 @@ pub enum ParseError {
         found: char,
         /// The invalid character position.
         index: usize,
+        /// Indicates the [`Uuid`] starts with `urn:uuid:`.
+        ///
+        /// This is a special case for [`Urn`] adapter parsing.
+        ///
+        /// [`Uuid`]: ../Uuid.html
+        urn: UrnPrefix,
     },
     /// Invalid number of segments in the [`Uuid`] string.
     ///


### PR DESCRIPTION
**I'm submitting a(n)** refactor

# Description
Allows for future parsing ability for the adapters.

# Motivation
This was a breaking change as such was needed to be added in 0.8.0`

# Tests
Current tests should pass. No new tests introduced.

# Related Issue(s)
closes #370 
