### PR TITLE
Fixed `uuid!("")` macro diagnostics when using `urn:uuid` prefix.

### DIFF
--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -36,11 +36,19 @@ pub fn parse_lit(input: TokenStream) -> TokenStream {
         let ts = TokenStream2::from(input);
         let span = match e {
             Error::UuidParse(error::Error(
-                error::ErrorKind::InvalidCharacter { index, .. },
+                error::ErrorKind::InvalidCharacter { found, index, .. },
             )) => {
+                // Hack to find the byte width of the char
+                // so we can set the span accordingly.
+                let mut bytes = found as u32;
+                let mut width = 0;
+                while bytes != 0 {
+                    bytes >>= 4;
+                    width += 1;
+                }
                 let mut s = proc_macro2::Literal::string("");
                 s.set_span(ts.span());
-                s.subspan(index + 1..=index + 1).unwrap()
+                s.subspan(index + 1..index + width).unwrap()
             }
             Error::UuidParse(error::Error(
                 error::ErrorKind::InvalidGroupLength { found, index, .. },

--- a/macros/src/lib.rs
+++ b/macros/src/lib.rs
@@ -43,15 +43,11 @@ pub fn parse_lit(input: TokenStream) -> TokenStream {
                 s.subspan(index + 1..=index + 1).unwrap()
             }
             Error::UuidParse(error::Error(
-                error::ErrorKind::InvalidGroupLength { found, group, .. },
+                error::ErrorKind::InvalidGroupLength { found, index, .. },
             )) => {
-                let start =
-                    parser::GROUP_LENS.iter().take(group).sum::<usize>()
-                        + group
-                        + 1;
                 let mut s = proc_macro2::Literal::string("");
                 s.set_span(ts.span());
-                s.subspan(start..start + found).unwrap()
+                s.subspan(index..index + found).unwrap()
             }
             _ => ts.span(),
         };

--- a/shared/error.rs
+++ b/shared/error.rs
@@ -81,6 +81,39 @@ impl fmt::Display for ExpectedLength {
     }
 }
 
+impl Error {
+    pub(crate) fn character(found: char, index: usize, offset: usize) -> Self {
+        Error(ErrorKind::InvalidCharacter {
+            expected: "0123456789abcdefABCDEF-",
+            found,
+            index: index + offset,
+            urn: UrnPrefix::Optional,
+        })
+    }
+
+    pub(crate) fn group_count(expected: ExpectedLength, found: usize) -> Self {
+        Error(ErrorKind::InvalidGroupCount { expected, found })
+    }
+
+    pub(crate) fn group_length(
+        expected: ExpectedLength,
+        found: usize,
+        group: usize,
+        offset: usize,
+    ) -> Self {
+        Error(ErrorKind::InvalidGroupLength {
+            expected,
+            found,
+            group,
+            index: [1, 10, 15, 20, 25][group] + offset,
+        })
+    }
+
+    pub(crate) fn length(expected: ExpectedLength, found: usize) -> Self {
+        Error(ErrorKind::InvalidLength { expected, found })
+    }
+}
+
 impl From<ErrorKind> for Error {
     fn from(kind: ErrorKind) -> Self {
         Error(kind)

--- a/shared/error.rs
+++ b/shared/error.rs
@@ -42,6 +42,8 @@ pub(crate) enum ErrorKind {
         found: usize,
         /// The segment with invalid length.
         group: usize,
+        /// The index of where the group starts
+        index: usize,
     },
     /// Invalid length of the [`Uuid`] string.
     ///
@@ -126,6 +128,7 @@ impl fmt::Display for Error {
                 ref expected,
                 found,
                 group,
+                ..
             } => write!(
                 f,
                 "expected {}, found {} in group {}",

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -221,6 +221,7 @@ mod tests {
                 expected: ExpectedLength::Exact(4),
                 found: 3,
                 group: 1,
+                index: 10,
             }))
         );
         // (group, found, expecting)
@@ -231,6 +232,7 @@ mod tests {
                 expected: ExpectedLength::Exact(12),
                 found: 8,
                 group: 4,
+                index: 25,
             }))
         );
 
@@ -307,6 +309,7 @@ mod tests {
                 expected: ExpectedLength::Exact(8),
                 found: 6,
                 group: 0,
+                index: 1,
             }))
         );
         assert_eq!(
@@ -315,6 +318,7 @@ mod tests {
                 expected: ExpectedLength::Exact(4),
                 found: 5,
                 group: 3,
+                index: 20,
             }))
         );
     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -209,9 +209,19 @@ mod tests {
 
         assert_eq!(
             Uuid::parse_str("{F9168C5E-CEB2-4faa9B6BFF329BF39FA1E41"),
+            Err(Error(ErrorKind::InvalidCharacter {
+                expected: EXPECTED_CHARS,
+                found: '{',
+                index: 0,
+                urn: UrnPrefix::Optional,
+            }))
+        );
+
+        assert_eq!(
+            Uuid::parse_str("{F9168C5E-CEB2-4faa9B6BFF329BF39FA1E41}"),
             Err(Error(ErrorKind::InvalidLength {
                 expected: ExpectedLength::Any(&[36, 32]),
-                found: 38
+                found: 39
             }))
         );
 

--- a/tests/ui/compile_fail/invalid_parse.rs
+++ b/tests/ui/compile_fail/invalid_parse.rs
@@ -12,7 +12,7 @@ const _: Uuid = uuid!("F9168C5E-CEB-24fa-eB6BFF32-BF39FA1E4");
 const _: Uuid = uuid!("01020304-1112-2122-3132-41424344");
 const _: Uuid = uuid!("67e5504410b1426f9247bb680e5fe0c88");
 const _: Uuid = uuid!("67e5504410b1426f9247bb680e5fe0cg8");
-const _: Uuid = uuid!("67e5504410b1426%9247bb680e5fe0c8");
+const _: Uuid = uuid!("urn:uuid:67e55044-10b1-426f-9247-bb680e5fe0c8");
 
 // Test error reporting
 const _: Uuid = uuid!("67e5504410b1426f9247bb680e5fe0c");
@@ -25,5 +25,10 @@ const _: Uuid = uuid!("F9168C5E-CEB2-4faa-BBF-329BF39FA1E4");
 const _: Uuid = uuid!("F9168C5E-CEB2-4faa-BGBF-329BF39FA1E4");
 const _: Uuid = uuid!("01020304-1112-2122-3132-41424344");
 const _: Uuid = uuid!("F9168C5E-CEB2-4faa-B6BFF329BF39FA1E4");
+const _: Uuid = uuid!("urn:uuid:F9168C5E-CEB2-4faa-BGBF-329BF39FA1E4");
+const _: Uuid = uuid!("urn:uuid:F9168C5E-CEB2-4faa-B2cBF-32BF39FA1E4");
+const _: Uuid = uuid!("{F9168C5E-CEB2-4faa-B0a75-32BF39FA1E4}");
+
+const _: Uuid = uuid!("{F9168C5E-CEB2-4faa-B6BF-329Bz39FA1E4}");
 
 fn main() {}

--- a/tests/ui/compile_fail/invalid_parse.rs
+++ b/tests/ui/compile_fail/invalid_parse.rs
@@ -31,4 +31,12 @@ const _: Uuid = uuid!("{F9168C5E-CEB2-4faa-B0a75-32BF39FA1E4}");
 
 const _: Uuid = uuid!("{F9168C5E-CEB2-4faa-B6BF-329Bz39FA1E4}");
 
+// group 0 has invalid length
+const _: Uuid = uuid!("67e550-4105b1426f9247bb680e5fe0c");
+
+const _: Uuid = uuid!("504410岡林aab1426f9247bb680e5fe0c8");
+const _: Uuid = uuid!("504410😎👍aab1426f9247bb680e5fe0c8");
+
+const _: Uuid = uuid!("{F9168C5E-CEB2-4faa-👍5-32BF39FA1E4}");
+
 fn main() {}

--- a/tests/ui/compile_fail/invalid_parse.stderr
+++ b/tests/ui/compile_fail/invalid_parse.stderr
@@ -70,12 +70,6 @@ error: invalid length: expected one of [36, 32], found 33
 14 | const _: Uuid = uuid!("67e5504410b1426f9247bb680e5fe0cg8");
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-error: invalid character: expected an optional prefix of `urn:uuid:` followed by 0123456789abcdefABCDEF-, found % at 15
-  --> tests/ui/compile_fail/invalid_parse.rs:15:39
-   |
-15 | const _: Uuid = uuid!("67e5504410b1426%9247bb680e5fe0c8");
-   |                                       ^
-
 error: invalid length: expected one of [36, 32], found 31
   --> tests/ui/compile_fail/invalid_parse.rs:18:23
    |
@@ -88,11 +82,14 @@ error: invalid character: expected an optional prefix of `urn:uuid:` followed by
 19 | const _: Uuid = uuid!("67e550X410b1426f9247bb680e5fe0cd");
    |                              ^
 
-error: invalid group length: expected 8, found 6 in group 0
-  --> tests/ui/compile_fail/invalid_parse.rs:20:24
+error: proc macro panicked
+  --> tests/ui/compile_fail/invalid_parse.rs:20:17
    |
 20 | const _: Uuid = uuid!("67e550-4105b1426f9247bb680e5fe0c");
-   |                        ^^^^^^
+   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   |
+   = help: message: attempt to subtract with overflow
+   = note: this error originates in the macro `uuid` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error: invalid group length: expected 4, found 5 in group 3
   --> tests/ui/compile_fail/invalid_parse.rs:21:43
@@ -123,3 +120,27 @@ error: invalid number of groups: expected one of [1, 5], found 4
    |
 27 | const _: Uuid = uuid!("F9168C5E-CEB2-4faa-B6BFF329BF39FA1E4");
    |                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error: invalid character: expected an optional prefix of `urn:uuid:` followed by 0123456789abcdefABCDEF-, found G at 29
+  --> tests/ui/compile_fail/invalid_parse.rs:28:53
+   |
+28 | const _: Uuid = uuid!("urn:uuid:F9168C5E-CEB2-4faa-BGBF-329BF39FA1E4");
+   |                                                     ^
+
+error: invalid group length: expected 4, found 5 in group 3
+  --> tests/ui/compile_fail/invalid_parse.rs:29:52
+   |
+29 | const _: Uuid = uuid!("urn:uuid:F9168C5E-CEB2-4faa-B2cBF-32BF39FA1E4");
+   |                                                    ^^^^^
+
+error: invalid group length: expected 4, found 5 in group 3
+  --> tests/ui/compile_fail/invalid_parse.rs:30:44
+   |
+30 | const _: Uuid = uuid!("{F9168C5E-CEB2-4faa-B0a75-32BF39FA1E4}");
+   |                                            ^^^^^
+
+error: invalid character: expected an optional prefix of `urn:uuid:` followed by 0123456789abcdefABCDEF-, found z at 29
+  --> tests/ui/compile_fail/invalid_parse.rs:32:53
+   |
+32 | const _: Uuid = uuid!("{F9168C5E-CEB2-4faa-B6BF-329Bz39FA1E4}");
+   |                                                     ^

--- a/tests/ui/compile_fail/invalid_parse.stderr
+++ b/tests/ui/compile_fail/invalid_parse.stderr
@@ -82,14 +82,11 @@ error: invalid character: expected an optional prefix of `urn:uuid:` followed by
 19 | const _: Uuid = uuid!("67e550X410b1426f9247bb680e5fe0cd");
    |                              ^
 
-error: proc macro panicked
-  --> tests/ui/compile_fail/invalid_parse.rs:20:17
+error: invalid group length: expected 8, found 6 in group 0
+  --> tests/ui/compile_fail/invalid_parse.rs:20:24
    |
 20 | const _: Uuid = uuid!("67e550-4105b1426f9247bb680e5fe0c");
-   |                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = help: message: attempt to subtract with overflow
-   = note: this error originates in the macro `uuid` (in Nightly builds, run with -Z macro-backtrace for more info)
+   |                        ^^^^^^
 
 error: invalid group length: expected 4, found 5 in group 3
   --> tests/ui/compile_fail/invalid_parse.rs:21:43
@@ -144,3 +141,27 @@ error: invalid character: expected an optional prefix of `urn:uuid:` followed by
    |
 32 | const _: Uuid = uuid!("{F9168C5E-CEB2-4faa-B6BF-329Bz39FA1E4}");
    |                                                     ^
+
+error: invalid group length: expected 8, found 6 in group 0
+  --> tests/ui/compile_fail/invalid_parse.rs:35:24
+   |
+35 | const _: Uuid = uuid!("67e550-4105b1426f9247bb680e5fe0c");
+   |                        ^^^^^^
+
+error: invalid character: expected an optional prefix of `urn:uuid:` followed by 0123456789abcdefABCDEF-, found 岡 at 6
+  --> tests/ui/compile_fail/invalid_parse.rs:37:30
+   |
+37 | const _: Uuid = uuid!("504410岡林aab1426f9247bb680e5fe0c8");
+   |                              ^^
+
+error: invalid character: expected an optional prefix of `urn:uuid:` followed by 0123456789abcdefABCDEF-, found 😎 at 6
+  --> tests/ui/compile_fail/invalid_parse.rs:38:30
+   |
+38 | const _: Uuid = uuid!("504410😎👍aab1426f9247bb680e5fe0c8");
+   |                              ^^
+
+error: invalid character: expected an optional prefix of `urn:uuid:` followed by 0123456789abcdefABCDEF-, found 👍 at 20
+  --> tests/ui/compile_fail/invalid_parse.rs:40:44
+   |
+40 | const _: Uuid = uuid!("{F9168C5E-CEB2-4faa-👍5-32BF39FA1E4}");
+   |                                            ^^


### PR DESCRIPTION
**I'm submitting a** bug fix

# Description
Fixed an bug where the `uuid!("")` macro would point to the wrong characters when using the `urn:uuid:` prefix or wrapping with the curly braces (`"{...}"`).

# Related Issue(s)
none