### PR TITLE
Rename Expected to ExpectedLength

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -716,7 +716,7 @@ impl Uuid {
             &[adapter::Hyphenated::LENGTH, adapter::Simple::LENGTH],
         ) {
             return Err(parser::ParseError::InvalidLength {
-                expected: parser::Expected::Any(&[
+                expected: parser::ExpectedLength::Any(&[
                     adapter::Hyphenated::LENGTH,
                     adapter::Simple::LENGTH,
                 ]),
@@ -734,7 +734,7 @@ impl Uuid {
             if digit as usize >= adapter::Simple::LENGTH && group != 4 {
                 if group == 0 {
                     return Err(parser::ParseError::InvalidLength {
-                        expected: parser::Expected::Any(&[
+                        expected: parser::ExpectedLength::Any(&[
                             adapter::Hyphenated::LENGTH,
                             adapter::Simple::LENGTH,
                         ]),
@@ -743,7 +743,7 @@ impl Uuid {
                 }
 
                 return Err(parser::ParseError::InvalidGroupCount {
-                    expected: parser::Expected::Any(&[1, 5]),
+                    expected: parser::ExpectedLength::Any(&[1, 5]),
                     found: group + 1,
                 });
             }
@@ -774,7 +774,7 @@ impl Uuid {
 
                             return Err(
                                 parser::ParseError::InvalidGroupLength {
-                                    expected: parser::Expected::Exact(
+                                    expected: parser::ExpectedLength::Exact(
                                         parser::GROUP_LENS[group],
                                     ),
                                     found: found as usize,
@@ -815,7 +815,7 @@ impl Uuid {
                         };
 
                         return Err(parser::ParseError::InvalidGroupLength {
-                            expected: parser::Expected::Exact(
+                            expected: parser::ExpectedLength::Exact(
                                 parser::GROUP_LENS[group],
                             ),
                             found: found as usize,
@@ -842,7 +842,7 @@ impl Uuid {
         //       ParseError
         if parser::ACC_GROUP_LENS[4] as u8 != digit {
             return Err(parser::ParseError::InvalidGroupLength {
-                expected: parser::Expected::Exact(parser::GROUP_LENS[4]),
+                expected: parser::ExpectedLength::Exact(parser::GROUP_LENS[4]),
                 found: (digit as usize - parser::ACC_GROUP_LENS[3]),
                 group,
             });
@@ -969,14 +969,14 @@ mod tests {
         use crate::adapter;
         use crate::parser;
 
-        const EXPECTED_UUID_LENGTHS: parser::Expected =
-            parser::Expected::Any(&[
+        const EXPECTED_UUID_LENGTHS: parser::ExpectedLength =
+            parser::ExpectedLength::Any(&[
                 adapter::Hyphenated::LENGTH,
                 adapter::Simple::LENGTH,
             ]);
 
-        const EXPECTED_GROUP_COUNTS: parser::Expected =
-            parser::Expected::Any(&[1, 5]);
+        const EXPECTED_GROUP_COUNTS: parser::ExpectedLength =
+            parser::ExpectedLength::Any(&[1, 5]);
 
         const EXPECTED_CHARS: &'static str = "0123456789abcdefABCDEF-";
 
@@ -1068,7 +1068,7 @@ mod tests {
         assert_eq!(
             Uuid::parse_str("F9168C5E-CEB-24fa-eB6BFF32-BF39FA1E4"),
             Err(parser::ParseError::InvalidGroupLength {
-                expected: parser::Expected::Exact(4),
+                expected: parser::ExpectedLength::Exact(4),
                 found: 3,
                 group: 1,
             })
@@ -1078,7 +1078,7 @@ mod tests {
         assert_eq!(
             Uuid::parse_str("01020304-1112-2122-3132-41424344"),
             Err(parser::ParseError::InvalidGroupLength {
-                expected: parser::Expected::Exact(12),
+                expected: parser::ExpectedLength::Exact(12),
                 found: 8,
                 group: 4,
             })
@@ -1174,7 +1174,7 @@ mod tests {
         assert_eq!(
             Uuid::parse_str("67e550-4105b1426f9247bb680e5fe0c"),
             Err(parser::ParseError::InvalidGroupLength {
-                expected: parser::Expected::Exact(8),
+                expected: parser::ExpectedLength::Exact(8),
                 found: 6,
                 group: 0,
             })
@@ -1182,7 +1182,7 @@ mod tests {
         assert_eq!(
             Uuid::parse_str("F9168C5E-CEB2-4faa-B6BF1-02BF39FA1E4"),
             Err(parser::ParseError::InvalidGroupLength {
-                expected: parser::Expected::Exact(4),
+                expected: parser::ExpectedLength::Exact(4),
                 found: 5,
                 group: 3,
             })

--- a/src/parser/core_support.rs
+++ b/src/parser/core_support.rs
@@ -21,7 +21,9 @@ impl From<parser::ParseError> for crate::Error {
 impl<'a> fmt::Display for parser::ExpectedLength {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
-            parser::ExpectedLength::Any(crits) => write!(f, "one of {:?}", crits),
+            parser::ExpectedLength::Any(crits) => {
+                write!(f, "one of {:?}", crits)
+            }
             parser::ExpectedLength::Exact(crit) => write!(f, "{}", crit),
             parser::ExpectedLength::Range { min, max } => {
                 write!(f, "{}..{} inclusive", min, max)

--- a/src/parser/core_support.rs
+++ b/src/parser/core_support.rs
@@ -18,12 +18,12 @@ impl From<parser::ParseError> for crate::Error {
     }
 }
 
-impl<'a> fmt::Display for parser::Expected {
+impl<'a> fmt::Display for parser::ExpectedLength {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
-            parser::Expected::Any(ref crits) => write!(f, "one of {:?}", crits),
-            parser::Expected::Exact(crit) => write!(f, "{}", crit),
-            parser::Expected::Range { min, max } => {
+            parser::ExpectedLength::Any(crits) => write!(f, "one of {:?}", crits),
+            parser::ExpectedLength::Exact(crit) => write!(f, "{}", crit),
+            parser::ExpectedLength::Range { min, max } => {
                 write!(f, "{}..{} inclusive", min, max)
             }
         }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -17,9 +17,9 @@ mod core_support;
 #[cfg(feature = "std")]
 mod std_support;
 
-/// The expected value.
+/// The expected length.
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
-pub enum Expected {
+pub enum ExpectedLength {
     /// Expected any one of the given values.
     Any(&'static [usize]),
     /// Expected the given value.
@@ -74,7 +74,7 @@ pub enum ParseError {
         // TODO: explain multiple segment count.
         // BODY: Parsers can expect a range of Uuid segment count.
         //       This needs to be expanded on.
-        expected: Expected,
+        expected: ExpectedLength,
         /// The number of segments found.
         found: usize,
     },
@@ -83,7 +83,7 @@ pub enum ParseError {
     /// [`Uuid`]: ../struct.Uuid.html
     InvalidGroupLength {
         /// The expected length of the segment.
-        expected: Expected,
+        expected: ExpectedLength,
         /// The length of segment found.
         found: usize,
         /// The segment with invalid length.
@@ -97,7 +97,7 @@ pub enum ParseError {
         // TODO: explain multiple lengths.
         // BODY: Parsers can expect a range of Uuid lenghts.
         //       This needs to be expanded on.
-        expected: Expected,
+        expected: ExpectedLength,
         /// The invalid length found.
         found: usize,
     },


### PR DESCRIPTION
**I'm submitting a(n)** refactor

# Description
Renamed `uuid::parser::Expected` to `uuid::parser::ExpectedLength`

# Motivation
`Expected` was slightly ambiguous.

# Tests
Current tests should pass as is. No new tests.

# Related Issue(s)
N/A