### PR TITLE
Allow access of inner Uuid for adapters

### DIFF
--- a/src/adapter/mod.rs
+++ b/src/adapter/mod.rs
@@ -1001,14 +1001,14 @@ macro_rules! impl_adapter_from {
 
         impl<$a> AsRef<Uuid> for $T<$a> {
             #[inline]
-            fn as_ref(&self) -> &$a Uuid {
+            fn as_ref(&self) -> &Uuid {
                 self.0
             }
         }
 
         impl<$a> Borrow<Uuid> for $T<$a> {
             #[inline]
-            fn borrow(&self) -> &$a Uuid {
+            fn borrow(&self) -> &Uuid {
                 self.0
             }
         }


### PR DESCRIPTION
**I'm submitting a** feature.


# Description
Trait implementations on the adapters:
* `From<Adapter> for Uuid`
* `AsRef<Uuid> for Adapter`
* `Borrow<Uuid> for Adapter`

An `Adapter::into_inner` method that takes self and returns a `Uuid`.

# Motivation
Open issue #482

# Tests
All tests pass.

# Related Issue(s)
Closes #482