### PR TITLE
Allow v3, v4, v5 features on wasm32-unknown-unknown

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ optional = true
 version = "0.2.0"
 
 [dependencies.md5]
+default-features = false
 optional = true
 version = "0.7"
 
@@ -68,6 +69,7 @@ optional = true
 version = "1.0.56"
 
 [dependencies.sha1]
+default-features = false
 optional = true
 version = "0.6"
 

--- a/README.md
+++ b/README.md
@@ -46,13 +46,16 @@ various pieces of functionality:
 * `serde` - adds the ability to serialize and deserialize a `Uuid` using the
   `serde` crate.
 
-You need to enable one of the following Cargo features together with
-`v3`, `v4` or `v5` feature if you're targeting `wasm32-unknown-unknown` target:
+You need to enable one of the following Cargo features together with the
+`v4` feature if you're targeting `wasm32-unknown-unknown` target:
 
 * `stdweb` - enables support for `OsRng` on `wasm32-unknown-unknown` via
   `stdweb` combined with `cargo-web`
 * `wasm-bindgen` - `wasm-bindgen` enables support for `OsRng` on
   `wasm32-unknown-unknown` via [`wasm-bindgen`]
+
+Alternatively, you can provide a custom `getrandom` implementation yourself
+via [`getrandom::register_custom_getrandom`](https://docs.rs/getrandom/0.2.2/getrandom/macro.register_custom_getrandom.html).
 
 By default, `uuid` can be depended on with:
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -156,41 +156,11 @@ mod serde_support;
 mod slog_support;
 #[cfg(test)]
 mod test_util;
-#[cfg(all(
-    feature = "v3",
-    any(
-        not(target_arch = "wasm32"),
-        target_os = "wasi",
-        all(
-            target_arch = "wasm32",
-            any(feature = "stdweb", feature = "wasm-bindgen")
-        )
-    )
-))]
+#[cfg(feature = "v3")]
 mod v3;
-#[cfg(all(
-    feature = "v4",
-    any(
-        not(target_arch = "wasm32"),
-        target_os = "wasi",
-        all(
-            target_arch = "wasm32",
-            any(feature = "stdweb", feature = "wasm-bindgen")
-        )
-    )
-))]
+#[cfg(feature = "v4")]
 mod v4;
-#[cfg(all(
-    feature = "v5",
-    any(
-        not(target_arch = "wasm32"),
-        target_os = "wasi",
-        all(
-            target_arch = "wasm32",
-            any(feature = "stdweb", feature = "wasm-bindgen")
-        )
-    )
-))]
+#[cfg(feature = "v5")]
 mod v5;
 #[cfg(all(windows, feature = "winapi"))]
 mod winapi_support;


### PR DESCRIPTION
I'm submitting a feature

# Description
The v3, v4, v5 features did not work on `wasm32-unknown-unknown` in a no_std context.

For v3 and v5, the `md5` and `sha1` crates are no_std if their default features are disabled, so they work on `wasm32-unknown-unknown`.

For v4, `getrandom` can work on any architecture if the root crate registers a custom implementation.

This is not a breaking change, as the other architectures (including `stdweb` and `wasm-bindgen`) are not impacted.

 
# Motivation
I wanted to use this crate (especially the v4 feature) on a `wasm32-unknown-unknown` context that does not have `stdweb` nor `wasm-bindgen`.


# Tests
The test suite unfortunately does not run on `wasm32-unknown-unknown`.
The v3, v4, v5 features work properly, as I was able to use them from a dependent crate.
