### PR TITLE
note that the Error display impl is public API

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -127,6 +127,7 @@ impl<'a> InvalidUuid<'a> {
     }
 }
 
+// NOTE: This impl is part of the public API. Breaking changes to it should be carefully considered
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self.0 {


### PR DESCRIPTION
I just spotted https://github.com/diesel-rs/diesel/pull/3143 run through, where they make some assertions based on the shape of `uuid::Error`'s display implementation. I think it's safe to treat `Display` impls as public API and avoid churning them. I didn't drop any comment on the adapter types that format UUIDs themselves since I think that's pretty clear that the format is part of their contract.