### PR TITLE
add more ci for wasm and embedded targets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   os_tests:
-    name: "Tests/OS: ${{ matrix.os }} - ${{ matrix.channel }}-${{ matrix.rust_target }}"
+    name: "Tests / OS: ${{ matrix.os }} - ${{ matrix.channel }}-${{ matrix.rust_target }}"
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
@@ -29,7 +29,6 @@ jobs:
         - stable
         - beta
         - nightly
-        - 1.34.0
         os:
         - macos-10.15
         - windows-2019
@@ -50,110 +49,89 @@ jobs:
         profile: minimal
         toolchain: ${{ matrix.channel }}-${{ matrix.rust_target }}
 
-    - name: Build with --no-default-features 
-      uses: actions-rs/cargo@v1
+    - name: Install cargo-hack
+      run: cargo install cargo-hack
+
+    - name: Powerset
+      run: cargo hack test --feature-powerset --lib --optional-deps serde --depth 3
+
+    - name: Docs
+      run: cargo test --all-features --doc
+
+  msrv:
+    name: "Tests / MSRV / OS: ${{ matrix.os }}"
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os:
+        - macos-10.15
+        - windows-2019
+        - ubuntu-20.04
+
+    steps:
+    - name: Checkout sources
+      uses: actions/checkout@v2
+
+    - name: Install Rust toolchain
+      uses: actions-rs/toolchain@v1
       with:
-        command: build
-        args: --no-default-features
-    - name: Test with --no-default-features 
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --no-default-features
-    
-    - name: Build with --all-features 
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
-        args: --all-features
-    - name: Test with --all-features 
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --all-features
-    
-    - name: Build with default features 
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
-    - name: Test with default features 
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-    
-    - name: Build with --features guid
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
-        args: --features guid
-    - name: Test with --features guid 
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --features guid
-    
-    - name: Build with --features serde
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
-        args: --features serde
-    - name: Test with --features serde 
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --features serde
-    
-    - name: Build with --features slog
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
-        args: --features slog
-    - name: Test with --features slog 
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --features slog
+        profile: minimal
+        toolchain: 1.46.0
+        override: true
+
+    - name: Default features
+      run: cargo test --features "v1 v3 v4 v5 serde"
+
+  wasm:
+    name: Tests / WebAssembly
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install
+        run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
       
-    - name: Build with --features v1
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
-        args: --features v1
-    - name: Test with --features serde 
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --features v1
-    
-    - name: Build with --features v3
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
-        args: --features v3
-    - name: Test with --features v3 
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --features v3
-    
-    - name: Build with --features v4
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
-        args: --features v4
-    - name: Test with --features v4 
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --features v4
-    
-    - name: Build with --features v5
-      uses: actions-rs/cargo@v1
-      with:
-        command: build
-        args: --features v5
-    - name: Test with --features v5 
-      uses: actions-rs/cargo@v1
-      with:
-        command: test
-        args: --features v5
+      - name: Default features
+        run: wasm-pack test --node -- --features "wasm-bindgen v1 v3 v4 v5"
+
+  embedded:
+    name: Build / Embedded
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          target: thumbv6m-none-eabi
+          override: true
+
+      - name: Default features
+        uses: actions-rs/cargo@v1
+        with:
+          command: build
+          args: -Z avoid-dev-deps --target thumbv6m-none-eabi --no-default-features
+
+  nodeps:
+    name: Build / No deps
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+
+      - name: Install Rust toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: nightly
+          override: true
+
+      - name: Install cargo-hack
+        run: cargo install cargo-hack
+
+      - name: Powerset
+        run: cargo hack check --feature-powerset -Z avoid-dev-deps

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,9 +39,6 @@ default-target = "x86_64-pc-windows-msvc"
 [package.metadata.playground]
 features = ["serde", "v1", "v3", "v4", "v5"]
 
-[badges.appveyor]
-repository = "uuid-rs/uuid"
-
 [badges.is-it-maintained-issue-resolution]
 repository = "uuid-rs/uuid"
 
@@ -88,6 +85,13 @@ version = "1.0"
 
 [dev-dependencies.serde_test]
 version = "1.0.56"
+
+[dev-dependencies.wasm-bindgen-lib]
+package = "wasm-bindgen"
+version = "0.2"
+
+[dev-dependencies.wasm-bindgen-test]
+version = "0.3"
 
 [features]
 default = ["std"]

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ uuid
 
 [![Latest Version](https://img.shields.io/crates/v/uuid.svg)](https://crates.io/crates/uuid)
 [![Join the chat at https://gitter.im/uuid-rs/Lobby](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/uuid-rs/Lobby?utm_source=badge&utm_medium=badge&utm_content=badge)
-![Minimum rustc version](https://img.shields.io/badge/rustc-1.34.0+-yellow.svg)
+![Minimum rustc version](https://img.shields.io/badge/rustc-1.46.0+-yellow.svg)
 [![Build Status](https://ci.appveyor.com/api/projects/status/github/uuid-rs/uuid?branch=master&svg=true)](https://ci.appveyor.com/project/uuid-rs/uuid/branch/master)
 [![Build Status](https://travis-ci.org/uuid-rs/uuid.svg?branch=master)](https://travis-ci.org/uuid-rs/uuid)
 [![Average time to resolve an issue](https://isitmaintained.com/badge/resolution/uuid-rs/uuid.svg)](https://isitmaintained.com/project/uuid-rs/uuid "Average time to resolve an issue")

--- a/src/adapter/compact.rs
+++ b/src/adapter/compact.rs
@@ -27,7 +27,6 @@ where
 
 #[cfg(test)]
 mod tests {
-
     use serde_test;
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -615,6 +615,9 @@ mod tests {
         test_util,
     };
 
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::*;
+
     macro_rules! check {
         ($buf:ident, $format:expr, $target:expr, $len:expr, $cond:expr) => {
             $buf.clear();
@@ -625,6 +628,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_uuid_compare() {
         let uuid1 = test_util::new();
         let uuid2 = test_util::new2();
@@ -637,6 +641,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_uuid_default() {
         let default_uuid = Uuid::default();
         let nil_uuid = Uuid::nil();
@@ -645,6 +650,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_uuid_display() {
         use super::fmt::Write;
 
@@ -660,6 +666,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_uuid_lowerhex() {
         use super::fmt::Write;
 
@@ -673,6 +680,7 @@ mod tests {
 
     // noinspection RsAssertEqual
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_uuid_operator_eq() {
         let uuid1 = test_util::new();
         let uuid1_dup = uuid1.clone();
@@ -689,6 +697,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_uuid_to_string() {
         use super::fmt::Write;
 
@@ -704,6 +713,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_uuid_upperhex() {
         use super::fmt::Write;
 
@@ -716,6 +726,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_nil() {
         let nil = Uuid::nil();
         let not_nil = test_util::new();
@@ -733,6 +744,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_predefined_namespaces() {
         assert_eq!(
             Uuid::NAMESPACE_DNS.to_hyphenated().to_string(),
@@ -754,6 +766,7 @@ mod tests {
 
     #[cfg(feature = "v3")]
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_get_version_v3() {
         let uuid =
             Uuid::new_v3(&Uuid::NAMESPACE_DNS, "rust-lang.org".as_bytes());
@@ -763,6 +776,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_get_variant() {
         let uuid1 = test_util::new();
         let uuid2 =
@@ -785,6 +799,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_to_simple_string() {
         let uuid1 = test_util::new();
         let s = uuid1.to_simple().to_string();
@@ -794,6 +809,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_to_hyphenated_string() {
         let uuid1 = test_util::new();
         let s = uuid1.to_hyphenated().to_string();
@@ -803,6 +819,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_upper_lower_hex() {
         use std::fmt::Write;
 
@@ -835,6 +852,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_to_urn_string() {
         let uuid1 = test_util::new();
         let ss = uuid1.to_urn().to_string();
@@ -846,6 +864,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_to_simple_string_matching() {
         let uuid1 = test_util::new();
 
@@ -858,6 +877,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_string_roundtrip() {
         let uuid = test_util::new();
 
@@ -871,6 +891,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_from_fields() {
         let d1: u32 = 0xa1a2a3a4;
         let d2: u16 = 0xb1b2;
@@ -885,6 +906,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_from_fields_le() {
         let d1: u32 = 0xa4a3a2a1;
         let d2: u16 = 0xb2b1;
@@ -899,6 +921,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_as_fields() {
         let u = test_util::new();
         let (d1, d2, d3, d4) = u.as_fields();
@@ -911,6 +934,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_fields_roundtrip() {
         let d1_in: u32 = 0xa1a2a3a4;
         let d2_in: u16 = 0xb1b2;
@@ -927,6 +951,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_fields_le_roundtrip() {
         let d1_in: u32 = 0xa4a3a2a1;
         let d2_in: u16 = 0xb2b1;
@@ -943,6 +968,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_fields_le_are_actually_le() {
         let d1_in: u32 = 0xa1a2a3a4;
         let d2_in: u16 = 0xb1b2;
@@ -959,6 +985,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_from_u128() {
         let v_in: u128 = 0xa1a2a3a4b1b2c1c2d1d2d3d4d5d6d7d8;
 
@@ -970,6 +997,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_from_u128_le() {
         let v_in: u128 = 0xd8d7d6d5d4d3d2d1c2c1b2b1a4a3a2a1;
 
@@ -981,6 +1009,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_from_u64_pair() {
         let high_in: u64 = 0xa1a2a3a4b1b2c1c2;
         let low_in: u64 = 0xd1d2d3d4d5d6d7d8;
@@ -993,6 +1022,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_u128_roundtrip() {
         let v_in: u128 = 0xa1a2a3a4b1b2c1c2d1d2d3d4d5d6d7d8;
 
@@ -1003,6 +1033,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_u128_le_roundtrip() {
         let v_in: u128 = 0xd8d7d6d5d4d3d2d1c2c1b2b1a4a3a2a1;
 
@@ -1013,6 +1044,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_u64_pair_roundtrip() {
         let high_in: u64 = 0xa1a2a3a4b1b2c1c2;
         let low_in: u64 = 0xd1d2d3d4d5d6d7d8;
@@ -1025,6 +1057,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_u128_le_is_actually_le() {
         let v_in: u128 = 0xa1a2a3a4b1b2c1c2d1d2d3d4d5d6d7d8;
 
@@ -1035,6 +1068,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_from_slice() {
         let b = [
             0xa1, 0xa2, 0xa3, 0xa4, 0xb1, 0xb2, 0xc1, 0xc2, 0xd1, 0xd2, 0xd3,
@@ -1048,6 +1082,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_from_bytes() {
         let b = [
             0xa1, 0xa2, 0xa3, 0xa4, 0xb1, 0xb2, 0xc1, 0xc2, 0xd1, 0xd2, 0xd3,
@@ -1061,6 +1096,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_as_bytes() {
         let u = test_util::new();
         let ub = u.as_bytes();
@@ -1073,6 +1109,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_bytes_roundtrip() {
         let b_in: crate::Bytes = [
             0xa1, 0xa2, 0xa3, 0xa4, 0xb1, 0xb2, 0xc1, 0xc2, 0xd1, 0xd2, 0xd3,
@@ -1087,6 +1124,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_iterbytes_impl_for_uuid() {
         let mut set = std::collections::HashSet::new();
         let id1 = test_util::new();

--- a/src/v1.rs
+++ b/src/v1.rs
@@ -280,9 +280,13 @@ impl ClockSequence for Context {
 mod tests {
     use super::*;
 
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::*;
+
     use crate::std::string::ToString;
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_new_v1() {
         let time: u64 = 1_496_854_535;
         let time_fraction: u32 = 812_946_000;

--- a/src/v3.rs
+++ b/src/v3.rs
@@ -42,6 +42,9 @@ impl Uuid {
 mod tests {
     use super::*;
 
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::*;
+
     use crate::std::string::ToString;
 
     static FIXTURE: &'static [(&'static Uuid, &'static str, &'static str)] = &[
@@ -128,6 +131,7 @@ mod tests {
     ];
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_new() {
         for &(ref ns, ref name, _) in FIXTURE {
             let uuid = Uuid::new_v3(*ns, name.as_bytes());
@@ -137,6 +141,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_to_hyphenated_string() {
         for &(ref ns, ref name, ref expected) in FIXTURE {
             let uuid = Uuid::new_v3(*ns, name.as_bytes());

--- a/src/v4.rs
+++ b/src/v4.rs
@@ -42,7 +42,11 @@ impl Uuid {
 mod tests {
     use crate::prelude::*;
 
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::*;
+
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_new() {
         let uuid = Uuid::new_v4();
 
@@ -51,6 +55,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_get_version() {
         let uuid = Uuid::new_v4();
 

--- a/src/v5.rs
+++ b/src/v5.rs
@@ -42,6 +42,9 @@ impl Uuid {
 mod tests {
     use super::*;
 
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::*;
+
     use crate::std::string::ToString;
 
     static FIXTURE: &'static [(&'static Uuid, &'static str, &'static str)] = &[
@@ -128,6 +131,7 @@ mod tests {
     ];
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_get_version() {
         let uuid =
             Uuid::new_v5(&Uuid::NAMESPACE_DNS, "rust-lang.org".as_bytes());
@@ -137,6 +141,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_hyphenated() {
         for &(ref ns, ref name, ref expected) in FIXTURE {
             let uuid = Uuid::new_v5(*ns, name.as_bytes());
@@ -146,6 +151,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_new() {
         for &(ref ns, ref name, ref u) in FIXTURE {
             let uuid = Uuid::new_v5(*ns, name.as_bytes());


### PR DESCRIPTION
This PR does some more work on our CI to explicitly test wasm through Node and that we build for a proper no-std target. It also uses `cargo-hack` instead of manually listing out feature combinations to test.