### PR TITLE
[WIP] Add support for zerocopy traits via a feature.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,7 +33,7 @@ repository = "https://github.com/uuid-rs/uuid"
 version = "0.8.1" # remember to update html_root_url in lib.rs
 
 [package.metadata.docs.rs]
-features = [ "guid", "serde", "slog", "v1", "v3", "v4", "v5" ]
+features = [ "guid", "serde", "slog", "v1", "v3", "v4", "v5", "zerocopy" ]
 default-target = "x86_64-pc-windows-msvc"
 
 [package.metadata.playground]
@@ -74,6 +74,11 @@ version = "0.6"
 [dependencies.slog]
 optional = true
 version = "2"
+
+[dependencies.zerocopy]
+default-features = false
+optional = true
+version = "0.3.0"
 
 [dev-dependencies.bincode]
 version = "1.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -197,6 +197,8 @@ mod v4;
 mod v5;
 #[cfg(all(windows, feature = "winapi"))]
 mod winapi_support;
+#[cfg(feature = "zerocopy")]
+use zerocopy::{AsBytes, FromBytes, Unaligned};
 
 use crate::std::{fmt, str};
 
@@ -259,7 +261,15 @@ pub enum Variant {
 }
 
 /// A Universally Unique Identifier (UUID).
+#[cfg(not(feature = "zerocopy"))]
 #[derive(Clone, Copy, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[repr(transparent)]
+pub struct Uuid(Bytes);
+
+/// A Universally Unique Identifier (UUID).
+#[cfg(feature = "zerocopy")]
+#[derive(Clone, Copy, Eq, Hash, Ord, PartialEq, PartialOrd,
+    AsBytes, FromBytes, Unaligned)]
 #[repr(transparent)]
 pub struct Uuid(Bytes);
 


### PR DESCRIPTION
I'm submitting a feature proposal.

# Description

Allows `uuid::Uuid` to be read from or serialized to a byte slice without copying by using the zerocopy crate.

# Motivation

I like the abstraction that zerocopy provides and UUIDs are often embedded in other structs I'd like to use zerocopy's traits on.  Hiding this behind a feature that needs to be explicitly enabled should keep the general cost of this very low for the vast majority of users of uuid that do not use zerocopy.

# Tests

Tests missing, therefore marked WIP.

# Related Issue(s)

Not aware of any, possibly somewhat related to #472, though.  Clearly adding another variant of `as_bytes()` via the `zerocopy::AsBytes` trait.