### PR TITLE
remove appveyor from bors

### DIFF
--- a/bors.toml
+++ b/bors.toml
@@ -1,4 +1,3 @@
 status = [
 	"continuous-integration/travis-ci/push",
-	"continuous-integration/appveyor/branch"
 ]


### PR DESCRIPTION
I missed to do this while working on #487, as now appveyor has been unlinked
