### PR TITLE
Follow C-GETTER convention

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ use uuid::{Uuid, Version};
 
 let my_uuid = Uuid::parse_str("67e55044-10b1-426f-9247-bb680e5fe0c8")?;
 
-assert_eq!(Some(Version::Random), my_uuid.get_version());
+assert_eq!(Some(Version::Random), my_uuid.version());
 ```
 
 If you'd like to parse UUIDs _really_ fast, check out the [`uuid-simd`](https://github.com/nugine/uuid-simd)

--- a/examples/random_uuid.rs
+++ b/examples/random_uuid.rs
@@ -9,7 +9,7 @@ fn generate_random_uuid() {
 
     let uuid = Uuid::new_v4();
 
-    assert_eq!(Some(uuid::Version::Random), uuid.get_version());
+    assert_eq!(Some(uuid::Version::Random), uuid.version());
 }
 
 fn main() {}

--- a/examples/uuid_macro.rs
+++ b/examples/uuid_macro.rs
@@ -13,7 +13,7 @@ fn parse_uuid_at_compile_time() {
 
     let uuid = uuid!("67e55044-10b1-426f-9247-bb680e5fe0c8");
 
-    assert_eq!(Some(uuid::Version::Random), uuid.get_version());
+    assert_eq!(Some(uuid::Version::Random), uuid.version());
 }
 
 fn main() {}

--- a/examples/windows_guid.rs
+++ b/examples/windows_guid.rs
@@ -110,8 +110,8 @@ fn uuid_from_cocreateguid() {
     let uuid =
         Uuid::from_fields(guid.Data1, guid.Data2, guid.Data3, &guid.Data4);
 
-    assert_eq!(Variant::RFC4122, uuid.get_variant());
-    assert_eq!(Some(Version::Random), uuid.get_version());
+    assert_eq!(Variant::RFC4122, uuid.variant());
+    assert_eq!(Some(Version::Random), uuid.version());
 }
 
 fn main() {}

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -35,8 +35,8 @@ use crate::{error::*, Bytes, Uuid, Variant, Version};
 ///
 /// let uuid = Builder::from_random_bytes(random_bytes).into_uuid();
 ///
-/// assert_eq!(Some(Version::Random), uuid.get_version());
-/// assert_eq!(Variant::RFC4122, uuid.get_variant());
+/// assert_eq!(Some(Version::Random), uuid.version());
+/// assert_eq!(Variant::RFC4122, uuid.variant());
 /// ```
 #[allow(missing_copy_implementations)]
 #[derive(Debug)]
@@ -535,8 +535,8 @@ impl Builder {
     /// let random_bytes = rng();
     /// let uuid = Builder::from_random_bytes(random_bytes).into_uuid();
     ///
-    /// assert_eq!(Some(Version::Random), uuid.get_version());
-    /// assert_eq!(Variant::RFC4122, uuid.get_variant());
+    /// assert_eq!(Some(Version::Random), uuid.version());
+    /// assert_eq!(Variant::RFC4122, uuid.variant());
     /// ```
     pub const fn from_random_bytes(b: Bytes) -> Self {
         Builder(Uuid::from_bytes(b))

--- a/src/external/arbitrary_support.rs
+++ b/src/external/arbitrary_support.rs
@@ -27,8 +27,8 @@ mod tests {
 
         let uuid = Uuid::arbitrary(&mut bytes).unwrap();
 
-        assert_eq!(Some(Version::Random), uuid.get_version());
-        assert_eq!(Variant::RFC4122, uuid.get_variant());
+        assert_eq!(Some(Version::Random), uuid.version());
+        assert_eq!(Variant::RFC4122, uuid.variant());
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -438,7 +438,7 @@ impl Uuid {
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let my_uuid = Uuid::parse_str("02f09a3f-1624-3b1d-8409-44eff7708208")?;
     ///
-    /// assert_eq!(Variant::RFC4122, my_uuid.get_variant());
+    /// assert_eq!(Variant::RFC4122, my_uuid.variant());
     /// # Ok(())
     /// # }
     /// ```
@@ -446,7 +446,7 @@ impl Uuid {
     /// # References
     ///
     /// * [Variant in RFC4122](http://tools.ietf.org/html/rfc4122#section-4.1.1)
-    pub const fn get_variant(&self) -> Variant {
+    pub const fn variant(&self) -> Variant {
         match self.as_bytes()[8] {
             x if x & 0x80 == 0x00 => Variant::NCS,
             x if x & 0xc0 == 0x80 => Variant::RFC4122,
@@ -462,7 +462,7 @@ impl Uuid {
     /// Returns the version number of the UUID.
     ///
     /// This represents the algorithm used to generate the value.
-    /// This method is the future-proof alternative to [`Uuid::get_version`].
+    /// This method is the future-proof alternative to [`Uuid::version`].
     ///
     /// # Examples
     ///
@@ -473,7 +473,7 @@ impl Uuid {
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let my_uuid = Uuid::parse_str("02f09a3f-1624-3b1d-8409-44eff7708208")?;
     ///
-    /// assert_eq!(3, my_uuid.get_version_num());
+    /// assert_eq!(3, my_uuid.version_num());
     /// # Ok(())
     /// # }
     /// ```
@@ -481,7 +481,7 @@ impl Uuid {
     /// # References
     ///
     /// * [Version in RFC4122](https://datatracker.ietf.org/doc/html/rfc4122#section-4.1.3)
-    pub const fn get_version_num(&self) -> usize {
+    pub const fn version_num(&self) -> usize {
         (self.as_bytes()[6] >> 4) as usize
     }
 
@@ -490,7 +490,7 @@ impl Uuid {
     /// This represents the algorithm used to generate the value.
     /// If the version field doesn't contain a recognized version then `None`
     /// is returned. If you're trying to read the version for a future extension
-    /// you can also use [`Uuid::get_version_num`] to unconditionally return a
+    /// you can also use [`Uuid::version_num`] to unconditionally return a
     /// number. Future extensions may start to return `Some` once they're standardized
     /// and supported.
     ///
@@ -503,7 +503,7 @@ impl Uuid {
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let my_uuid = Uuid::parse_str("02f09a3f-1624-3b1d-8409-44eff7708208")?;
     ///
-    /// assert_eq!(Some(Version::Md5), my_uuid.get_version());
+    /// assert_eq!(Some(Version::Md5), my_uuid.version());
     /// # Ok(())
     /// # }
     /// ```
@@ -511,8 +511,8 @@ impl Uuid {
     /// # References
     ///
     /// * [Version in RFC4122](https://datatracker.ietf.org/doc/html/rfc4122#section-4.1.3)
-    pub const fn get_version(&self) -> Option<Version> {
-        match self.get_version_num() {
+    pub const fn version(&self) -> Option<Version> {
+        match self.version_num() {
             0 if self.is_nil() => Some(Version::Nil),
             1 => Some(Version::Mac),
             2 => Some(Version::Dce),
@@ -945,13 +945,13 @@ mod tests {
             4, 54, 67, 12, 43, 2, 2, 76, 32, 50, 87, 5, 1, 33, 43, 87,
         ]);
 
-        assert_eq!(from_bytes.get_version(), None);
+        assert_eq!(from_bytes.version(), None);
 
         assert!(nil.is_nil());
         assert!(!not_nil.is_nil());
 
-        assert_eq!(nil.get_version(), Some(Version::Nil));
-        assert_eq!(not_nil.get_version(), Some(Version::Random))
+        assert_eq!(nil.version(), Some(Version::Nil));
+        assert_eq!(not_nil.version(), Some(Version::Random))
     }
 
     #[test]
@@ -982,8 +982,8 @@ mod tests {
         let uuid =
             Uuid::new_v3(&Uuid::NAMESPACE_DNS, "rust-lang.org".as_bytes());
 
-        assert_eq!(uuid.get_version().unwrap(), Version::Md5);
-        assert_eq!(uuid.get_version_num(), 3);
+        assert_eq!(uuid.version().unwrap(), Version::Md5);
+        assert_eq!(uuid.version_num(), 3);
     }
 
     #[test]
@@ -1001,12 +1001,12 @@ mod tests {
         let uuid6 =
             Uuid::parse_str("f81d4fae-7dec-11d0-7765-00a0c91e6bf6").unwrap();
 
-        assert_eq!(uuid1.get_variant(), Variant::RFC4122);
-        assert_eq!(uuid2.get_variant(), Variant::RFC4122);
-        assert_eq!(uuid3.get_variant(), Variant::RFC4122);
-        assert_eq!(uuid4.get_variant(), Variant::Microsoft);
-        assert_eq!(uuid5.get_variant(), Variant::Microsoft);
-        assert_eq!(uuid6.get_variant(), Variant::NCS);
+        assert_eq!(uuid1.variant(), Variant::RFC4122);
+        assert_eq!(uuid2.variant(), Variant::RFC4122);
+        assert_eq!(uuid3.variant(), Variant::RFC4122);
+        assert_eq!(uuid4.variant(), Variant::Microsoft);
+        assert_eq!(uuid5.variant(), Variant::Microsoft);
+        assert_eq!(uuid6.variant(), Variant::NCS);
     }
 
     #[test]

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -51,8 +51,8 @@ impl Uuid {
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let uuid = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000")?;
     ///
-    /// assert_eq!(Some(Version::Random), uuid.get_version());
-    /// assert_eq!(Variant::RFC4122, uuid.get_variant());
+    /// assert_eq!(Some(Version::Random), uuid.version());
+    /// assert_eq!(Variant::RFC4122, uuid.variant());
     /// # Ok(())
     /// # }
     /// ```
@@ -79,8 +79,8 @@ impl Uuid {
     /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
     /// let uuid = Uuid::try_parse("550e8400-e29b-41d4-a716-446655440000")?;
     ///
-    /// assert_eq!(Some(Version::Random), uuid.get_version());
-    /// assert_eq!(Variant::RFC4122, uuid.get_variant());
+    /// assert_eq!(Some(Version::Random), uuid.version());
+    /// assert_eq!(Variant::RFC4122, uuid.variant());
     /// # Ok(())
     /// # }
     /// ```

--- a/src/v1.rs
+++ b/src/v1.rs
@@ -232,8 +232,8 @@ impl Uuid {
     /// value into more commonly-used formats, such as a unix timestamp.
     ///
     /// [`Timestamp`]: v1/struct.Timestamp.html
-    pub const fn get_timestamp(&self) -> Option<Timestamp> {
-        match self.get_version() {
+    pub const fn timestamp(&self) -> Option<Timestamp> {
+        match self.version() {
             Some(Version::Mac) => {
                 let ticks: u64 = ((self.as_bytes()[6] & 0x0F) as u64) << 56
                     | ((self.as_bytes()[7]) as u64) << 48
@@ -321,14 +321,14 @@ mod tests {
             &node,
         );
 
-        assert_eq!(uuid.get_version(), Some(Version::Mac));
-        assert_eq!(uuid.get_variant(), Variant::RFC4122);
+        assert_eq!(uuid.version(), Some(Version::Mac));
+        assert_eq!(uuid.variant(), Variant::RFC4122);
         assert_eq!(
             uuid.hyphenated().to_string(),
             "20616934-4ba2-11e7-8000-010203040506"
         );
 
-        let ts = uuid.get_timestamp().unwrap().to_rfc4122();
+        let ts = uuid.timestamp().unwrap().to_rfc4122();
 
         assert_eq!(ts.0 - 0x01B2_1DD2_1381_4000, 14_968_545_358_129_460);
 
@@ -336,10 +336,7 @@ mod tests {
         let parsed =
             Uuid::parse_str("20616934-4ba2-11e7-8000-010203040506").unwrap();
 
-        assert_eq!(
-            uuid.get_timestamp().unwrap(),
-            parsed.get_timestamp().unwrap()
-        );
+        assert_eq!(uuid.timestamp().unwrap(), parsed.timestamp().unwrap());
     }
 
     #[test]
@@ -364,8 +361,8 @@ mod tests {
             &node,
         );
 
-        assert_eq!(uuid1.get_timestamp().unwrap().to_rfc4122().1, 16382);
-        assert_eq!(uuid2.get_timestamp().unwrap().to_rfc4122().1, 0);
+        assert_eq!(uuid1.timestamp().unwrap().to_rfc4122().1, 16382);
+        assert_eq!(uuid2.timestamp().unwrap().to_rfc4122().1, 0);
 
         let time = 1_496_854_535;
 
@@ -378,7 +375,7 @@ mod tests {
             &node,
         );
 
-        assert_eq!(uuid3.get_timestamp().unwrap().to_rfc4122().1, 1);
-        assert_eq!(uuid4.get_timestamp().unwrap().to_rfc4122().1, 2);
+        assert_eq!(uuid3.timestamp().unwrap().to_rfc4122().1, 1);
+        assert_eq!(uuid4.timestamp().unwrap().to_rfc4122().1, 2);
     }
 }

--- a/src/v3.rs
+++ b/src/v3.rs
@@ -24,7 +24,7 @@ impl Uuid {
     /// # use uuid::{Uuid, Version};
     /// let uuid = Uuid::new_v3(&Uuid::NAMESPACE_DNS, b"rust-lang.org");
     ///
-    /// assert_eq!(Some(Version::Md5), uuid.get_version());
+    /// assert_eq!(Some(Version::Md5), uuid.version());
     /// ```
     ///
     /// [`NAMESPACE_DNS`]: #associatedconstant.NAMESPACE_DNS
@@ -148,8 +148,8 @@ mod tests {
     fn test_new() {
         for &(ref ns, ref name, _) in FIXTURE {
             let uuid = Uuid::new_v3(*ns, name.as_bytes());
-            assert_eq!(uuid.get_version(), Some(Version::Md5));
-            assert_eq!(uuid.get_variant(), Variant::RFC4122);
+            assert_eq!(uuid.version(), Some(Version::Md5));
+            assert_eq!(uuid.variant(), Variant::RFC4122);
         }
     }
 

--- a/src/v4.rs
+++ b/src/v4.rs
@@ -21,7 +21,7 @@ impl Uuid {
     /// # use uuid::{Uuid, Version};
     /// let uuid = Uuid::new_v4();
     ///
-    /// assert_eq!(Some(Version::Random), uuid.get_version());
+    /// assert_eq!(Some(Version::Random), uuid.version());
     /// ```
     ///
     /// [`getrandom`]: https://crates.io/crates/getrandom
@@ -45,8 +45,8 @@ mod tests {
     fn test_new() {
         let uuid = Uuid::new_v4();
 
-        assert_eq!(uuid.get_version(), Some(Version::Random));
-        assert_eq!(uuid.get_variant(), Variant::RFC4122);
+        assert_eq!(uuid.version(), Some(Version::Random));
+        assert_eq!(uuid.variant(), Variant::RFC4122);
     }
 
     #[test]
@@ -54,7 +54,7 @@ mod tests {
     fn test_get_version() {
         let uuid = Uuid::new_v4();
 
-        assert_eq!(uuid.get_version(), Some(Version::Random));
-        assert_eq!(uuid.get_version_num(), 4)
+        assert_eq!(uuid.version(), Some(Version::Random));
+        assert_eq!(uuid.version_num(), 4)
     }
 }

--- a/src/v5.rs
+++ b/src/v5.rs
@@ -23,7 +23,7 @@ impl Uuid {
     /// # use uuid::{Uuid, Version};
     /// let uuid = Uuid::new_v5(&Uuid::NAMESPACE_DNS, b"rust-lang.org");
     ///
-    /// assert_eq!(Some(Version::Sha1), uuid.get_version());
+    /// assert_eq!(Some(Version::Sha1), uuid.version());
     /// ```
     ///
     /// [`NAMESPACE_DNS`]: struct.Uuid.html#associatedconst.NAMESPACE_DNS
@@ -148,8 +148,8 @@ mod tests {
         let uuid =
             Uuid::new_v5(&Uuid::NAMESPACE_DNS, "rust-lang.org".as_bytes());
 
-        assert_eq!(uuid.get_version(), Some(Version::Sha1));
-        assert_eq!(uuid.get_version_num(), 5);
+        assert_eq!(uuid.version(), Some(Version::Sha1));
+        assert_eq!(uuid.version_num(), 5);
     }
 
     #[test]
@@ -168,8 +168,8 @@ mod tests {
         for &(ref ns, ref name, ref u) in FIXTURE {
             let uuid = Uuid::new_v5(*ns, name.as_bytes());
 
-            assert_eq!(uuid.get_version(), Some(Version::Sha1));
-            assert_eq!(uuid.get_variant(), Variant::RFC4122);
+            assert_eq!(uuid.version(), Some(Version::Sha1));
+            assert_eq!(uuid.variant(), Variant::RFC4122);
             assert_eq!(Ok(uuid), u.parse());
         }
     }


### PR DESCRIPTION
Renames getters to follow [C-GETTER](https://rust-lang.github.io/api-guidelines/naming.html#c-getter)