### PR TITLE
Fixed documentation link

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -233,10 +233,10 @@ mod v4;
 #[cfg(feature = "v5")]
 mod v5;
 
-#[cfg(feature = "rng")]
-mod rng;
 #[cfg(feature = "md5")]
 mod md5;
+#[cfg(feature = "rng")]
+mod rng;
 #[cfg(feature = "sha1")]
 mod sha1;
 
@@ -334,10 +334,10 @@ pub enum Variant {
 ///
 /// A UUID can be formatted in one of a few ways:
 ///
-/// * [`simple`](#method.to_simple): `a1a2a3a4b1b2c1c2d1d2d3d4d5d6d7d8`.
+/// * [`simple`](#method.simple): `a1a2a3a4b1b2c1c2d1d2d3d4d5d6d7d8`.
 /// * [`hyphenated`](#method.hyphenated):
 ///   `a1a2a3a4-b1b2-c1c2-d1d2-d3d4d5d6d7d8`.
-/// * [`urn`](#method.to_urn): `urn:uuid:A1A2A3A4-B1B2-C1C2-D1D2-D3D4D5D6D7D8`.
+/// * [`urn`](#method.urn): `urn:uuid:A1A2A3A4-B1B2-C1C2-D1D2-D3D4D5D6D7D8`.
 /// * [`braced`](#method.braced): `{a1a2a3a4-b1b2-c1c2-d1d2-d3d4d5d6d7d8}`.
 ///
 /// The default representation when formatting a UUID with `Display` is
@@ -395,10 +395,7 @@ pub enum Variant {
 ///
 /// The `Uuid` type is always guaranteed to be have the same ABI as [`Bytes`].
 #[derive(Clone, Copy, Eq, Hash, Ord, PartialEq, PartialOrd)]
-#[cfg_attr(
-    feature = "zerocopy",
-    derive(AsBytes, FromBytes, Unaligned)
-)]
+#[cfg_attr(feature = "zerocopy", derive(AsBytes, FromBytes, Unaligned))]
 #[repr(transparent)]
 pub struct Uuid(Bytes);
 


### PR DESCRIPTION
**I'm submitting a** bug fix

# Description

The link to the `to_simple()` and `to_urn()` methods in the `Uuid` structure documentation were broken.

# Related Issue(s)

None