### PR TITLE
add endian adapters

### DIFF
--- a/src/adapter/endian/core_support.rs
+++ b/src/adapter/endian/core_support.rs
@@ -1,7 +1,26 @@
 use byteorder;
 use crate::prelude::*;
 use crate::adapter::endian;
-use rand::AsByteSliceMut;
+
+impl From<u128> for endian::Big {
+    fn from(f: u128) -> Self {
+        let mut bytes: Bytes = [0; 16];
+
+        <byteorder::BE as byteorder::ByteOrder>::write_u128(&mut bytes, f);
+
+        endian::Big(bytes)
+    }
+}
+
+impl From<u128> for endian::Little {
+    fn from(f: u128) -> Self {
+        let mut bytes: Bytes = [0; 16];
+
+        <byteorder::LE as byteorder::ByteOrder>::write_u128(&mut bytes, f);
+
+        endian::Little(bytes)
+    }
+}
 
 impl From<Uuid> for endian::Big {
     fn from(f: Uuid) -> Self {

--- a/src/adapter/endian/core_support.rs
+++ b/src/adapter/endian/core_support.rs
@@ -1,0 +1,22 @@
+use byteorder;
+use crate::prelude::*;
+use crate::adapter::endian;
+use rand::AsByteSliceMut;
+
+impl From<Uuid> for endian::Big {
+    fn from(f: Uuid) -> Self {
+        let bytes = f.0;
+
+        endian::Big(bytes)
+    }
+}
+
+impl From<Uuid> for endian::Little {
+    fn from(f: Uuid) -> Self {
+        let mut bytes = f.0;
+
+        bytes.reverse();
+
+        endian::Little(bytes)
+    }
+}

--- a/src/adapter/endian/mod.rs
+++ b/src/adapter/endian/mod.rs
@@ -1,0 +1,16 @@
+//! Adapters for handling endianness for [`Uuid`]s.
+//!
+//! [`Uuid`]: ../../struct.Uuid.html
+use crate::prelude::*;
+
+/// Represents a [`Uuid`] in **big** endian.
+///
+/// [`Uuid`]: ../../struct.Uuid.html
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct Big(Bytes);
+
+/// Represents a [`Uuid`] in **little** endian.
+///
+/// [`Uuid`]: ../../struct.Uuid.html
+#[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub struct Little(Bytes);

--- a/src/adapter/endian/mod.rs
+++ b/src/adapter/endian/mod.rs
@@ -3,6 +3,8 @@
 //! [`Uuid`]: ../../struct.Uuid.html
 use crate::prelude::*;
 
+mod core_support;
+
 /// Represents a [`Uuid`] in **big** endian.
 ///
 /// [`Uuid`]: ../../struct.Uuid.html

--- a/src/adapter/mod.rs
+++ b/src/adapter/mod.rs
@@ -16,6 +16,7 @@
 use crate::prelude::*;
 use core::str;
 
+pub mod endian;
 mod core_support;
 
 #[cfg(feature = "serde")]


### PR DESCRIPTION
**I'm submitting a(n)** feature

# Description
Add `uuid::adapter::endian::{Big, Little}`.

# Motivation
Currently we have single representation for `uuid::Uuid` in-memory. However people have needed for little endian. Particularly bindings have a requirement of the memory layout (see #406).

# Tests
Currently new tests are needed to be added

# Related Issue(s)
#406