### PR TITLE
Remove the set_version and set_variant methods

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -169,7 +169,7 @@ impl Builder {
         d4: &[u8],
     ) -> Result<Self, crate::BytesError> {
         crate::Uuid::from_fields(d1, d2, d3, d4).map(|uuid| {
-            let bytes = uuid.as_bytes().to_owned();
+            let bytes = *uuid.as_bytes();
 
             Builder::from_bytes(bytes)
         })

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -36,7 +36,7 @@ use crate::prelude::*;
 /// ```
 #[allow(missing_copy_implementations)]
 #[derive(Debug)]
-pub struct Builder(crate::Uuid);
+pub struct Builder(crate::Bytes);
 
 impl Builder {
     /// Creates a `Builder` using the supplied big-endian bytes.
@@ -72,7 +72,7 @@ impl Builder {
     /// let uuid = Builder::from_bytes(bytes);
     /// ```
     pub const fn from_bytes(b: Bytes) -> Self {
-        Builder(crate::Uuid::from_bytes(b))
+        Builder(b)
     }
 
     /// Creates a `Builder` using the supplied big-endian bytes.
@@ -168,7 +168,11 @@ impl Builder {
         d3: u16,
         d4: &[u8],
     ) -> Result<Self, crate::BytesError> {
-        crate::Uuid::from_fields(d1, d2, d3, d4).map(Builder)
+        crate::Uuid::from_fields(d1, d2, d3, d4).map(|uuid| {
+            let bytes = uuid.as_bytes().to_owned();
+
+            Builder::from_bytes(bytes)
+        })
     }
 
     /// Creates a `Builder` with an initial [`Uuid::nil`]
@@ -187,18 +191,27 @@ impl Builder {
     /// );
     /// ```
     pub const fn nil() -> Self {
-        Builder(crate::Uuid::nil())
+        Builder(crate::Bytes::default())
     }
 
     /// Specifies the variant of the internal [`Uuid`].
     pub fn set_variant(&mut self, v: crate::Variant) -> &mut Self {
-        self.0.set_variant(v);
+        let byte = self.0[8];
+
+        self.0[8] = match v {
+            crate::Variant::NCS => byte & 0x7f,
+            crate::Variant::RFC4122 => (byte & 0x3f) | 0x80,
+            crate::Variant::Microsoft => (byte & 0x1f) | 0xc0,
+            crate::Variant::Future => (byte & 0x1f) | 0xe0,
+        };
+
         self
     }
 
     /// Specifies the version number of the internal [`Uuid`].
     pub fn set_version(&mut self, v: crate::Version) -> &mut Self {
-        self.0.set_version(v);
+        self.0[6] = (self.0[6] & 0xf0) | ((v as u8) << 4);
+
         self
     }
 
@@ -218,6 +231,8 @@ impl Builder {
     /// );
     /// ```
     pub fn build(&mut self) -> Uuid {
-        self.0
+        let uuid = crate::Uuid::from_bytes(self.0);
+
+        uuid
     }
 }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -191,7 +191,7 @@ impl Builder {
     /// );
     /// ```
     pub const fn nil() -> Self {
-        Builder(crate::Bytes::default())
+        Builder([0; 16])
     }
 
     /// Specifies the variant of the internal [`Uuid`].

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -210,7 +210,7 @@ impl Builder {
 
     /// Specifies the version number of the internal [`Uuid`].
     pub fn set_version(&mut self, v: crate::Version) -> &mut Self {
-        self.0[6] = (self.0[6] & 0xf0) | ((v as u8) << 4);
+        self.0[6] = (self.0[6] & 0x0f) | ((v as u8) << 4);
 
         self
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -559,17 +559,6 @@ impl Uuid {
         uuid
     }
 
-    /// Specifies the variant of the UUID structure
-    fn set_variant(&mut self, v: Variant) {
-        // Octet 8 contains the variant in the most significant 3 bits
-        self.0[8] = match v {
-            Variant::NCS => self.as_bytes()[8] & 0x7f, // b0xx...
-            Variant::RFC4122 => (self.as_bytes()[8] & 0x3f) | 0x80, // b10x...
-            Variant::Microsoft => (self.as_bytes()[8] & 0x1f) | 0xc0, // b110...
-            Variant::Future => (self.as_bytes()[8] & 0x1f) | 0xe0, // b111...
-        }
-    }
-
     /// Returns the variant of the `Uuid` structure.
     ///
     /// This determines the interpretation of the structure of the UUID.
@@ -584,11 +573,6 @@ impl Uuid {
             x if x & 0xe0 == 0xe0 => Some(Variant::Future),
             _ => None,
         }
-    }
-
-    /// Specifies the version number of the `Uuid`.
-    fn set_version(&mut self, v: Version) {
-        self.0[6] = (self.as_bytes()[6] & 0xF) | ((v as u8) << 4);
     }
 
     /// Returns the version number of the `Uuid`.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -940,7 +940,6 @@ mod tests {
             Uuid::new_v3(&Uuid::NAMESPACE_DNS, "rust-lang.org".as_bytes());
 
         assert_eq!(uuid.get_version().unwrap(), Version::Md5);
-        println!("pass1");
         assert_eq!(uuid.get_version_num(), 3);
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -940,6 +940,7 @@ mod tests {
             Uuid::new_v3(&Uuid::NAMESPACE_DNS, "rust-lang.org".as_bytes());
 
         assert_eq!(uuid.get_version().unwrap(), Version::Md5);
+        println!("pass1");
         assert_eq!(uuid.get_version_num(), 3);
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -527,17 +527,6 @@ impl Uuid {
         Uuid(bytes)
     }
 
-    /// Specifies the variant of the UUID structure
-    fn set_variant(&mut self, v: Variant) {
-        // Octet 8 contains the variant in the most significant 3 bits
-        self.0[8] = match v {
-            Variant::NCS => self.as_bytes()[8] & 0x7f, // b0xx...
-            Variant::RFC4122 => (self.as_bytes()[8] & 0x3f) | 0x80, // b10x...
-            Variant::Microsoft => (self.as_bytes()[8] & 0x1f) | 0xc0, // b110...
-            Variant::Future => (self.as_bytes()[8] & 0x1f) | 0xe0, // b111...
-        }
-    }
-
     /// Returns the variant of the `Uuid` structure.
     ///
     /// This determines the interpretation of the structure of the UUID.

--- a/src/v3.rs
+++ b/src/v3.rs
@@ -29,8 +29,7 @@ impl Uuid {
         let computed = context.compute();
         let bytes = computed.into();
 
-        let mut builder =
-            crate::builder::Builder::from_bytes(bytes);
+        let mut builder = crate::builder::Builder::from_bytes(bytes);
 
         builder
             .set_variant(Variant::RFC4122)

--- a/src/v3.rs
+++ b/src/v3.rs
@@ -26,11 +26,14 @@ impl Uuid {
         context.consume(namespace.as_bytes());
         context.consume(name);
 
-        let mut uuid = Uuid::from_bytes(context.compute().into());
+        let mut builder =
+            crate::builder::Builder::from_bytes(context.compute().into());
 
-        uuid.set_variant(Variant::RFC4122);
-        uuid.set_version(Version::Md5);
-        uuid
+        builder
+            .set_variant(Variant::RFC4122)
+            .set_version(Version::Md5);
+
+        builder.build()
     }
 }
 

--- a/src/v3.rs
+++ b/src/v3.rs
@@ -26,8 +26,11 @@ impl Uuid {
         context.consume(namespace.as_bytes());
         context.consume(name);
 
+        let computed = context.compute();
+        let bytes = computed.into();
+
         let mut builder =
-            crate::builder::Builder::from_bytes(context.compute().into());
+            crate::builder::Builder::from_bytes(bytes);
 
         builder
             .set_variant(Variant::RFC4122)

--- a/src/v5.rs
+++ b/src/v5.rs
@@ -25,13 +25,16 @@ impl Uuid {
         hash.update(name);
 
         let buffer = hash.digest().bytes();
-        let mut uuid = Uuid::default();
 
-        uuid.0.copy_from_slice(&buffer[..16]);
-        uuid.set_variant(Variant::RFC4122);
-        uuid.set_version(Version::Sha1);
+        let mut bytes = crate::Bytes::default();
+        bytes.copy_from_slice(&buffer[..16]);
 
-        uuid
+        let mut builder = crate::builder::Builder::from_bytes(bytes);
+        builder
+            .set_variant(Variant::RFC4122)
+            .set_version(Version::Sha1);
+
+        builder.build()
     }
 }
 


### PR DESCRIPTION
**I'm submitting a(n)** removal

# Description
Removes `Uuid::set_variant` and `Uuid::set_version`

# Motivation
These methods were private and already `uuid::builder::Builder` was being recommended.

# Tests
Current tests should pass.

# Related Issue(s)
N/A