### PR TITLE
Revert default compact serialization

### DIFF
--- a/shared/error.rs
+++ b/shared/error.rs
@@ -14,6 +14,9 @@ pub(crate) enum ErrorKind {
     ///
     /// [`Uuid`]: ../struct.Uuid.html
     SimpleLength { len: usize },
+    /// A byte array didn't contain 16 bytes
+    #[allow(dead_code)]
+    ByteLength { len: usize },
     /// A hyphenated [`Uuid`] didn't contain 5 groups
     ///
     /// [`Uuid`]: ../struct.Uuid.html
@@ -26,6 +29,9 @@ pub(crate) enum ErrorKind {
         len: usize,
         index: usize,
     },
+    /// Some other error occurred.
+    #[allow(dead_code)]
+    Other,
 }
 
 /// A string that is guaranteed to fail to parse to a [`Uuid`].
@@ -126,6 +132,9 @@ impl fmt::Display for Error {
                     len
                 )
             }
+            ErrorKind::ByteLength { len } => {
+                write!(f, "invalid length: expected 16 bytes, found {}", len)
+            }
             ErrorKind::GroupCount { count } => {
                 write!(f, "invalid group count: expected 5, found {}", count)
             }
@@ -137,6 +146,7 @@ impl fmt::Display for Error {
                     group, expected, len
                 )
             }
+            ErrorKind::Other => write!(f, "failed to parse a UUID"),
         }
     }
 }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -308,7 +308,7 @@ impl Uuid {
     /// ```
     pub fn from_slice(b: &[u8]) -> Result<Uuid, Error> {
         if b.len() != 16 {
-            return Err(Error(ErrorKind::SimpleLength { len: b.len() * 2 }));
+            return Err(Error(ErrorKind::ByteLength { len: b.len() }));
         }
 
         let mut bytes: Bytes = [0; 16];
@@ -349,7 +349,7 @@ impl Uuid {
     /// ```
     pub fn from_slice_le(b: &[u8]) -> Result<Uuid, Error> {
         if b.len() != 16 {
-            return Err(Error(ErrorKind::SimpleLength { len: b.len() * 2 }));
+            return Err(Error(ErrorKind::ByteLength { len: b.len() }));
         }
 
         let mut bytes: Bytes = [0; 16];
@@ -452,9 +452,7 @@ impl Uuid {
     /// ```
     pub fn from_bytes_ref(bytes: &Bytes) -> &Uuid {
         // SAFETY: `Bytes` and `Uuid` have the same ABI
-        unsafe {
-            &*(bytes as *const Bytes as *const Uuid)
-        }
+        unsafe { &*(bytes as *const Bytes as *const Uuid) }
     }
 }
 

--- a/src/external/mod.rs
+++ b/src/external/mod.rs
@@ -1,6 +1,6 @@
 #[cfg(feature = "arbitrary")]
-mod arbitrary_support;
+pub(crate) mod arbitrary_support;
 #[cfg(feature = "serde")]
-mod serde_support;
+pub(crate) mod serde_support;
 #[cfg(feature = "slog")]
-mod slog_support;
+pub(crate) mod slog_support;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -293,8 +293,7 @@ pub enum Variant {
 /// * [`hyphenated`](#method.hyphenated):
 ///   `a1a2a3a4-b1b2-c1c2-d1d2-d3d4d5d6d7d8`.
 /// * [`urn`](#method.to_urn): `urn:uuid:A1A2A3A4-B1B2-C1C2-D1D2-D3D4D5D6D7D8`.
-/// * [`braced`](#method.braced):
-///   `{a1a2a3a4-b1b2-c1c2-d1d2-d3d4d5d6d7d8}`.
+/// * [`braced`](#method.braced): `{a1a2a3a4-b1b2-c1c2-d1d2-d3d4d5d6d7d8}`.
 ///
 /// The default representation when formatting a UUID with `Display` is
 /// hyphenated:
@@ -743,6 +742,17 @@ impl AsRef<[u8]> for Uuid {
     fn as_ref(&self) -> &[u8] {
         &self.0
     }
+}
+
+#[cfg(feature = "serde")]
+pub mod serde {
+    //! Adapters for `serde`.
+    //!
+    //! This module contains adapters you can use with [`#[serde(with)]`](https://serde.rs/field-attrs.html#with)
+    //! to change the way a [`Uuid`](../struct.Uuid.html) is serialized
+    //! and deserialized.
+
+    pub use crate::external::serde_support::compact;
 }
 
 #[cfg(test)]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -66,12 +66,35 @@ impl Uuid {
             .map_err(InvalidUuid::into_err)
     }
 
-    /// Intended to replace `Uuid::parse_str`
+    /// Parses a `Uuid` from a string of hexadecimal digits with optional
+    /// hyphens.
+    ///
+    /// This function is similar to [`parse_str`], in fact `parse_str` shares
+    /// the same underlying parser. The difference is that if `try_parse`
+    /// fails, it won't generate very useful error messages. The `parse_str`
+    /// function will eventually be deprecated in favor or `try_parse`.
+    ///
+    /// # Examples
+    ///
+    /// Parse a hyphenated UUID:
+    ///
+    /// ```
+    /// # use uuid::{Uuid, Version, Variant};
+    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// let uuid = Uuid::try_parse("550e8400-e29b-41d4-a716-446655440000")?;
+    ///
+    /// assert_eq!(Some(Version::Random), uuid.get_version());
+    /// assert_eq!(Variant::RFC4122, uuid.get_variant());
+    /// # Ok(())
+    /// # }
+    /// ```
+    ///
+    /// [`parse_str`]: #method.parse_str
     #[inline]
-    pub const fn try_parse(input: &str) -> Result<Uuid, InvalidUuid> {
+    pub const fn try_parse(input: &str) -> Result<Uuid, Error> {
         match imp::try_parse(input) {
             Ok(bytes) => Ok(Uuid::from_bytes(bytes)),
-            Err(e) => Err(e),
+            Err(_) => Err(Error(ErrorKind::Other)),
         }
     }
 }


### PR DESCRIPTION
Closes #557 

It turns out that serializing as a `[u8; 16]` is not really a better default than `&[u8]`, so this PR reverts it in favor of the current stable implementation.