### PR TITLE
remove Uuid::from_random_bytes

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -527,38 +527,6 @@ impl Uuid {
         Uuid(bytes)
     }
 
-    /// Creates a v4 Uuid from random bytes (e.g. bytes supplied from `Rand`
-    /// crate)
-    ///
-    /// # Examples
-    ///
-    /// Basic usage:
-    ///
-    /// ```
-    /// use uuid::Bytes;
-    /// use uuid::Uuid;
-    ///
-    /// let bytes: Bytes = [
-    ///     70, 235, 208, 238, 14, 109, 67, 201, 185, 13, 204, 195, 90, 145, 63, 62,
-    /// ];
-    /// let uuid = Uuid::from_random_bytes(bytes);
-    /// let uuid = uuid.to_hyphenated().to_string();
-    ///
-    /// let expected_uuid = String::from("46ebd0ee-0e6d-43c9-b90d-ccc35a913f3e");
-    ///
-    /// assert_eq!(expected_uuid, uuid);
-    /// ```
-    #[deprecated(
-        since = "0.7.2",
-        note = "please use the `uuid::Builder` instead to set the variant and version"
-    )]
-    pub fn from_random_bytes(bytes: Bytes) -> Uuid {
-        let mut uuid = Uuid::from_bytes(bytes);
-        uuid.set_variant(Variant::RFC4122);
-        uuid.set_version(Version::Random);
-        uuid
-    }
-
     /// Specifies the variant of the UUID structure
     fn set_variant(&mut self, v: Variant) {
         // Octet 8 contains the variant in the most significant 3 bits
@@ -1459,20 +1427,6 @@ mod tests {
         let b_out = u.as_bytes();
 
         assert_eq!(&b_in, b_out);
-    }
-
-    #[test]
-    #[allow(deprecated)]
-    fn test_from_random_bytes() {
-        let b = [
-            0xa1, 0xa2, 0xa3, 0xa4, 0xb1, 0xb2, 0xc1, 0xc2, 0xd1, 0xd2, 0xd3,
-            0xd4, 0xd5, 0xd6, 0xd7, 0xd8,
-        ];
-
-        let u = Uuid::from_random_bytes(b);
-        let expected = "a1a2a3a4b1b241c291d2d3d4d5d6d7d8";
-
-        assert_eq!(u.to_simple().to_string(), expected);
     }
 
     #[test]


### PR DESCRIPTION
**I'm submitting a(n)** removal

# Description
Removed `Uuid::from_random_bytes(crate::Bytes) -> Self`

# Motivation
`Uuid::from_random_bytes` was already deprecated. Time to remove.

# Tests
All tests should pass. A test regarding the `Uuid::from_random_bytes` was removed.

# Related Issue(s)
N/A