### PR TITLE
Only check diagnostics output on nightly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -145,6 +145,9 @@ version = "0.3"
 [dev-dependencies.trybuild]
 version = "1.0.52"
 
+[dev-dependencies.rustversion]
+version = "1"
+
 [target.'cfg(windows)'.dev-dependencies.winapi]
 version = "0.3"
 features = ["combaseapi", "impl-default"]

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -18,7 +18,12 @@ license = "Apache-2.0 OR MIT"
 [lib]
 proc-macro = true
 
-[dependencies]
-syn = "1.0.80"
-quote = "1.0.10"
-proc-macro2 = "1.0.29"
+[dependencies.syn]
+version = "1.0.80"
+
+[dependencies.quote]
+version = "1.0.10"
+
+[dependencies.proc-macro2]
+version = "1.0.29"
+features = ["span-locations"]

--- a/tests/macros.rs
+++ b/tests/macros.rs
@@ -2,6 +2,10 @@
 #[test]
 fn ui() {
     let t = trybuild::TestCases::new();
+
     t.pass("tests/ui/compile_pass/*.rs");
-    t.compile_fail("tests/ui/compile_fail/*.rs");
+
+    if rustversion::cfg!(nightly) {
+        t.compile_fail("tests/ui/compile_fail/*.rs");
+    }
 }


### PR DESCRIPTION
For #585 

These tests will only ever make sense on `nightly` compilers, since in other cases we won't be able to produce subspans (we can't currently get them anyways, but that might be fixable).