### PR TITLE
Move windows builds to Github Actions

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -17,5 +17,6 @@ jobs:
           override: true
       - name: Build
         uses: actions-rs/cargo@v1
-        command: build
-        args: --all-features
+        with:
+          command: build
+          args: --all-features

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -38,11 +38,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
       - name: Install Toolchain
-          uses: actions-rs/toolchain@v1
-          with:
-            target: x86_64-pc-windows-gnu
-            toolchain: nightly
-            override: true
+        uses: actions-rs/toolchain@v1
+        with:
+          target: x86_64-pc-windows-gnu
+          toolchain: nightly
+          override: true
       - name: Build
         uses: actions-rs/cargo@v1
         with:
@@ -66,11 +66,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
       - name: Install Toolchain
-          uses: actions-rs/toolchain@v1
-          with:
-            target: i686-pc-windows-msvc
-            toolchain: nightly
-            override: true
+        uses: actions-rs/toolchain@v1
+        with:
+          target: i686-pc-windows-msvc
+          toolchain: nightly
+          override: true
       - name: Build
         uses: actions-rs/cargo@v1
         with:
@@ -94,11 +94,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
       - name: Install Toolchain
-          uses: actions-rs/toolchain@v1
-          with:
-            target: i686-pc-windows-gnu
-            toolchain: nightly
-            override: true
+        uses: actions-rs/toolchain@v1
+        with:
+          target: i686-pc-windows-gnu
+          toolchain: nightly
+          override: true
       - name: Build
         uses: actions-rs/cargo@v1
         with:

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -3,18 +3,19 @@ name: Windows
 on: [push, pull_request]
 
 jobs:
-  name: Windows-x86_64-MSVC
-  runs: windows-latest
-  steps:
-    - name: Checkout
-      uses: actions/checkout@v1
-    - name: Install Toolchain
-      uses: actions-rs/toolchain@v1
-      with:
-        target: x86_64-pc-windows-msvc
-        toolchain: nightly
-        override: true
-    - name: Build
-      uses: actions-rs/cargo@v1
-      command: build
-      args: --all-features
+  windows-x86_64-msvc:
+    name: Windows-x86_64-MSVC
+    runs: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Install Toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          target: x86_64-pc-windows-msvc
+          toolchain: nightly
+          override: true
+      - name: Build
+        uses: actions-rs/cargo@v1
+        command: build
+        args: --all-features

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -3,8 +3,8 @@ name: Windows
 on: [push, pull_request]
 
 jobs:
-  windows-x86_64-msvc:
-    name: Windows-x86_64-MSVC
+  x86_64-windows-msvc:
+    name: x86_64-Windows-MSVC
     runs-on: windows-latest
     steps:
       - name: Checkout
@@ -19,4 +19,98 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
+          args: --all-features
+      - name: Test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --all-features
+      - name: Bench
+        uses: actions-rs/cargo@v1
+        with:
+          command: bench
+          args: --all-features
+
+  x86_64-windows-gnu:
+    name: x86_64-Windows-GNU
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Install Toolchain
+          uses: actions-rs/toolchain@v1
+          with:
+            target: x86_64-pc-windows-gnu
+            toolchain: nightly
+            override: true
+      - name: Build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --all-features
+      - name: Test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --all-features
+      - name: Bench
+        uses: actions-rs/cargo@v1
+        with:
+          command: bench
+          args: --all-features
+
+  i686-windows-msvc:
+    name: i686-Windows-MSVC
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Install Toolchain
+          uses: actions-rs/toolchain@v1
+          with:
+            target: i686-pc-windows-msvc
+            toolchain: nightly
+            override: true
+      - name: Build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --all-features
+      - name: Test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --all-features
+      - name: Bench
+        uses: actions-rs/cargo@v1
+        with:
+          command: bench
+          args: --all-features
+
+  i686-windows-gnu:
+    name: i686-Windows-GNU
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+      - name: Install Toolchain
+          uses: actions-rs/toolchain@v1
+          with:
+            target: i686-pc-windows-gnu
+            toolchain: nightly
+            override: true
+      - name: Build
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: --all-features
+      - name: Test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --all-features
+      - name: Bench
+        uses: actions-rs/cargo@v1
+        with:
+          command: bench
           args: --all-features

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -5,7 +5,7 @@ on: [push, pull_request]
 jobs:
   windows-x86_64-msvc:
     name: Windows-x86_64-MSVC
-    runs: windows-latest
+    runs-on: windows-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v1

--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -1,0 +1,20 @@
+name: Windows
+
+on: [push, pull_request]
+
+jobs:
+  name: Windows-x86_64-MSVC
+  runs: windows-latest
+  steps:
+    - name: Checkout
+      uses: actions/checkout@v1
+    - name: Install Toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        target: x86_64-pc-windows-msvc
+        toolchain: nightly
+        override: true
+    - name: Build
+      uses: actions-rs/cargo@v1
+      command: build
+      args: --all-features

--- a/bors.toml
+++ b/bors.toml
@@ -1,4 +1,4 @@
 status = [
 	"continuous-integration/travis-ci/push",
-	"continuous-integration/appveyor/branch"
+	"x86_64-Windows-MSVC"
 ]


### PR DESCRIPTION
# Description
Move the Appveyor builds to Github Actions

# Motivation
This had been the plan for a while, we just never implemented it.

# Tests
The tests in Github Actions for Windows should pass to indicate success