### PR TITLE
Prepare for 1.0.0 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ homepage = "https://github.com/uuid-rs/uuid"
 name = "uuid"
 readme = "README.md"
 repository = "https://github.com/uuid-rs/uuid"
-version = "1.0.0-alpha.1" # remember to update html_root_url in lib.rs
+version = "1.0.0" # remember to update html_root_url in lib.rs
 
 [package.metadata.docs.rs]
 features = ["serde", "arbitrary", "slog", "v1", "v3", "v4", "v5"]
@@ -132,7 +132,7 @@ version = "1"
 # Use the `macro-diagnostics` feature instead
 [dependencies.private_uuid-macro-internal]
 package = "uuid-macro-internal"
-version = "1.0.0-alpha.1"
+version = "1.0.0"
 path = "macros"
 optional = true
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Add the following to your `Cargo.toml`:
 
 ```toml
 [dependencies.uuid]
-version = "1.0.0-alpha.1"
+version = "1.0.0"
 features = [
     "v4",                # Lets you generate random UUIDs
     "fast-rng",          # Use a faster (but still sufficiently random) RNG
@@ -66,7 +66,7 @@ assert_eq!(Some(Version::Random), my_uuid.get_version());
 If you'd like to parse UUIDs _really_ fast, check out the [`uuid-simd`](https://github.com/nugine/uuid-simd)
 library.
 
-For more details on using `uuid`, [see the library documentation](https://docs.rs/uuid/1.0.0-alpha.1/uuid).
+For more details on using `uuid`, [see the library documentation](https://docs.rs/uuid/1.0.0/uuid).
 
 ## Minimum Supported Rust Version (MSRV)
 
@@ -75,7 +75,7 @@ CI. It may be bumped in minor releases as necessary.
 
 ## References
 
-* [`uuid` library docs](https://docs.rs/uuid/1.0.0-alpha.1/uuid).
+* [`uuid` library docs](https://docs.rs/uuid/1.0.0/uuid).
 * [Wikipedia: Universally Unique Identifier](http://en.wikipedia.org/wiki/Universally_unique_identifier).
 * [RFC4122: A Universally Unique IDentifier (UUID) URN Namespace](http://tools.ietf.org/html/rfc4122).
 

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uuid-macro-internal"
-version = "1.0.0-alpha.1"
+version = "1.0.0"
 edition = "2018"
 authors = [
     "QnnOkabayashi"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@
 //!
 //! ```toml
 //! [dependencies.uuid]
-//! version = "1.0.0-alpha.1"
+//! version = "1.0.0"
 //! features = [
 //!     "v4",                # Lets you generate random UUIDs
 //!     "fast-rng",          # Use a faster (but still sufficiently random) RNG
@@ -200,7 +200,7 @@
 #![doc(
     html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
     html_favicon_url = "https://www.rust-lang.org/favicon.ico",
-    html_root_url = "https://docs.rs/uuid/1.0.0-alpha.1"
+    html_root_url = "https://docs.rs/uuid/1.0.0"
 )]
 
 #[cfg(any(feature = "std", test))]


### PR DESCRIPTION
Closes #113

Well, here we are :tada: This PR officially stabilizes the `uuid` crate's API and semantics. There's some future work around support for v6-v8 UUIDs, but those will be done in a backwards compatible fashion. I haven't bumped our MSRV or anything here, since we can do that along with edition upgrades in minor releases as per our MSRV policy.

We've been sitting on this alpha release for a while now so I think it's time to commit.

cc @kinggoesgaming