### PR TITLE
cleanup: use better-maintained sha-1 crate instead of sha1 crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -67,9 +67,9 @@ default-features = false
 optional = true
 version = "1.0.56"
 
-[dependencies.sha1]
+[dependencies.sha-1]
 optional = true
-version = "0.6"
+version = "0.9.1"
 
 [dependencies.slog]
 optional = true
@@ -95,10 +95,9 @@ stdweb = ["getrandom", "getrandom/js"]
 v1 = []
 v3 = ["md5"]
 v4 = ["getrandom"]
-v5 = ["sha1"]
+v5 = ["sha-1"]
 wasm-bindgen = ["getrandom", "getrandom/js"]
 
 [target.'cfg(windows)'.dependencies.winapi]
 optional = true
 version = "0.3"
-

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,9 +58,9 @@ repository = "uuid-rs/uuid"
 optional = true
 version = "0.2.0"
 
-[dependencies.md5]
+[dependencies.md-5]
 optional = true
-version = "0.7"
+version = "0.9.1"
 
 [dependencies.serde]
 default-features = false
@@ -93,7 +93,7 @@ guid = ["winapi"]
 std = []
 stdweb = ["getrandom", "getrandom/js"]
 v1 = []
-v3 = ["md5"]
+v3 = ["md-5"]
 v4 = ["getrandom"]
 v5 = ["sha-1"]
 wasm-bindgen = ["getrandom", "getrandom/js"]

--- a/src/v3.rs
+++ b/src/v3.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use md5;
+use md5::Digest;
 
 impl Uuid {
     /// Creates a UUID using a name from a namespace, based on the MD5
@@ -20,15 +20,14 @@ impl Uuid {
     /// [`NAMESPACE_URL`]: #associatedconstant.NAMESPACE_URL
     /// [`NAMESPACE_X500`]: #associatedconstant.NAMESPACE_X500
     pub fn new_v3(namespace: &Uuid, name: &[u8]) -> Uuid {
-        let mut context = md5::Context::new();
+        let mut hasher = md5::Md5::new();
 
-        context.consume(namespace.as_bytes());
-        context.consume(name);
+        hasher.update(namespace.as_bytes());
+        hasher.update(name);
 
-        let computed = context.compute();
-        let bytes = computed.into();
+        let computed = hasher.finalize();
 
-        let mut builder = crate::Builder::from_bytes(bytes);
+        let mut builder = crate::Builder::from_slice(&computed[..16]).unwrap();
 
         builder
             .set_variant(Variant::RFC4122)

--- a/src/v5.rs
+++ b/src/v5.rs
@@ -1,5 +1,5 @@
 use crate::prelude::*;
-use sha1;
+use sha1::Digest;
 
 impl Uuid {
     /// Creates a UUID using a name from a namespace, based on the SHA-1 hash.
@@ -24,7 +24,7 @@ impl Uuid {
         hash.update(namespace.as_bytes());
         hash.update(name);
 
-        let buffer = hash.digest().bytes();
+        let buffer = hash.finalize();
 
         let mut bytes = crate::Bytes::default();
         bytes.copy_from_slice(&buffer[..16]);


### PR DESCRIPTION
This removes a "duplicate" dependency in the tree of pyoxidizer.