### PR TITLE
Remove unnecessary AND

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -754,7 +754,7 @@ impl Builder {
             Variant::NCS => byte & 0x7f,
             Variant::RFC4122 => (byte & 0x3f) | 0x80,
             Variant::Microsoft => (byte & 0x1f) | 0xc0,
-            Variant::Future => (byte & 0x1f) | 0xe0,
+            Variant::Future => byte | 0xe0,
         };
 
         self


### PR DESCRIPTION
`& 0x1f` sets the left three bits to zero, but `| 0xe0` sets them back to one. The AND (`&`) can therefore be removed as unnecessary. This is similar to how in the NCS case there is only an AND (no OR).

- 0x1f = 00011111
- 0xe0 = 11100000