### PR TITLE
remove the #[repr(C) attributions

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -225,8 +225,7 @@ pub enum Error {
 }
 
 /// The version of the UUID, denoting the generating algorithm.
-#[derive(Debug, PartialEq, Copy, Clone)]
-#[repr(C)]
+#[derive(Clone, Copy, Debug, PartialEq)]
 pub enum Version {
     /// Special case for `nil` [`Uuid`].
     ///
@@ -246,7 +245,6 @@ pub enum Version {
 
 /// The reserved variants of UUIDs.
 #[derive(Clone, Copy, Debug, PartialEq)]
-#[repr(C)]
 pub enum Variant {
     /// Reserved by the NCS for backward compatibility
     NCS = 0,


### PR DESCRIPTION
**I'm submitting a(n)** (bug fix|deprecation|feature|refactor|removal|other)

# Description
Remove the `#[repr(C)]` for `Variant` and `Version`.

# Motivation
These were added because uncertainty on whether the
C interface will be directly provided in the crate itself.
Since then I have resolved to use uuid-rs/xuuid.c instead.

# Tests
No test changes are needed

# Related Issue(s)
N/A