### PR TITLE
Clarify documentation around the relation to the rand crate

### DIFF
--- a/src/v4.rs
+++ b/src/v4.rs
@@ -5,7 +5,9 @@ impl Uuid {
     ///
     /// This uses the [`getrandom`] crate to utilise the operating system's RNG
     /// as the source of random numbers. If you'd like to use a custom generator,
-    /// don't use this method: use the `rand::Rand trait`'s `rand()` method instead.
+    /// don't use this method: generate random bytes using your custom generator
+    /// and pass them to the [`uuid::Builder::from_bytes`][from_bytes] function
+    /// instead.
     ///
     /// Note that usage of this method requires the `v4` feature of this crate
     /// to be enabled.
@@ -21,7 +23,7 @@ impl Uuid {
     /// ```
     ///
     /// [`getrandom`]: https://crates.io/crates/getrandom
-    /// [`rand`]: https://crates.io/crates/rand
+    /// [from_bytes]: struct.Builder.html#method.from_bytes
     // TODO: change signature to support uuid's Error.
     pub fn new_v4() -> Result<Uuid, getrandom::Error> {
         let mut bytes = [0u8; 16];


### PR DESCRIPTION
**I'm submitting a(n)** other - documentation improvement

# Description

The rand crate changed its trait names, so these docs were referencing a
trait that doesn't exist in the current version of rand. Change to be a
bit more vague to avoid this getting out of date again.

Also "use rand instead" wasn't very clear because "rand" doesn't contain
something clearly equivalent like `get_uuid_v4`. To be clearer, add a
reference to the `Builder::from_bytes` function in this crate.

# Motivation

It took me a few minutes to figure out what this documentation was saying, and I'd like to save someone else those few minutes in the future.

# Tests

N/A

# Related Issue(s)

None
