### PR TITLE
Prepare for 0.8.0 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ homepage = "https://github.com/uuid-rs/uuid"
 name = "uuid"
 readme = "README.md"
 repository = "https://github.com/uuid-rs/uuid"
-version = "0.7.4" # remember to update html_root_url in lib.rs
+version = "0.8.0" # remember to update html_root_url in lib.rs
 
 [package.metadata.docs.rs]
 features = [ "guid", "serde", "slog", "v1", "v3", "v4", "v5" ]

--- a/README.md
+++ b/README.md
@@ -57,21 +57,21 @@ By default, `uuid` can be depended on with:
 
 ```toml
 [dependencies]
-uuid = "0.7"
+uuid = "0.8.0"
 ```
 
 To activate various features, use syntax like:
 
 ```toml
 [dependencies]
-uuid = { version = "0.7", features = ["serde", "v4"] }
+uuid = { version = "0.8.0", features = ["serde", "v4"] }
 ```
 
 You can disable default features with:
 
 ```toml
 [dependencies]
-uuid = { version = "0.7", default-features = false }
+uuid = { version = "0.8.0", default-features = false }
 ```
 
 ## Examples
@@ -116,7 +116,7 @@ Examples of string representations:
 
 [`wasm-bindgen`]: https://github.com/rustwasm/wasm-bindgen
 
-[`Uuid`]: https://docs.rs/uuid/0.7.4/uuid/struct.Uuid.html
+[`Uuid`]: https://docs.rs/uuid/0.8.0/uuid/struct.Uuid.html
 
 ---
 # License

--- a/README.md
+++ b/README.md
@@ -57,21 +57,21 @@ By default, `uuid` can be depended on with:
 
 ```toml
 [dependencies]
-uuid = "0.8.0"
+uuid = "0.8"
 ```
 
 To activate various features, use syntax like:
 
 ```toml
 [dependencies]
-uuid = { version = "0.8.0", features = ["serde", "v4"] }
+uuid = { version = "0.8", features = ["serde", "v4"] }
 ```
 
 You can disable default features with:
 
 ```toml
 [dependencies]
-uuid = { version = "0.8.0", default-features = false }
+uuid = { version = "0.8", default-features = false }
 ```
 
 ## Examples

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -119,7 +119,7 @@
 #![doc(
     html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
     html_favicon_url = "https://www.rust-lang.org/favicon.ico",
-    html_root_url = "https://docs.rs/uuid/0.7.4"
+    html_root_url = "https://docs.rs/uuid/0.8.0"
 )]
 
 #[cfg(any(feature = "std", test))]
@@ -398,7 +398,22 @@ impl Uuid {
         (d1, d2, d3, d4)
     }
 
-    /// Returns a 128bit big-endian value containing the UUID data.
+    /// Returns a 128bit value containing the UUID data.
+    ///
+    /// The bytes in the UUID will be packed into a `u128`, like the `as_bytes`
+    /// method.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use uuid::Uuid;
+    ///
+    /// let uuid = Uuid::parse_str("936DA01F-9ABD-4D9D-80C7-02AF85C822A8").unwrap();
+    /// assert_eq!(
+    ///     uuid.as_u128(),
+    ///     0x936DA01F9ABD4D9D80C702AF85C822A8,
+    /// )
+    /// ```
     pub fn as_u128(&self) -> u128 {
         u128::from(self.as_bytes()[0]) << 120
             | u128::from(self.as_bytes()[1]) << 112
@@ -419,6 +434,24 @@ impl Uuid {
     }
 
     /// Returns a 128bit little-endian value containing the UUID data.
+    ///
+    /// The bytes in the UUID will be reversed and packed into a `u128`.
+    /// Note that this will produce a different result than `to_fields_le`,
+    /// because the entire UUID is reversed, rather than reversing the
+    /// individual fields in-place.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use uuid::Uuid;
+    ///
+    /// let uuid = Uuid::parse_str("936DA01F-9ABD-4D9D-80C7-02AF85C822A8").unwrap();
+    ///
+    /// assert_eq!(
+    ///     uuid.to_u128_le(),
+    ///     0xA822C885AF02C7809D4DBD9A1FA06D93,
+    /// )
+    /// ```
     pub fn to_u128_le(&self) -> u128 {
         u128::from(self.as_bytes()[0])
             | u128::from(self.as_bytes()[1]) << 8

--- a/src/parser/error.rs
+++ b/src/parser/error.rs
@@ -66,24 +66,13 @@ pub(crate) enum ExpectedLength {
     Any(&'static [usize]),
     /// Expected the given value.
     Exact(usize),
-    /// Expected any values in the given range.
-    Range {
-        /// The minimum expected value.
-        min: usize,
-        /// The maximum expected value.
-        max: usize,
-    },
 }
 
 /// Urn prefix value.
 #[derive(Clone, Copy, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub(crate) enum UrnPrefix {
-    /// No `urn:uuid:` prefix should be provided.
-    None,
     /// The `urn:uuid:` prefix should optionally provided.
     Optional,
-    /// The `urn:uuid:` prefix is required.
-    Required,
 }
 
 impl Error {
@@ -102,9 +91,6 @@ impl fmt::Display for ExpectedLength {
         match *self {
             ExpectedLength::Any(crits) => write!(f, "one of {:?}", crits),
             ExpectedLength::Exact(crit) => write!(f, "{}", crit),
-            ExpectedLength::Range { min, max } => {
-                write!(f, "{}..{} inclusive", min, max)
-            }
         }
     }
 }
@@ -121,12 +107,8 @@ impl fmt::Display for Error {
                 urn,
             } => {
                 let urn_str = match urn {
-                    UrnPrefix::None => "",
                     UrnPrefix::Optional => {
                         " an optional prefix of `urn:uuid:` followed by"
-                    }
-                    UrnPrefix::Required => {
-                        " a prefix of `urn:uuid` followed by"
                     }
                 };
 


### PR DESCRIPTION
Closes #431 

[Changeset since the last release](https://github.com/uuid-rs/uuid/compare/0.7.4...master)

Includes:

- #427 
- #419 
- #424 
- #418 
- #413 
- #407 
- #404 
- #400 
- #399 
- #398 
- #397 
- #396 
- #394 
- #393 
- #390
- #389 
- #388 

I've also added some docs to the 128bit integer methods to clarify how they're different than `to_fields` (for consistency with other uuid libs in the wild).