### PR TITLE
Fix unspecified direct object in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ unique 128-bit number, stored as 16 octets. UUIDs are used to  assign
 unique identifiers to entities without requiring a central allocating
 authority.
 
-They are particularly useful in distributed systems, though can be used in
+They are particularly useful in distributed systems, though they can be used in
 disparate areas, such as databases and network protocols.  Typically a UUID
 is displayed in a readable string form as a sequence of hexadecimal digits,
 separated into groups by hyphens.


### PR DESCRIPTION
<!--
    If this PR is a breaking change, ensure that you are opening it against 
    the `breaking` branch.  If the pull request is incomplete, prepend the Title with WIP: 
-->

**I'm submitting a grammar fix for the README**


# Description
Previously, the README contained "They are particularly useful in distributed systems, *though can be used*..."
To a native speaker, this sounds a little strange, whereas "They are particularly useful in distributed systems, though **they** can be used..." is clearer and more grammatically correct.

# Motivation
I'd like to make the README easier to understand

# Tests
I read it out loud and it sounded better and made more sense.

# Related Issue(s)
N/A