### PR TITLE
Use getrandom crate for uuid

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -54,11 +54,11 @@ status = "actively-developed"
 [badges.travis-ci]
 repository = "uuid-rs/uuid"
 
-[dependencies.md5]
+[dependencies.getrandom]
 optional = true
-version = "0.7"
+version = "0.1"
 
-[dependencies.rand]
+[dependencies.md5]
 optional = true
 version = "0.7"
 
@@ -92,12 +92,12 @@ version = "1.0.56"
 default = ["std"]
 guid = ["winapi"]
 std = []
-stdweb = [ "rand/stdweb" ]
+stdweb = ["getrandom"]
 v1 = []
 v3 = ["md5"]
-v4 = ["rand"]
+v4 = ["getrandom"]
 v5 = ["sha1"]
-wasm-bindgen = ["rand/wasm-bindgen"]
+wasm-bindgen = ["getrandom"]
 
 [target.'cfg(windows)'.dependencies.winapi]
 optional = true

--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ To create a new random (V4) UUID and print it out in hexadecimal form:
 
 use uuid::Uuid;
 
-fn main() {
+fn main() -> Result<(), Box<std::error::Error> {
     let my_uuid = Uuid::new_v4().unwrap();
     println!("{}", my_uuid);
 }

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ To create a new random (V4) UUID and print it out in hexadecimal form:
 use uuid::Uuid;
 
 fn main() {
-    let my_uuid = Uuid::new_v4();
+    let my_uuid = Uuid::new_v4().unwrap();
     println!("{}", my_uuid);
 }
 ```

--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ To create a new random (V4) UUID and print it out in hexadecimal form:
 use uuid::Uuid;
 
 fn main() -> Result<(), Box<std::error::Error> {
-    let my_uuid = Uuid::new_v4().unwrap();
+    let my_uuid = Uuid::new_v4()?;
     println!("{}", my_uuid);
 }
 ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -94,7 +94,7 @@
 //! use uuid::Uuid;
 //!
 //! fn main() {
-//!     let my_uuid = Uuid::new_v4();
+//!     let my_uuid = Uuid::new_v4().unwrap();
 //!     println!("{}", my_uuid);
 //! }
 //! ```

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -93,8 +93,8 @@
 //!
 //! use uuid::Uuid;
 //!
-//! fn main() {
-//!     let my_uuid = Uuid::new_v4().unwrap();
+//! fn main() -> Result<(), Box<std::error::Error> {
+//!     let my_uuid = Uuid::new_v4()?;
 //!     println!("{}", my_uuid);
 //! }
 //! ```

--- a/src/v4.rs
+++ b/src/v4.rs
@@ -4,7 +4,7 @@ impl Uuid {
     /// Creates a random UUID.
     ///
     /// This uses the [`getrandom`] crate to utilise the operating system's RNG
-    /// as the source of randomnumbers. If you'd like to use a custom generator,
+    /// as the source of random numbers. If you'd like to use a custom generator,
     /// don't use this method: use the `rand::Rand trait`'s `rand()` method instead.
     ///
     /// Note that usage of this method requires the `v4` feature of this crate

--- a/src/v4.rs
+++ b/src/v4.rs
@@ -1,12 +1,11 @@
 use crate::prelude::*;
-use rand;
 
 impl Uuid {
     /// Creates a random UUID.
     ///
-    /// This uses the [`rand`] crate's default task RNG as the source of random
-    /// numbers. If you'd like to use a custom generator, don't use this
-    /// method: use the `rand::Rand trait`'s `rand()` method instead.
+    /// This uses the [`getrandom`] crate to utilise the operating system's RNG
+    /// as the source of randomnumbers. If you'd like to use a custom generator,
+    /// don't use this method: use the `rand::Rand trait`'s `rand()` method instead.
     ///
     /// Note that usage of this method requires the `v4` feature of this crate
     /// to be enabled.
@@ -21,19 +20,17 @@ impl Uuid {
     /// let uuid = Uuid::new_v4();
     /// ```
     ///
+    /// [`getrandom`]: https://crates.io/crates/getrandom
     /// [`rand`]: https://crates.io/crates/rand
-    pub fn new_v4() -> Self {
-        use rand::RngCore;
+    pub fn new_v4() -> Result<Uuid, getrandom::Error> {
+        let mut bytes = [0u8; 16];
+        getrandom::getrandom(&mut bytes)?;
 
-        let mut rng = rand::thread_rng();
-        let mut bytes = [0; 16];
-
-        rng.fill_bytes(&mut bytes);
-
-        Builder::from_bytes(bytes)
+        let uuid = crate::builder::Builder::from_bytes(bytes)
             .set_variant(Variant::RFC4122)
             .set_version(Version::Random)
-            .build()
+            .build();
+        Ok(uuid)
     }
 }
 
@@ -43,7 +40,7 @@ mod tests {
 
     #[test]
     fn test_new() {
-        let uuid = Uuid::new_v4();
+        let uuid = Uuid::new_v4().unwrap();
 
         assert_eq!(uuid.get_version(), Some(Version::Random));
         assert_eq!(uuid.get_variant(), Some(Variant::RFC4122));
@@ -51,7 +48,7 @@ mod tests {
 
     #[test]
     fn test_get_version() {
-        let uuid = Uuid::new_v4();
+        let uuid = Uuid::new_v4().unwrap();
 
         assert_eq!(uuid.get_version(), Some(Version::Random));
         assert_eq!(uuid.get_version_num(), 4)

--- a/src/v4.rs
+++ b/src/v4.rs
@@ -22,6 +22,7 @@ impl Uuid {
     ///
     /// [`getrandom`]: https://crates.io/crates/getrandom
     /// [`rand`]: https://crates.io/crates/rand
+    // TODO: change signature to support uuid's Error.
     pub fn new_v4() -> Result<Uuid, getrandom::Error> {
         let mut bytes = [0u8; 16];
         getrandom::getrandom(&mut bytes)?;


### PR DESCRIPTION
<!--
    If this PR is a breaking change, ensure that you are opening it against 
    the `breaking` branch.  If the pull request is incomplete, prepend the Title with WIP: 
-->

**I'm submitting a(n)** other

# Description

Use `getrandom` crate directly instead of `rand` for generating UUIDs using v4.

# Motivation

Reduce the number of dependencies used by the crate.

Running the example in the README: 
- Before (10): c2-chacha, cfg-if, getrandom, libc, ppv-lite86, rand, rand_chacha, rand_core, rand_hc, wasi  
- After (4): cfg-if, getrandom, libc, wasi

# Tests
<!-- How are these changes tested? -->
`cargo test` locally and test usage in a simple program.

# Related Issue(s)

# Other

Wasn't sure whether I should bump the version here or not.
