### PR TITLE
Prepare for 1.0.0-alpha.1 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,11 +30,10 @@ homepage = "https://github.com/uuid-rs/uuid"
 name = "uuid"
 readme = "README.md"
 repository = "https://github.com/uuid-rs/uuid"
-version = "0.8.1" # remember to update html_root_url in lib.rs
+version = "1.0.0-alpha.1" # remember to update html_root_url in lib.rs
 
 [package.metadata.docs.rs]
-features = [ "serde", "slog", "v1", "v3", "v4", "v5" ]
-default-target = "x86_64-pc-windows-msvc"
+features = ["serde", "arbitrary", "slog", "v1", "v3", "v4", "v5"]
 
 [package.metadata.playground]
 features = ["serde", "v1", "v3", "v4", "v5"]
@@ -54,7 +53,7 @@ repository = "uuid-rs/uuid"
 [features]
 default = ["std"]
 std = []
-macro-diagnostics = ["uuid_macro"]
+macro-diagnostics = ["uuid-macro-internal"]
 
 v1 = ["atomic"]
 v3 = ["md-5"]
@@ -98,7 +97,7 @@ optional = true
 version = "0.9"
 
 # Public: Re-exported
-[dependencies.uuid_macro]
+[dependencies.uuid-macro-internal]
 path = "macros"
 optional = true
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ To get started with generating random UUIDs, add this to your `Cargo.toml`:
 
 ```toml
 [dependencies.uuid]
-version = "0.8"
+version = "1"
 features = ["v4", "fast-rng"]
 ```
 
@@ -113,6 +113,11 @@ flag through your environment to opt-in to unstable `uuid` features:
 RUSTFLAGS="--cfg uuid_unstable"
 ```
 
+## Minimum Supported Rust Version (MSRV)
+
+The minimum supported Rust version for `uuid` is documented in
+CI. It may be bumped in minor releases as necessary.
+
 ## References
 
 * [Wikipedia: Universally Unique Identifier](     http://en.wikipedia.org/wiki/Universally_unique_identifier)
@@ -120,7 +125,7 @@ RUSTFLAGS="--cfg uuid_unstable"
 
 [`wasm-bindgen`]: https://github.com/rustwasm/wasm-bindgen
 
-[`Uuid`]: https://docs.rs/uuid/0.8.1/uuid/struct.Uuid.html
+[`Uuid`]: https://docs.rs/uuid/1.0.0-alpha.1/uuid/struct.Uuid.html
 
 ---
 # License

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,7 +1,18 @@
 [package]
-name = "uuid_macro"
-version = "0.0.0"
+name = "uuid-macro-internal"
+version = "1.0.0-alpha.1"
 edition = "2018"
+authors = [
+    "QnnOkabayashi"
+]
+categories = [
+    "data-structures",
+    "no-std",
+    "parser-implementations",
+    "wasm"
+]
+description = "Private implementation details of the uuid! macro."
+documentation = "https://docs.rs/uuid"
 
 [lib]
 proc-macro = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -35,8 +35,13 @@
 //! Add the following to your `Cargo.toml`:
 //!
 //! ```toml
-//! [dependencies]
-//! uuid = { version = "0.8", features = ["v4"] }
+//! [dependencies.uuid]
+//! version = "1.0.0-alpha.1"
+//! features = [
+//!     "v4",                # Lets you generate random UUIDs
+//!     "fast-rng",          # Use a faster (but still sufficiently random) RNG
+//!     "macro-diagnostics", # Enable better diagnostics for compile-time UUIDs
+//! ]
 //! ```
 //!
 //! When you want a UUID, you can generate one:
@@ -50,6 +55,14 @@
 //! let id = Uuid::new_v4();
 //! # }
 //! # }
+//! ```
+//!
+//! If you have a UUID value you can use it inline:
+//!
+//! ```
+//! use uuid::{uuid, Uuid};
+//!
+//! const ID: Uuid = uuid!("67e55044-10b1-426f-9247-bb680e5fe0c8");
 //! ```
 //!
 //! # Dependencies
@@ -83,21 +96,21 @@
 //!
 //! ```toml
 //! [dependencies]
-//! uuid = "0.8"
+//! uuid = "1"
 //! ```
 //!
 //! To activate various features, use syntax like:
 //!
 //! ```toml
 //! [dependencies]
-//! uuid = { version = "0.8", features = ["serde", "v4", "fast-rng"] }
+//! uuid = { version = "1", features = ["serde", "v4", "fast-rng"] }
 //! ```
 //!
 //! You can disable default features with:
 //!
 //! ```toml
 //! [dependencies]
-//! uuid = { version = "0.8", default-features = false }
+//! uuid = { version = "1", default-features = false }
 //! ```
 //!
 //! ## Unstable features
@@ -127,7 +140,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! uuid = { version = "0.8", features = ["v4", "js"] }
+//! uuid = { version = "1", features = ["v4", "js"] }
 //! ```
 //!
 //! You don't need the `js` feature to use `uuid` in WebAssembly if you're
@@ -140,7 +153,7 @@
 //!
 //! ```toml
 //! [dependencies]
-//! uuid = { version = "0.8", default-features = false }
+//! uuid = { version = "1", default-features = false }
 //! ```
 //!
 //! Some additional features are supported in no-std environments though:
@@ -203,7 +216,7 @@
 #![doc(
     html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
     html_favicon_url = "https://www.rust-lang.org/favicon.ico",
-    html_root_url = "https://docs.rs/uuid/0.8.1"
+    html_root_url = "https://docs.rs/uuid/1.0.0-alpha.1"
 )]
 
 #[cfg(any(feature = "std", test))]
@@ -246,7 +259,7 @@ mod macros;
 
 #[doc(hidden)]
 #[cfg(feature = "macro-diagnostics")]
-pub extern crate uuid_macro;
+pub extern crate uuid_macro_internal;
 
 use crate::std::convert;
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -5,7 +5,7 @@ macro_rules! define_uuid_macro {
         #[macro_export]
         macro_rules! uuid {
             ($uuid:literal) => {{
-                $crate::Uuid::from_bytes($crate::uuid_macro::parse_lit!($uuid))
+                $crate::Uuid::from_bytes($crate::uuid_macro_internal::parse_lit!($uuid))
             }};
         }
 

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -54,8 +54,8 @@ define_uuid_macro! {
 /// Defining a local variable:
 ///
 /// ```
-/// # use uuid::{uuid, Uuid};
-/// let uuid: Uuid = uuid!("urn:uuid:F9168C5E-CEB2-4faa-B6BF-329BF39FA1E4");
+/// # use uuid::uuid;
+/// let uuid = uuid!("urn:uuid:F9168C5E-CEB2-4faa-B6BF-329BF39FA1E4");
 /// ```
 ///
 /// ## Compilation Failures
@@ -63,8 +63,8 @@ define_uuid_macro! {
 /// Invalid UUIDs are rejected:
 ///
 /// ```compile_fail
-/// # use uuid::{uuid, Uuid};
-/// let uuid: Uuid = uuid!("F9168C5E-ZEB2-4FAA-B6BF-329BF39FA1E4");
+/// # use uuid::uuid;
+/// let uuid = uuid!("F9168C5E-ZEB2-4FAA-B6BF-329BF39FA1E4");
 /// ```
 ///
 /// Enable the feature `macro-diagnostics` to see the error messages below.
@@ -74,16 +74,16 @@ define_uuid_macro! {
 /// ```txt
 /// error: invalid character: expected an optional prefix of `urn:uuid:` followed by 0123456789abcdefABCDEF-, found Z at 9
 ///     |
-///     |     let id: Uuid = uuid!("F9168C5E-ZEB2-4FAA-B6BF-329BF39FA1E4");
-///     |                                    ^
+///     |     let id = uuid!("F9168C5E-ZEB2-4FAA-B6BF-329BF39FA1E4");
+///     |                              ^
 /// ```
 ///
 /// Tokens that aren't string literals are also rejected:
 ///
 /// ```compile_fail
-/// # use uuid::{uuid, Uuid};
+/// # use uuid::uuid;
 /// let uuid_str: &str = "550e8400e29b41d4a716446655440000";
-/// let uuid: Uuid = uuid!(uuid_str);
+/// let uuid = uuid!(uuid_str);
 /// ```
 ///
 /// Provides the following compilation error:
@@ -91,8 +91,8 @@ define_uuid_macro! {
 /// ```txt
 /// error: expected string literal
 ///   |
-///   |     let uuid: Uuid = uuid!(uuid_str);
-///   |                            ^^^^^^^^
+///   |     let uuid = uuid!(uuid_str);
+///   |                      ^^^^^^^^
 /// ```
 ///
 /// [uuid::Uuid]: https://docs.rs/uuid/*/uuid/struct.Uuid.html


### PR DESCRIPTION
Part of #113 

This PR gets us ready for an alpha release of `uuid` `1.0` that can be used to ensure everything is good in downstream consumers. Ideally we won't make any API changes before actually stabilizing `1.0` proper, but some things may come up that need additional breaking alpha releases.

This release includes a _huge_ amount of work from a lot of contributors. I'll try call out breakage here as well as in release notes once we're ready to merge so everyone knows what to expect.

# Changes since the last release

https://github.com/uuid-rs/uuid/compare/0.8.2...main

# Contributions since the last release

- #510 
- #482 
- #511 
- #507 
- #518 
- #519 
- #512 
- #520 
- #521 
- #525 
- #526 
- #527 
- #528 
- #535 
- #536 
- #539 
- #538 
- #540 
- #541 
- #542 
- #544 
- #545 
- #546 
- #543 
- #547 
- #548 
- #549 
- #550 
- #552 
- #554 
- #558 
- #560 
- #562 
- #563 
- #564 
- #565
- #566

# Highlights

Parsing and formatting methods are now much faster, and work in `const` too! On my i9 9900K Windows desktop, the difference looks something like this:

Case                    | `1.0.0-alpha.1`    | `0.8.3`
----------------------- | ------------------ | ------------------
parse_invalid_character | 40 ns/iter (+/- 0) | 39 ns/iter (+/- 1)
parse_invalid_group_len | 47 ns/iter (+/- 1) | 52 ns/iter (+/- 5)
parse_invalid_groups    | 58 ns/iter (+/- 1) | 58 ns/iter (+/- 0)
parse_invalid_len       | 57 ns/iter (+/- 2) |  6 ns/iter (+/- 0)
parse_nil               | 16 ns/iter (+/- 0) | 50 ns/iter (+/- 4)
parse_nil_hyphenated    | 17 ns/iter (+/- 0) | 59 ns/iter (+/- 2)
parse_random            | 16 ns/iter (+/- 0) | 42 ns/iter (+/- 1)
parse_random_hyphenated | 18 ns/iter (+/- 0) | 51 ns/iter (+/- 2)
parse_urn               | 18 ns/iter (+/- 0) | 51 ns/iter (+/- 1)

You can go one step further and look at the [`uuid-simd`](https://github.com/Nugine/uuid-simd) library for vectorized UUID parsing. It's _fast_!

You've got two options for compile-time UUIDs:

You can create UUIDs at compile time using the `uuid!` macro:

```rust
#[macro_use]
extern crate uuid;

use uuid::Uuid;

const ID: Uuid = uuid!("67e55044-10b1-426f-9247-bb680e5fe0c8");
```

Enable the `macro-diagnostics` crate feature to get better diagnostics from `uuid!` using a procedural macro.

# Breaking changes

## Relocation of `adapter::compact`

This module can now be found in `serde::compact`. It can be combined with `#[serde(with)]` to serialize a `Uuid` using a more compact representation. We originally moved to this representation directly, but discovered it comes with its own drawbacks that aren't suitable for all formats.

## Infallible constructors

The following methods have been changed to accept a `&[u8; N]` instead of a `&[u8]`, making them infallible instead of returning a `Result`:

- `Uuid::from_fields`
- `Uuid::from_fields_le`
- `Uuid::new_v1`
- `Builder::from_fields`
- `Builder::from_fields_le`

## Infallible `get_variant`

The `Uuid::get_variant` method now returns a `Variant` instead of an `Option<Varaint>`, because it's not actually possible for it to ever be `None`.

## `Uuid::to_timestamp` is now `Uuid::get_timestamp`

The `Uuid::to_timestamp` method has been renamed to `Uuid::get_timestamp` to make it more consistent with `Uuid::get_version` and `Uuid::get_variant`.

## Changes to formatting methods

The following methods that produce formatting adapters have been renamed:

- `Uuid::to_hyphenated` -> `Uuid::hyphenated`
- `Uuid::to_simple` -> `Uuid::simple`
- `Uuid::to_urn` -> `Uuid::urn`

The following types have been removed:

- `HyphenatedRef`
- `SimpleRef`
- `UrnRef`

The following methods have been changed to return a `&<AdapterType>` instead of an `<AtapterType>Ref`:

- `Uuid::to_hyphenated_ref` -> `Uuid::as_hyphenated`
- `Uuid::to_simple_ref` -> `Uuid::as_simple`
- `Uuid::to_urn_ref` -> `Uuid::as_urn`

## `Builder` method consistency

The `Builder::build` method has been renamed to `Builder::into_uuid`, to complement the `<AdapterType>::into_uuid` methods. It also gets an equivalent `Builder::as_uuid` method.

## `Version` and `Variant` are non-exhaustive

The `#[non_exhaustive]` attribute has been added to `Version` and `Variant`. There are already active proposals for new UUID versions, so these are likely to continue evolving in the future.

## Removed `winapi` support

The `Uuid::to_guid` and `Uuid::from_guid` methods have been removed. This was done for two reasons:

- We need to avoid unstable `winapi` types in the stable `uuid` public API.
- Whether or not GUID fields need to be flipped to convert into a UUID depends on the source of the GUID, so we can't really offer a single pair of methods to convert a GUID into a UUID.

There are some examples in the repository root that demonstrate how to convert GUIDs into UUIDs as a replacement.

## Building with `--all-features`

Now that `uuid` includes unstable features, if you're building with `--all-features` (such as in package manager scenarios), you'll also need to pass `RUSTFLAGS="--cfg uuid_unstable"`, or you'll end up with compilation errors. If this strategy becomes problematic for users we can change unstable features to silently no-op instead of cause compilation failures if the corresponding cfg is not also supplied. Please reach out if that affects you!

# Stability commitment

Once `uuid` releases `1.0` we'll try to stay on that version "forever". There won't be a `2.0` unless there's a very compelling need for it. That means you should feel safe depending on `Uuid` in the public API of your libraries if you want to.