### PR TITLE
Update hashes to v0.10 and change sha-1 to sha1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -88,13 +88,13 @@ version = "0.5"
 [dependencies.md-5]
 default-features = false
 optional = true
-version = "0.9"
+version = "0.10"
 
 # Private
-[dependencies.sha-1]
+[dependencies.sha1]
 default-features = false
 optional = true
-version = "0.9"
+version = "0.10"
 
 # Public: Re-exported
 [dependencies.uuid-macro-internal]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -58,7 +58,7 @@ macro-diagnostics = ["uuid-macro-internal"]
 v1 = ["atomic"]
 v3 = ["md-5"]
 v4 = ["rng"]
-v5 = ["sha-1"]
+v5 = ["sha1"]
 
 js = ["getrandom", "getrandom/js"]
 


### PR DESCRIPTION
`sha1` got transferred to RustCrypto and should be preferred over `sha-1`, which will be deprecated after v0.11 release.