### PR TITLE
Use TryInto to avoid unsafe.

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,7 +198,7 @@ mod v5;
 #[cfg(all(windows, feature = "winapi"))]
 mod winapi_support;
 
-use crate::std::{convert::TryInto, fmt, str};
+use crate::std::{convert, fmt, str};
 
 pub use crate::error::Error;
 
@@ -390,7 +390,8 @@ impl Uuid {
         let d3 =
             u16::from(self.as_bytes()[6]) << 8 | u16::from(self.as_bytes()[7]);
 
-        let d4: &[u8; 8] = self.as_bytes()[8..16].try_into().unwrap();
+        let d4: &[u8; 8] =
+            convert::TryInto::try_into(&self.as_bytes()[8..16]).unwrap();
         (d1, d2, d3, d4)
     }
 
@@ -430,7 +431,8 @@ impl Uuid {
         let d3 =
             u16::from(self.as_bytes()[6]) | u16::from(self.as_bytes()[7]) << 8;
 
-        let d4: &[u8; 8] = self.as_bytes()[8..16].try_into().unwrap();
+        let d4: &[u8; 8] =
+            convert::TryInto::try_into(&self.as_bytes()[8..16]).unwrap();
         (d1, d2, d3, d4)
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -198,7 +198,7 @@ mod v5;
 #[cfg(all(windows, feature = "winapi"))]
 mod winapi_support;
 
-use crate::std::{fmt, str};
+use crate::std::{convert::TryInto, fmt, str};
 
 pub use crate::error::Error;
 
@@ -390,8 +390,7 @@ impl Uuid {
         let d3 =
             u16::from(self.as_bytes()[6]) << 8 | u16::from(self.as_bytes()[7]);
 
-        let d4: &[u8; 8] =
-            unsafe { &*(self.as_bytes()[8..16].as_ptr() as *const [u8; 8]) };
+        let d4: &[u8; 8] = self.as_bytes()[8..16].try_into().unwrap();
         (d1, d2, d3, d4)
     }
 
@@ -431,8 +430,7 @@ impl Uuid {
         let d3 =
             u16::from(self.as_bytes()[6]) | u16::from(self.as_bytes()[7]) << 8;
 
-        let d4: &[u8; 8] =
-            unsafe { &*(self.as_bytes()[8..16].as_ptr() as *const [u8; 8]) };
+        let d4: &[u8; 8] = self.as_bytes()[8..16].try_into().unwrap();
         (d1, d2, d3, d4)
     }
 


### PR DESCRIPTION
<!--
    If this PR is a breaking change, ensure that you are opening it against 
    the `breaking` branch.  If the pull request is incomplete, prepend the Title with WIP: 
-->

**I'm submitting a(n)** refactor

# Description

Previously, to_fields and to_fields_le used unsafe to convert a &[u8] into a &[u8; 8]. Now that we're only supporting Rust versions where TryInto is stable, we can use try_into().unwrap() instead, making uuid entirely safe Rust.

In release mode, the compiler detects that the slice will always be the correct size, so try_into can never fail. Thus, the unwrap
is optimized out and we end up with the exact same assembly as the unsafe block.

Godbolt output showing the resulting assembly: https://godbolt.org/z/nWxT6W

# Motivation

Makes UUID entirely safe Rust.

With this PR,

# Tests

All existing tests pass. Doesn't add any new functionality, so that should be sufficient. Assuming the Godbolt test is consistent with what happens in the context of the larger crate, this shouldn't change the resulting binary at all.

# Related Issue(s)

Closes #488.
