### PR TITLE
Update to getrandom:0.2.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -29,7 +29,7 @@ jobs:
         - stable
         - beta
         - nightly
-        - 1.32.0
+        - 1.34.0
         os:
         - macos-10.15
         - windows-2019

--- a/.github/workflows/clippy.yml
+++ b/.github/workflows/clippy.yml
@@ -15,7 +15,7 @@ jobs:
          components: clippy
          override: true
          profile: minimal
-         toolchain: 1.32.0
+         toolchain: 1.34.0
      - name: Run `cargo clippy`
        uses: actions-rs/cargo@v1
        with:
@@ -33,7 +33,7 @@ jobs:
          components: clippy
          override: true
          profile: minimal
-         toolchain: 1.32.0
+         toolchain: 1.34.0
      - name: Run `cargo clippy`
        uses: actions-rs/cargo@v1
        with:

--- a/.github/workflows/fmt.yml
+++ b/.github/workflows/fmt.yml
@@ -14,7 +14,7 @@ jobs:
           components: rustfmt
           override: true
           profile: minimal
-          toolchain: 1.32.0
+          toolchain: 1.34.0
       - name: Run `cargo fmt`
         uses: actions-rs/cargo@v1
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ repository = "uuid-rs/uuid"
 
 [dependencies.getrandom]
 optional = true
-version = "0.1"
+version = "0.2.0"
 
 [dependencies.md5]
 optional = true
@@ -91,12 +91,12 @@ version = "1.0.56"
 default = ["std"]
 guid = ["winapi"]
 std = []
-stdweb = ["getrandom"]
+stdweb = ["getrandom", "getrandom/js"]
 v1 = []
 v3 = ["md5"]
 v4 = ["getrandom"]
 v5 = ["sha1"]
-wasm-bindgen = ["getrandom"]
+wasm-bindgen = ["getrandom", "getrandom/js"]
 
 [target.'cfg(windows)'.dependencies.winapi]
 optional = true

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ uuid
 
 [![Latest Version](https://img.shields.io/crates/v/uuid.svg)](https://crates.io/crates/uuid)
 [![Join the chat at https://gitter.im/uuid-rs/Lobby](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/uuid-rs/Lobby?utm_source=badge&utm_medium=badge&utm_content=badge)
-![Minimum rustc version](https://img.shields.io/badge/rustc-1.31.0+-yellow.svg)
+![Minimum rustc version](https://img.shields.io/badge/rustc-1.34.0+-yellow.svg)
 [![Build Status](https://ci.appveyor.com/api/projects/status/github/uuid-rs/uuid?branch=master&svg=true)](https://ci.appveyor.com/project/uuid-rs/uuid/branch/master)
 [![Build Status](https://travis-ci.org/uuid-rs/uuid.svg?branch=master)](https://travis-ci.org/uuid-rs/uuid)
 [![Average time to resolve an issue](https://isitmaintained.com/badge/resolution/uuid-rs/uuid.svg)](https://isitmaintained.com/project/uuid-rs/uuid "Average time to resolve an issue")

--- a/README.tpl
+++ b/README.tpl
@@ -3,7 +3,7 @@
 
 [![Latest Version](https://img.shields.io/crates/v/uuid.svg)](https://crates.io/crates/uuid)
 [![Join the chat at https://gitter.im/uuid-rs/Lobby](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/uuid-rs/Lobby?utm_source=badge&utm_medium=badge&utm_content=badge)
-![Minimum rustc version](https://img.shields.io/badge/rustc-1.31.0+-yellow.svg)
+![Minimum rustc version](https://img.shields.io/badge/rustc-1.34.0+-yellow.svg)
 {{badges}}
 
 ---


### PR DESCRIPTION
<!--
    If this PR is a breaking change, ensure that you are opening it against 
    the `breaking` branch.  If the pull request is incomplete, prepend the Title with WIP: 
-->

**I'm submitting a(n)** other


# Description

Update getrandom to v0.2.0.

This raises the MSRV to getrandom's, 1.34.0.

# Motivation

Use the latest version of upstream.

# Tests

N/A

# Related Issue(s)

- #475: It'd be great to have a new release that uses `getrandom` instead of `rand`, especially since a new version of `rand` is out as well. (NB: the change to `new_v4` from returning `Self` to returning `Result<Self, _>` is, of course, breaking, and will mean releasing the new version as `uuid:0.9`.)
- closes #494: the @dependabot-bot version of this PR. Failing due to not updating the MSRV.