### PR TITLE
prepare for 0.6.6 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,7 +18,7 @@ homepage = "https://github.com/uuid-rs/uuid"
 name = "uuid"
 readme = "README.md"
 repository = "https://github.com/uuid-rs/uuid"
-version = "0.6.5"
+version = "0.6.6"
 
 [package.metadata.docs.rs]
 all-features = true


### PR DESCRIPTION
This updates `rand` to `0.7.x` in our `0.6.x` minor of `uuid` to simplify some uncertain licensing with Fuchsia.