### PR TITLE
Added support for converting u64 pair into UUID and back

### DIFF
--- a/src/builder/mod.rs
+++ b/src/builder/mod.rs
@@ -204,7 +204,24 @@ impl Uuid {
 
     /// Creates a UUID from two 64bit values in big-endian order.
     pub const fn from_u64_pair(high_bits: u64, low_bits: u64) -> Self {
-        Uuid::from_u128((high_bits as u128) << 64 | (low_bits as u128))
+        Uuid::from_bytes([
+            (high_bits >> 56) as u8,
+            (high_bits >> 48) as u8,
+            (high_bits >> 40) as u8,
+            (high_bits >> 32) as u8,
+            (high_bits >> 24) as u8,
+            (high_bits >> 16) as u8,
+            (high_bits >> 8) as u8,
+            high_bits as u8,
+            (low_bits >> 56) as u8,
+            (low_bits >> 48) as u8,
+            (low_bits >> 40) as u8,
+            (low_bits >> 32) as u8,
+            (low_bits >> 24) as u8,
+            (low_bits >> 16) as u8,
+            (low_bits >> 8) as u8,
+            low_bits as u8,
+        ])
     }
 
     /// Creates a UUID using the supplied big-endian bytes.

--- a/src/builder/mod.rs
+++ b/src/builder/mod.rs
@@ -202,6 +202,11 @@ impl Uuid {
         ])
     }
 
+    /// Creates a UUID from two 64bit values in big-endian order.
+    pub const fn from_u64_pair(high_bits: u64, low_bits: u64) -> Self {
+        Uuid::from_u128((high_bits as u128) << 64 | (low_bits as u128))
+    }
+
     /// Creates a UUID using the supplied big-endian bytes.
     ///
     /// # Errors

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -512,6 +512,32 @@ impl Uuid {
             | u128::from(self.as_bytes()[15]) << 120
     }
 
+    /// Returns two 64bit values containing the UUID data.
+    ///
+    /// The bytes in the UUID will be split into two `u64`.
+    /// The first u64 represents the 64 most significant bits,
+    /// the second one represents the 64 least significant.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use uuid::Uuid;
+    ///
+    /// fn main() -> Result<(), uuid::Error> {
+    ///     let uuid = Uuid::parse_str("936DA01F-9ABD-4D9D-80C7-02AF85C822A8")?;
+    ///     assert_eq!(
+    ///         uuid.as_u64_pair(),
+    ///         (0x936DA01F9ABD4D9D,
+    ///         0x80C702AF85C822A8),
+    ///     );
+    ///     Ok(())
+    /// }
+    /// ```
+    pub fn as_u64_pair(&self) -> (u64, u64) {
+        let value = self.as_u128();
+        ((value >> 64) as u64, value as u64)
+    }
+
     /// Returns an array of 16 octets containing the UUID data.
     pub const fn as_bytes(&self) -> &Bytes {
         &self.0
@@ -986,6 +1012,18 @@ mod tests {
     }
 
     #[test]
+    fn test_from_u64_pair() {
+        let high_in: u64 = 0xa1a2a3a4b1b2c1c2;
+        let low_in: u64 = 0xd1d2d3d4d5d6d7d8;
+
+        let u = Uuid::from_u64_pair(high_in, low_in);
+
+        let expected = "a1a2a3a4b1b2c1c2d1d2d3d4d5d6d7d8";
+        let result = u.to_simple().to_string();
+        assert_eq!(result, expected);
+    }
+
+    #[test]
     fn test_u128_roundtrip() {
         let v_in: u128 = 0xa1a2a3a4b1b2c1c2d1d2d3d4d5d6d7d8;
 
@@ -1003,6 +1041,18 @@ mod tests {
         let v_out = u.to_u128_le();
 
         assert_eq!(v_in, v_out);
+    }
+
+    #[test]
+    fn test_u64_pair_roundtrip() {
+        let high_in: u64 = 0xa1a2a3a4b1b2c1c2;
+        let low_in: u64 = 0xd1d2d3d4d5d6d7d8;
+
+        let u = Uuid::from_u64_pair(high_in, low_in);
+        let (high_out, low_out) = u.as_u64_pair();
+
+        assert_eq!(high_in, high_out);
+        assert_eq!(low_in, low_out);
     }
 
     #[test]


### PR DESCRIPTION
This PR resolves #517 by adding two methods:
`Uuid::from_u64_pair(high_bits, low_bits) -> Uuid`: Creates a UUID from two u64, the first being the MSBs, and the second, the LSBs.
`Uuid::as_u64_pair(&self) -> (u64, u64)`: Returns a pair of u64, the first being the MSBs, and the second, the LSBs.