### PR TITLE
Don't flip GUID fields when converting to UUID

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -126,3 +126,7 @@ version = "0.2"
 
 [dev-dependencies.wasm-bindgen-test]
 version = "0.3"
+
+[target.'cfg(windows)'.dev-dependencies.winapi]
+version = "0.3"
+features = ["combaseapi"]

--- a/src/winapi_support.rs
+++ b/src/winapi_support.rs
@@ -4,11 +4,14 @@ use winapi::shared::guiddef;
 
 #[cfg(feature = "guid")]
 impl Uuid {
-    /// Converts a little endian winapi `GUID` into a [`Uuid`]
+    /// Converts a winapi `GUID` into a [`Uuid`]
+    ///
+    /// This method will pass fields unchanged, so they must already
+    /// be in the right endianness for a UUID.
     ///
     /// [`Uuid`]: ../struct.Uuid.html
     pub const fn from_guid(guid: guiddef::GUID) -> Self {
-        Uuid::from_fields_le(
+        Uuid::from_fields(
             guid.Data1 as u32,
             guid.Data2 as u16,
             guid.Data3 as u16,
@@ -16,11 +19,14 @@ impl Uuid {
         )
     }
 
-    /// Converts a [`Uuid`] into a little endian winapi `GUID`
+    /// Converts a [`Uuid`] into a winapi `GUID`
+    ///
+    /// This method will pass fields unchanged, so they must already
+    /// be in the right endianness for a UUID.
     ///
     /// [`Uuid`]: ../struct.Uuid.html
     pub fn to_guid(&self) -> guiddef::GUID {
-        let (data1, data2, data3, data4) = self.to_fields_le();
+        let (data1, data2, data3, data4) = self.as_fields();
 
         guiddef::GUID {
             Data1: data1,
@@ -36,8 +42,36 @@ impl Uuid {
 mod tests {
     use super::*;
 
-    use crate::std::string::ToString;
-    use winapi::shared::guiddef;
+    use crate::{std::string::ToString, Variant, Version};
+    use winapi::{shared::guiddef, um::combaseapi::CoCreateGuid};
+
+    #[test]
+    fn test_parse_guid() {
+        // This example GUID is directly from https://docs.microsoft.com/en-us/windows/win32/api/guiddef/ns-guiddef-guid
+        let uuid = Uuid::parse_str("6B29FC40-CA47-1067-B31D-00DD010662DA").unwrap();
+
+        assert_eq!(Variant::RFC4122, uuid.get_variant());
+        assert_eq!(Some(Version::Mac), uuid.get_version());
+    }
+
+    #[test]
+    fn test_new_native_guid() {
+        let mut guid = guiddef::GUID {
+            Data1: Default::default(),
+            Data2: Default::default(),
+            Data3: Default::default(),
+            Data4: Default::default(),
+        };
+    
+        unsafe {
+            CoCreateGuid(&mut guid as *mut _);
+        }
+    
+        let uuid = Uuid::from_guid(guid);
+    
+        assert_eq!(Variant::RFC4122, uuid.get_variant());
+        assert_eq!(Some(Version::Random), uuid.get_version());
+    }
 
     #[test]
     fn test_from_guid() {
@@ -50,7 +84,7 @@ mod tests {
 
         let uuid = Uuid::from_guid(guid);
         assert_eq!(
-            "9d22354a-2755-304f-8647-9dc54e1ee1e8",
+            "4a35229d-5527-4f30-8647-9dc54e1ee1e8",
             uuid.to_hyphenated().to_string()
         );
     }


### PR DESCRIPTION
Part of #537

In #336 we introduced conversions between Windows GUIDs and UUIDs. These didn't attempt to swap the ordering of the fields in any way. GUID specifies its fields as being in the native endianness (which for Windows is basically always little endian), while UUID requires them to be big endian. So we started flipping those fields coming from GUIDs in #345. Unfortunately, this seems like it was the wrong thing to do. All GUIDs I've been able to find already have the right ordering for UUIDs, so we've just been mangling them and losing the UUID version and variant.

This PR fixes that by removing the endianness conversion. We're going to be pulling this out into a separate crate before stabilizing so we can call out the change there. Anybody who actually does want to flip bytes between GUID and UUID fields can use the `from_fields_le` and `to_fields_le` methods.