### PR TITLE
Implement the default trait.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -889,7 +889,7 @@ impl Uuid {
     }
 }
 
-impl Default for Uuuid {
+impl Default for Uuid {
     fn default() -> Self {
         Uuid::nil()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1434,6 +1434,6 @@ mod tests {
     #[test]
     fn test_default() {
         let u: Uuid = Default::default();
-        assert_eq(u, Uuid::nil()
+        assert_eq!(u, Uuid::nil());
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -889,6 +889,12 @@ impl Uuid {
     }
 }
 
+impl Default for Uuuid {
+    fn default() -> Self {
+        Uuid::nil()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     extern crate std;
@@ -1423,5 +1429,11 @@ mod tests {
 
         assert!(set.contains(&id1));
         assert!(!set.contains(&id2));
+    }
+    
+    #[test]
+    fn test_default() {
+        let u: Uuid = Default::default();
+        assert_eq(u, Uuid::nil()
     }
 }


### PR DESCRIPTION
<!--
    If this PR is a breaking change, ensure that you are opening it against 
    the `breaking` branch.  If the pull request is incomplete, prepend the Title with WIP: 
-->

**I'm submitting a(n)** feature


# Description
The default trait allows us to use Rust's syntax for default values.
It was previously missing.

The default value is `Uuid::nil()`.

# Motivation
I want to allow Rust programmers to use the idioms they are used to with this library.

# Tests
<!-- How are these changes tested? -->
I added a unit test.

# Related Issue(s)
None