### PR TITLE
Update Uuid::new_v4 documentation to reflect `Try` no longer being implemented

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -92,12 +92,11 @@
 //!
 //! use uuid::Uuid;
 //!
-//! fn main() -> Result<(), Box<dyn std::error::Error>> {
-//!     #[cfg(feature = "v4")] {
-//!         let my_uuid = Uuid::new_v4()?;
-//!         println!("{}", my_uuid);
-//!     }
-//!     Ok(())
+//! fn main() {
+//! #    #[cfg(feature = "v4")] {
+//!      let my_uuid = Uuid::new_v4();
+//!      println!("{}", my_uuid);
+//! #    }
 //! }
 //! ```
 //!

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -87,7 +87,7 @@
 //!
 //! To create a new random (V4) UUID and print it out in hexadecimal form:
 //!
-//! ```ignore,rust
+//! ```rust
 //! // Note that this requires the `v4` feature enabled in the uuid crate.
 //!
 //! use uuid::Uuid;
@@ -95,7 +95,7 @@
 //! fn main() {
 //! #    #[cfg(feature = "v4")] {
 //!      let my_uuid = Uuid::new_v4();
-//!      println!("{}", my_uuid);
+//!      println!("{}", my_uuid)
 //! #    }
 //! }
 //! ```


### PR DESCRIPTION
<!--
    If this PR is a breaking change, ensure that you are opening it against 
    the `breaking` branch.  If the pull request is incomplete, prepend the Title with WIP: 
-->

**I'm submitting a(n)** other (documentation fix)


# Description
The current example at https://docs.rs/uuid/0.8.2/uuid/index.html#examples to generate a UUIDV4 currently does not compile, given that `Uuid` no longer implements `Try`.

This PR updates the example to match the one given in the README of this repo, along with enabling testing for it again to ensure it doesn't go out of date. I've run `cargo test --all-features` to ensure that the tests do indeed pass.

Finally, we also hide the configuration flags, `#[cfg(feature = "v4")]`, from the example, since it should not be copied by the user of the crate, if they wanted to use the example.

# Motivation
I was looking to generate a UUID V4 and unfortunately the examples in https://docs.rs/uuid/0.8.2/uuid/index.html#examples were out-of-date.

# Tests
<!-- How are these changes tested? -->
This enables the doc-test that was already there, which now compiles after updating the code in the example.

# Related Issue(s)
None that I'm aware of