### PR TITLE
check more features in no-std

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,7 +114,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: -Z avoid-dev-deps --target thumbv6m-none-eabi --no-default-features
+          args: -Z avoid-dev-deps --target thumbv6m-none-eabi --no-default-features --features "v1 v3 v5 serde"
 
   nodeps:
     name: Build / No deps

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,7 @@ optional = true
 version = "0.2"
 
 [dependencies.atomic]
+default-features = false
 optional = true
 version = "0.5"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -53,7 +53,11 @@ repository = "uuid-rs/uuid"
 
 [dependencies.getrandom]
 optional = true
-version = "0.2.0"
+version = "0.2"
+
+[dependencies.atomic]
+optional = true
+version = "0.5"
 
 [dependencies.md-5]
 default-features = false
@@ -98,7 +102,7 @@ default = ["std"]
 guid = ["winapi"]
 std = []
 stdweb = ["getrandom", "getrandom/js"]
-v1 = []
+v1 = ["atomic"]
 v3 = ["md-5"]
 v4 = ["getrandom"]
 v5 = ["sha-1"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,12 +43,6 @@
 //! * `serde` - adds the ability to serialize and deserialize a UUID using the
 //!   `serde` crate.
 //!
-//! For WebAssembly, enable one of the following features depending
-//! on your JavaScript interop toolchain of choice:
-//!
-//! * `stdweb` - for [`stdweb`] combined with [`cargo-web`]
-//! * `wasm-bindgen` - for [`wasm-bindgen`]
-//!
 //! By default, `uuid` can be depended on with:
 //!
 //! ```toml
@@ -69,6 +63,35 @@
 //! [dependencies]
 //! uuid = { version = "0.8", default-features = false }
 //! ```
+//!
+//! # Building for other targets
+//!
+//! ## WebAssembly
+//!
+//! For WebAssembly, enable one of the following features depending
+//! on your JavaScript interop toolchain of choice:
+//!
+//! * `stdweb` - for [`stdweb`] combined with [`cargo-web`]
+//! * `wasm-bindgen` - for [`wasm-bindgen`]
+//!
+//! ## Embedded
+//!
+//! For embedded targets without the standard library, you'll need to
+//! disable default features when building `uuid`:
+//!
+//! ```toml
+//! [dependencies]
+//! uuid = { version = "0.8", default-features = false }
+//! ```
+//!
+//! Some additional features are supported in no-std environments:
+//!
+//! * `v1`, `v3`, and `v5`
+//! * `serde`
+//!
+//! If you need to use `v4` in a no-std environment, you'll need to
+//! follow [`getrandom`'s docs] on configuring a source of randomness
+//! on unsupported targets.
 //!
 //! # Examples
 //!
@@ -143,6 +166,7 @@
 //! [`Uuid::new_v5`]: struct.Uuid.html#method.new_v5
 //! [`v1::ClockSequence`]: v1/trait.ClockSequence.html
 //! [`v1::Context`]: v1/struct.Context.html
+//! [`getrandom`'s docs]: https://docs.rs/getrandom
 
 #![no_std]
 #![deny(missing_debug_implementations, missing_docs)]

--- a/src/v1.rs
+++ b/src/v1.rs
@@ -3,7 +3,7 @@
 //! Note that you need feature `v1` in order to use these features.
 
 use crate::prelude::*;
-use core::sync::atomic;
+use atomic::Atomic;
 
 /// The number of 100 ns ticks between the UUID epoch
 /// `1582-10-15 00:00:00` and the Unix epoch `1970-01-01 00:00:00`.
@@ -13,7 +13,7 @@ const UUID_TICKS_BETWEEN_EPOCHS: u64 = 0x01B2_1DD2_1381_4000;
 /// process-wide uniqueness.
 #[derive(Debug)]
 pub struct Context {
-    count: atomic::AtomicUsize,
+    count: Atomic<usize>,
 }
 
 /// Stores the number of nanoseconds from an epoch and a counter for ensuring
@@ -265,7 +265,7 @@ impl Context {
     /// process.
     pub const fn new(count: u16) -> Self {
         Self {
-            count: atomic::AtomicUsize::new(count as usize),
+            count: Atomic::new(count as usize),
         }
     }
 }


### PR DESCRIPTION
For #469

This checks a few more features against a proper no-std target, to make sure we're not accidentally pulling in `std`.

It doesn't currently test `v4`, because it needs an ambient source of randomness. I _think_ that's possible to do with `getrandom`, but we also have other methods for constructing a random UUID without needing the `v4` feature explicitly.