### PR TITLE
Use the sha1_smol library for SHA1

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ js = ["private_getrandom", "private_getrandom/js"]
 rng = ["private_getrandom"]
 fast-rng = ["rng", "private_rand"]
 
-sha1 = ["private_sha1"]
+sha1 = ["private_sha1_smol"]
 md5 = ["private_md-5"]
 
 # Public: Used in trait impls on `Uuid`
@@ -121,11 +121,11 @@ version = "0.10"
 # Private
 # Don't depend on this optional feature directly: it may change at any time
 # Use the `sha1` feature instead
-[dependencies.private_sha1]
-package = "sha1"
+[dependencies.private_sha1_smol]
+package = "sha1_smol"
 default-features = false
 optional = true
-version = "0.10"
+version = "1"
 
 # Public: Re-exported
 # Don't depend on this optional feature directly: it may change at any time

--- a/src/sha1.rs
+++ b/src/sha1.rs
@@ -1,6 +1,6 @@
 #[cfg(feature = "v5")]
 pub(crate) fn hash(ns: &[u8], src: &[u8]) -> [u8; 16] {
-    use private_sha1::{Sha1, Digest};
+    use private_sha1_smol::Sha1;
 
     let mut hasher = Sha1::new();
 
@@ -8,7 +8,7 @@ pub(crate) fn hash(ns: &[u8], src: &[u8]) -> [u8; 16] {
     hasher.update(src);
 
     let mut bytes = [0; 16];
-    bytes.copy_from_slice(&hasher.finalize()[..16]);
+    bytes.copy_from_slice(&hasher.digest().bytes()[..16]);
 
     bytes
 }


### PR DESCRIPTION
Closes #582 

Follow-up for #581 

This PR follows the crate renaming of `sha1` so that we default to the zero-dependency `sha1_smol` crate, but support a `fast-sha1` feature that pulls in the rust-crypto `sha1` crate with its `asm` feature. This follows the same approach we've used for RNG where users get a small footprint by default, but can pull in more specialized implementations if they want to.