### PR TITLE
Improve deserialization error message

### DIFF
--- a/src/serde_support.rs
+++ b/src/serde_support.rs
@@ -13,7 +13,6 @@ use crate::prelude::*;
 use core::fmt;
 use serde::{de, Deserialize, Deserializer, Serialize, Serializer};
 
-#[cfg(feature = "serde")]
 impl Serialize for Uuid {
     fn serialize<S: Serializer>(
         &self,
@@ -28,7 +27,6 @@ impl Serialize for Uuid {
     }
 }
 
-#[cfg(feature = "serde")]
 impl<'de> Deserialize<'de> for Uuid {
     fn deserialize<D: Deserializer<'de>>(
         deserializer: D,
@@ -88,7 +86,7 @@ impl<'de> Deserialize<'de> for Uuid {
     }
 }
 
-#[cfg(all(test, feature = "serde"))]
+#[cfg(test)]
 mod serde_tests {
     use serde_test;
 

--- a/src/serde_support.rs
+++ b/src/serde_support.rs
@@ -31,6 +31,10 @@ impl<'de> Deserialize<'de> for Uuid {
     fn deserialize<D: Deserializer<'de>>(
         deserializer: D,
     ) -> Result<Self, D::Error> {
+        fn de_error<E: de::Error>(e: crate::Error) -> E {
+            E::custom(format_args!("UUID parsing failed: {}", e))
+        }
+
         if deserializer.is_human_readable() {
             struct UuidStringVisitor;
 
@@ -48,14 +52,14 @@ impl<'de> Deserialize<'de> for Uuid {
                     self,
                     value: &str,
                 ) -> Result<Uuid, E> {
-                    value.parse::<Uuid>().map_err(E::custom)
+                    value.parse::<Uuid>().map_err(de_error)
                 }
 
                 fn visit_bytes<E: de::Error>(
                     self,
                     value: &[u8],
                 ) -> Result<Uuid, E> {
-                    Uuid::from_slice(value).map_err(E::custom)
+                    Uuid::from_slice(value).map_err(de_error)
                 }
             }
 
@@ -77,7 +81,7 @@ impl<'de> Deserialize<'de> for Uuid {
                     self,
                     value: &[u8],
                 ) -> Result<Uuid, E> {
-                    Uuid::from_slice(value).map_err(E::custom)
+                    Uuid::from_slice(value).map_err(de_error)
                 }
             }
 
@@ -88,31 +92,34 @@ impl<'de> Deserialize<'de> for Uuid {
 
 #[cfg(test)]
 mod serde_tests {
-    use serde_test;
+    use serde_test::{Compact, Configure, Readable, Token};
 
     use crate::prelude::*;
 
     #[test]
     fn test_serialize_readable() {
-        use serde_test::Configure;
-
         let uuid_str = "f9168c5e-ceb2-4faa-b6bf-329bf39fa1e4";
         let u = Uuid::parse_str(uuid_str).unwrap();
-        serde_test::assert_tokens(
-            &u.readable(),
-            &[serde_test::Token::Str(uuid_str)],
-        );
+        serde_test::assert_tokens(&u.readable(), &[Token::Str(uuid_str)]);
     }
 
     #[test]
     fn test_serialize_compact() {
-        use serde_test::Configure;
-
         let uuid_bytes = b"F9168C5E-CEB2-4F";
         let u = Uuid::from_slice(uuid_bytes).unwrap();
-        serde_test::assert_tokens(
-            &u.compact(),
-            &[serde_test::Token::Bytes(uuid_bytes)],
+        serde_test::assert_tokens(&u.compact(), &[Token::Bytes(uuid_bytes)]);
+    }
+
+    #[test]
+    fn test_de_failure() {
+        serde_test::assert_de_tokens_error::<Readable<Uuid>>(
+            &[Token::Str("hello_world")],
+            "UUID parsing failed: invalid length: expected one of [36, 32], found 11",
+        );
+
+        serde_test::assert_de_tokens_error::<Compact<Uuid>>(
+            &[Token::Bytes(b"hello_world")],
+            "UUID parsing failed: invalid bytes length: expected 16, found 11",
         );
     }
 }


### PR DESCRIPTION
**I'm submitting a** refactor

# Description

Improves the deserialization error message by including that a UUID was attempted to be parsed.

Before: `invalid length: expected one of [36, 32], found 11`
After: `UUID parsing failed: invalid length: expected one of [36, 32], found 11`

# Motivation

It was not easy to tell from the previous error message what went wrong when trying to deserialize a larger object containing a UUID.

# Tests

I added a unit test.

# Related Issue(s)

Closes #499