### PR TITLE
refactors Timestamp, Context and ClockSequence, and adds UUIDS v6, v7, v8

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,7 +1,7 @@
 name: Continuous integration
 
 env:
-  VERSION_FEATURES: "v1 v3 v4 v5"
+  VERSION_FEATURES: "v1 v3 v4 v5 v6 v7"
   STABLE_DEP_FEATURES: "serde arbitrary"
 
 on:
@@ -39,11 +39,11 @@ jobs:
         os:
         - macos-10.15
         - ubuntu-20.04
-        rust_target: 
+        rust_target:
         - x86_64-gnu
         - x86_64-msvc
         - x86_64-apple-darwin
-  
+
     steps:
     - name: Checkout repository
       uses: actions/checkout@v2
@@ -66,7 +66,7 @@ jobs:
 
     - name: Each version feature
       run: cargo hack test --lib --each-feature --optional-deps $STABLE_DEP_FEATURES
-    
+
     - name: All version features
       run: cargo hack test --lib --each-feature --features "$VERSION_FEATURES" --optional-deps "$STABLE_DEP_FEATURES"
 
@@ -108,10 +108,10 @@ jobs:
 
       - name: Version features
         run: wasm-pack test --node -- --features "$VERION_FEATURES $STABLE_DEP_FEATURES js"
-      
+
       - name: Fast RNG
         run: wasm-pack test --node -- --features "js v4 fast-rng"
-  
+
   mips:
     name: Tests / MIPS (Big Endian)
     runs-on: ubuntu-latest
@@ -155,7 +155,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: -Z avoid-dev-deps --target thumbv6m-none-eabi --no-default-features --features "v1 v3 v5 serde"
+          args: -Z avoid-dev-deps --target thumbv6m-none-eabi --no-default-features --features "v1 v3 v5 v6 v7 serde"
 
   nodeps:
     name: Build / No deps
@@ -180,7 +180,7 @@ jobs:
         run: cargo hack check --each-feature -Z avoid-dev-deps
   win_tests:
     name: "Tests / OS: Windows 2019 - ${{ matrix.channel }}-${{ matrix.rust_target }}"
-    runs-on: windows-2019 
+    runs-on: windows-2019
     env:
       RUSTFLAGS: "--cfg uuid_unstable"
       RUSTDOCFLAGS: "--cfg uuid_unstable"
@@ -192,7 +192,7 @@ jobs:
         - nightly
         os:
         - windows-2019
-        rust_target: 
+        rust_target:
         - x86_64-gnu
         - x86_64-msvc
     steps:
@@ -223,7 +223,7 @@ jobs:
 
   win-msrv:
     name: "Tests / MSRV / OS: Windows 2019"
-    runs-on: windows-2019 
+    runs-on: windows-2019
     steps:
     - name: Checkout sources
       uses: actions/checkout@v2

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,6 @@ jobs:
         - nightly
         os:
         - macos-10.15
-        - windows-2019
         - ubuntu-20.04
         rust_target: 
         - x86_64-gnu
@@ -69,7 +68,7 @@ jobs:
       run: cargo hack test --lib --each-feature --optional-deps $STABLE_DEP_FEATURES
     
     - name: All version features
-      run: cargo hack test --lib --features "$VERSION_FEATURES" --each-feature --optional-deps "$STABLE_DEP_FEATURES"
+      run: cargo hack test --lib --each-feature --features "$VERSION_FEATURES" --optional-deps "$STABLE_DEP_FEATURES"
 
   msrv:
     name: "Tests / MSRV / OS: ${{ matrix.os }}"
@@ -78,7 +77,6 @@ jobs:
       matrix:
         os:
         - macos-10.15
-        - windows-2019
         - ubuntu-20.04
 
     steps:
@@ -120,7 +118,6 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
-      
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -154,7 +151,6 @@ jobs:
         with:
           command: build
           args: -Z avoid-dev-deps --target thumbv6m-none-eabi --no-default-features
-      
       - name: Version features
         uses: actions-rs/cargo@v1
         with:
@@ -182,3 +178,62 @@ jobs:
 
       - name: Powerset
         run: cargo hack check --each-feature -Z avoid-dev-deps
+  win_tests:
+    name: "Tests / OS: Windows 2019 - ${{ matrix.channel }}-${{ matrix.rust_target }}"
+    runs-on: windows-2019 
+    env:
+      RUSTFLAGS: "--cfg uuid_unstable"
+      RUSTDOCFLAGS: "--cfg uuid_unstable"
+    strategy:
+      matrix:
+        channel:
+        - stable
+        - beta
+        - nightly
+        os:
+        - windows-2019
+        rust_target: 
+        - x86_64-gnu
+        - x86_64-msvc
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Install Rust Toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        override: true
+        profile: minimal
+        toolchain: ${{ matrix.channel }}-${{ matrix.rust_target }}
+
+    - name: Install cargo-hack
+      run: cargo install cargo-hack
+
+    - name: Docs
+      run: cargo test --all-features --doc
+
+    - name: Examples
+      run: cargo test --all-features --examples
+
+    - name: Each version feature
+      run: cargo hack test --lib --each-feature --optional-deps $env:STABLE_DEP_FEATURES
+
+    - name: All version features
+      run: cargo hack test --lib --each-feature --features "$env:VERSION_FEATURES" --optional-deps "$env:STABLE_DEP_FEATURES"
+
+  win-msrv:
+    name: "Tests / MSRV / OS: Windows 2019"
+    runs-on: windows-2019 
+    steps:
+    - name: Checkout sources
+      uses: actions/checkout@v2
+
+    - name: Install Rust toolchain
+      uses: actions-rs/toolchain@v1
+      with:
+        profile: minimal
+        toolchain: 1.57.0
+        override: true
+
+    - name: Version features
+      run: cargo test --features "$env:VERSION_FEATURES $env:STABLE_DEP_FEATURES"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: Continuous integration
 
+env:
+  VERSION_FEATURES: "v1 v3 v4 v5"
+  STABLE_DEP_FEATURES: "serde arbitrary"
+
 on:
   pull_request:
   push:
@@ -61,8 +65,11 @@ jobs:
     - name: Examples
       run: cargo test --all-features --examples
 
-    - name: Powerset
-      run: cargo hack test --feature-powerset --lib --optional-deps "serde arbitrary" --depth 3
+    - name: Each version feature
+      run: cargo hack test --lib --each-feature --optional-deps $STABLE_DEP_FEATURES
+    
+    - name: All version features
+      run: cargo hack test --lib --features "$VERSION_FEATURES" --each-feature --optional-deps "$STABLE_DEP_FEATURES"
 
   msrv:
     name: "Tests / MSRV / OS: ${{ matrix.os }}"
@@ -86,7 +93,7 @@ jobs:
         override: true
 
     - name: Version features
-      run: cargo test --features "v1 v3 v4 v5 serde"
+      run: cargo test --features "$VERSION_FEATURES $STABLE_DEP_FEATURES"
 
   wasm:
     name: Tests / WebAssembly
@@ -102,7 +109,7 @@ jobs:
         run: wasm-pack test --node
 
       - name: Version features
-        run: wasm-pack test --node -- --features "js v1 v3 v4 v5"
+        run: wasm-pack test --node -- --features "$VERION_FEATURES $STABLE_DEP_FEATURES js"
       
       - name: Fast RNG
         run: wasm-pack test --node -- --features "js v4 fast-rng"
@@ -174,4 +181,4 @@ jobs:
         run: cargo install cargo-hack
 
       - name: Powerset
-        run: cargo hack check --feature-powerset -Z avoid-dev-deps
+        run: cargo hack check --each-feature -Z avoid-dev-deps

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,7 +155,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: build
-          args: -Z avoid-dev-deps --target thumbv6m-none-eabi --no-default-features --features "v1 v3 v5 v6 v7 serde"
+          args: -Z avoid-dev-deps --target thumbv6m-none-eabi --no-default-features --features "v1 v3 v5 v6 serde"
 
   nodeps:
     name: Build / No deps

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,14 +51,15 @@ repository = "uuid-rs/uuid"
 default = ["std"]
 std = []
 macro-diagnostics = ["private_uuid-macro-internal"]
-
-# NOTE: When adding new features, check the `ci.yml` workflow
+# NOTE: When adding new features, check the `ci.yml` workflow                                              ..
 # and include them where necessary (you can follow along with existing features)
 v1 = ["private_atomic"]
 v3 = ["md5"]
 v4 = ["rng"]
 v5 = ["sha1"]
-
+v6 = ["private_atomic"]
+v7 = ["rng"]
+v8 = []
 js = ["private_getrandom", "private_getrandom/js"]
 
 rng = ["private_getrandom"]
@@ -86,7 +87,7 @@ version = "1"
 # Public (unstable): Used in `zerocopy` derive
 # Unstable: also need RUSTFLAGS="--cfg uuid_unstable" to work
 # This feature may break between releases, or be removed entirely before
-# stabilization. 
+# stabilization.
 # See: https://github.com/uuid-rs/uuid/issues/588
 [dependencies.zerocopy]
 optional = true
@@ -135,8 +136,6 @@ version = "1.1.2"
 path = "macros"
 optional = true
 
-# Private
-# Don't depend on this optional feature directly: it may change at any time
 [dependencies.private_atomic]
 package = "atomic"
 default-features = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,13 +51,14 @@ repository = "uuid-rs/uuid"
 default = ["std"]
 std = []
 macro-diagnostics = ["private_uuid-macro-internal"]
+
+# NOTE: When adding new features, check the `ci.yml` workflow
+# and include them where necessary (you can follow along with existing features)
 v1 = ["private_atomic"]
 v3 = ["md5"]
 v4 = ["rng"]
 v5 = ["sha1"]
-v6 = ["private_atomic"]
-v7 = ["rng"]
-v8 = []
+
 js = ["private_getrandom", "private_getrandom/js"]
 
 rng = ["private_getrandom"]
@@ -85,7 +86,7 @@ version = "1"
 # Public (unstable): Used in `zerocopy` derive
 # Unstable: also need RUSTFLAGS="--cfg uuid_unstable" to work
 # This feature may break between releases, or be removed entirely before
-# stabilization.
+# stabilization. 
 # See: https://github.com/uuid-rs/uuid/issues/588
 [dependencies.zerocopy]
 optional = true
@@ -134,6 +135,8 @@ version = "1.1.2"
 path = "macros"
 optional = true
 
+# Private
+# Don't depend on this optional feature directly: it may change at any time
 [dependencies.private_atomic]
 package = "atomic"
 default-features = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -82,7 +82,7 @@ version = "2"
 # Public: Used in trait impls on `Uuid`
 [dependencies.arbitrary]
 optional = true
-version = "1"
+version = "=1.1.3"
 
 # Public (unstable): Used in `zerocopy` derive
 # Unstable: also need RUSTFLAGS="--cfg uuid_unstable" to work

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,9 +66,6 @@ fast-rng = ["rng", "private_rand"]
 sha1 = ["private_sha1_smol"]
 md5 = ["private_md-5"]
 
-[dependencies]
-num-traits = "0.2.15"
-
 # Public: Used in trait impls on `Uuid`
 [dependencies.serde]
 default-features = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ categories = [
 ]
 description = "A library to generate and parse UUIDs."
 documentation = "https://docs.rs/uuid"
-edition = "2021"
+edition = "2018"
 exclude = [
     ".github/**"
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ categories = [
 ]
 description = "A library to generate and parse UUIDs."
 documentation = "https://docs.rs/uuid"
-edition = "2018"
+edition = "2021"
 exclude = [
     ".github/**"
 ]
@@ -51,12 +51,13 @@ repository = "uuid-rs/uuid"
 default = ["std"]
 std = []
 macro-diagnostics = ["private_uuid-macro-internal"]
-
-v1 = ["private_atomic"]
+v1 = []
 v3 = ["md5"]
 v4 = ["rng"]
 v5 = ["sha1"]
-
+v6 = []
+v7 = ["rng"]
+v8 = []
 js = ["private_getrandom", "private_getrandom/js"]
 
 rng = ["private_getrandom"]
@@ -64,6 +65,9 @@ fast-rng = ["rng", "private_rand"]
 
 sha1 = ["private_sha1_smol"]
 md5 = ["private_md-5"]
+
+[dependencies]
+num-traits = "0.2.15"
 
 # Public: Used in trait impls on `Uuid`
 [dependencies.serde]
@@ -84,7 +88,7 @@ version = "1"
 # Public (unstable): Used in `zerocopy` derive
 # Unstable: also need RUSTFLAGS="--cfg uuid_unstable" to work
 # This feature may break between releases, or be removed entirely before
-# stabilization. 
+# stabilization.
 # See: https://github.com/uuid-rs/uuid/issues/588
 [dependencies.zerocopy]
 optional = true
@@ -132,14 +136,6 @@ package = "uuid-macro-internal"
 version = "1.1.2"
 path = "macros"
 optional = true
-
-# Private
-# Don't depend on this optional feature directly: it may change at any time
-[dependencies.private_atomic]
-package = "atomic"
-default-features = false
-optional = true
-version = "0.5"
 
 [dev-dependencies.bincode]
 version = "1.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,11 +51,11 @@ repository = "uuid-rs/uuid"
 default = ["std"]
 std = []
 macro-diagnostics = ["private_uuid-macro-internal"]
-v1 = []
+v1 = ["private_atomic"]
 v3 = ["md5"]
 v4 = ["rng"]
 v5 = ["sha1"]
-v6 = []
+v6 = ["private_atomic"]
 v7 = ["rng"]
 v8 = []
 js = ["private_getrandom", "private_getrandom/js"]
@@ -133,6 +133,12 @@ package = "uuid-macro-internal"
 version = "1.1.2"
 path = "macros"
 optional = true
+
+[dependencies.private_atomic]
+package = "atomic"
+default-features = false
+optional = true
+version = "0.5"
 
 [dev-dependencies.bincode]
 version = "1.0"

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -307,7 +307,7 @@ impl Uuid {
     /// Basic usage:
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # fn main() -> Result<(), uuid::Error> {
     /// # use uuid::Uuid;
     /// let bytes = [
     ///     0xa1, 0xa2, 0xa3, 0xa4,
@@ -348,7 +348,7 @@ impl Uuid {
     /// Basic usage:
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # fn main() -> Result<(), uuid::Error> {
     /// # use uuid::Uuid;
     /// let bytes = [
     ///     0xa1, 0xa2, 0xa3, 0xa4,
@@ -383,7 +383,7 @@ impl Uuid {
     /// Basic usage:
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # fn main() -> Result<(), uuid::Error> {
     /// # use uuid::Uuid;
     /// let bytes = [
     ///     0xa1, 0xa2, 0xa3, 0xa4,
@@ -414,7 +414,7 @@ impl Uuid {
     /// Basic usage:
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # fn main() -> Result<(), uuid::Error> {
     /// # use uuid::Uuid;
     /// let bytes = [
     ///     0xa1, 0xa2, 0xa3, 0xa4,
@@ -446,7 +446,7 @@ impl Uuid {
     /// Basic usage:
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # fn main() -> Result<(), uuid::Error> {
     /// # use uuid::Uuid;
     /// let bytes = [
     ///     0xa1, 0xa2, 0xa3, 0xa4,
@@ -515,7 +515,7 @@ impl Builder {
     /// Basic usage:
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # fn main() -> Result<(), uuid::Error> {
     /// # use uuid::{Builder, Uuid};
     /// let bytes = [
     ///     0xa1, 0xa2, 0xa3, 0xa4,
@@ -589,7 +589,7 @@ impl Builder {
     ///
     /// ```
     /// # use uuid::Builder;
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # fn main() -> Result<(), uuid::Error> {
     /// let bytes = [
     ///     0xa1, 0xa2, 0xa3, 0xa4,
     ///     0xb1, 0xb2,
@@ -624,7 +624,7 @@ impl Builder {
     ///
     /// ```
     /// # use uuid::Builder;
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # fn main() -> Result<(), uuid::Error> {
     /// let bytes = [
     ///     0xa1, 0xa2, 0xa3, 0xa4,
     ///     0xb1, 0xb2,

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -40,7 +40,7 @@ use crate::{error::*, Bytes, Uuid, Variant, Version};
 /// ```
 #[allow(missing_copy_implementations)]
 #[derive(Debug)]
-pub struct Builder(pub Uuid);
+pub struct Builder(Uuid);
 
 impl Uuid {
     /// The 'nil UUID'.

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -40,7 +40,7 @@ use crate::{error::*, Bytes, Uuid, Variant, Version};
 /// ```
 #[allow(missing_copy_implementations)]
 #[derive(Debug)]
-pub struct Builder(Uuid);
+pub struct Builder(pub Uuid);
 
 impl Uuid {
     /// The 'nil UUID'.
@@ -65,6 +65,30 @@ impl Uuid {
     /// ```
     pub const fn nil() -> Self {
         Uuid::from_bytes([0; 16])
+    }
+
+    /// The 'max UUID'.
+    ///
+    /// The max UUID is a special form of UUID that is specified to have all
+    /// 128 bits set to one, as defined in [IETF RFC 4122 Update Section 5.4][Draft RFC].
+    ///
+    /// [Draft RFC]: https://datatracker.ietf.org/doc/html/draft-peabody-dispatch-new-uuid-format-04#page-12
+    ///
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// # use uuid::Uuid;
+    /// let uuid = Uuid::max();
+    ///
+    /// assert_eq!(
+    ///     "ffffffff-ffff-ffff-ffff-ffffffffffff",
+    ///     uuid.hyphenated().to_string(),
+    /// );
+    /// ```
+    pub const fn max() -> Self {
+        Uuid::from_bytes([0xFF; 16])
     }
 
     /// Creates a UUID from four field values.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -241,7 +241,7 @@ mod v5;
 #[cfg(feature = "v6")]
 mod v6;
 #[cfg(feature = "v7")]
-mod v7;
+pub mod v7;
 #[cfg(feature = "v8")]
 mod v8;
 
@@ -891,8 +891,7 @@ impl Uuid {
                     | (bytes[2] as u64) << 8
                     | (bytes[3] as u64);
 
-                let counter: u16 =
-                    ((bytes[8] & 0x3F) as u16) << 8 | (bytes[9] as u16);
+                let counter: u16 = ((bytes[8] & 0x3F) as u16) << 8 | (bytes[9] as u16);
 
                 Some(crate::timestamp::Timestamp::from_rfc4122(ticks, counter))
             }
@@ -907,8 +906,7 @@ impl Uuid {
                     | ((bytes[6] & 0xF) as u64) << 8
                     | (bytes[7] as u64);
 
-                let counter: u16 =
-                    ((bytes[8] & 0x3F) as u16) << 8 | (bytes[9] as u16);
+                let counter: u16 = ((bytes[8] & 0x3F) as u16) << 8 | (bytes[9] as u16);
 
                 Some(crate::timestamp::Timestamp::from_rfc4122(ticks, counter))
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -883,17 +883,18 @@ impl Uuid {
     ) -> Option<(crate::timestamp::Timestamp, u16)> {
         match self.get_version() {
             Some(Version::Mac) => {
-                let ticks: u64 = ((self.as_bytes()[6] & 0x0F) as u64) << 56
-                    | ((self.as_bytes()[7]) as u64) << 48
-                    | ((self.as_bytes()[4]) as u64) << 40
-                    | ((self.as_bytes()[5]) as u64) << 32
-                    | ((self.as_bytes()[0]) as u64) << 24
-                    | ((self.as_bytes()[1]) as u64) << 16
-                    | ((self.as_bytes()[2]) as u64) << 8
-                    | (self.as_bytes()[3] as u64);
+                let bytes = self.as_bytes();
+                let ticks: u64 = ((bytes[6] & 0x0F) as u64) << 56
+                    | (bytes[7] as u64) << 48
+                    | (bytes[4] as u64) << 40
+                    | (bytes[5] as u64) << 32
+                    | (bytes[0] as u64) << 24
+                    | (bytes[1] as u64) << 16
+                    | (bytes[2] as u64) << 8
+                    | (bytes[3] as u64);
 
-                let counter: u16 = ((self.as_bytes()[8] & 0x3F) as u16) << 8
-                    | (self.as_bytes()[9] as u16);
+                let counter: u16 =
+                    ((bytes[8] & 0x3F) as u16) << 8 | (bytes[9] as u16);
 
                 Some((
                     crate::timestamp::Timestamp::from_rfc4122(ticks),
@@ -901,21 +902,37 @@ impl Uuid {
                 ))
             }
             Some(Version::SortMac) => {
+                let bytes = self.as_bytes();
                 let ticks: u64 = ((self.as_bytes()[0]) as u64) << 52
-                    | ((self.as_bytes()[1]) as u64) << 44
-                    | ((self.as_bytes()[2]) as u64) << 36
-                    | ((self.as_bytes()[3]) as u64) << 28
-                    | ((self.as_bytes()[4]) as u64) << 20
-                    | ((self.as_bytes()[5]) as u64) << 12
-                    | ((self.as_bytes()[6] & 0xF) as u64) << 8
-                    | (self.as_bytes()[7] as u64);
+                    | (bytes[1] as u64) << 44
+                    | (bytes[2] as u64) << 36
+                    | (bytes[3] as u64) << 28
+                    | (bytes[4] as u64) << 20
+                    | (bytes[5] as u64) << 12
+                    | ((bytes[6] & 0xF) as u64) << 8
+                    | (bytes[7] as u64);
 
-                let counter: u16 = ((self.as_bytes()[8] & 0x3F) as u16) << 8
-                    | (self.as_bytes()[9] as u16);
+                let counter: u16 =
+                    ((bytes[8] & 0x3F) as u16) << 8 | (bytes[9] as u16);
 
                 Some((
                     crate::timestamp::Timestamp::from_rfc4122(ticks),
                     counter,
+                ))
+            }
+            Some(Version::SortRand) => {
+                let bytes = self.as_bytes();
+                let millis: u64 = (bytes[0] as u64) << 40
+                    | (bytes[1] as u64) << 32
+                    | (bytes[2] as u64) << 24
+                    | (bytes[3] as u64) << 16
+                    | (bytes[4] as u64) << 8
+                    | (bytes[5] as u64);
+                let seconds = millis / 1000;
+                let nanos = ((millis % 1000) * 1_000_000) as u32;
+                Some((
+                    crate::timestamp::Timestamp::from_unix(seconds, nanos),
+                    0,
                 ))
             }
             _ => None,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -227,7 +227,7 @@ pub mod timestamp;
 
 pub use timestamp::{ClockSequence, Timestamp};
 
-#[cfg(any(feature = "v1", feature = "v3"))]
+#[cfg(any(feature = "v1", feature = "v6"))]
 pub use timestamp::context::Context;
 
 #[cfg(feature = "v1")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,7 +157,7 @@
 //!
 //! ```
 //! # use uuid::Uuid;
-//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # fn main() -> Result<(), uuid::Error> {
 //! let my_uuid = Uuid::parse_str("a1a2a3a4b1b2c1c2d1d2d3d4d5d6d7d8")?;
 //!
 //! println!("{}", my_uuid.urn());
@@ -326,7 +326,7 @@ pub enum Variant {
 ///
 /// ```
 /// # use uuid::Uuid;
-/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// # fn main() -> Result<(), uuid::Error> {
 /// let my_uuid = Uuid::parse_str("a1a2a3a4b1b2c1c2d1d2d3d4d5d6d7d8")?;
 ///
 /// println!("{}", my_uuid.urn());
@@ -363,7 +363,7 @@ pub enum Variant {
 ///
 /// ```
 /// # use uuid::Uuid;
-/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// # fn main() -> Result<(), uuid::Error> {
 /// let my_uuid = Uuid::parse_str("a1a2a3a4b1b2c1c2d1d2d3d4d5d6d7d8")?;
 ///
 /// assert_eq!(
@@ -378,7 +378,7 @@ pub enum Variant {
 ///
 /// ```
 /// # use uuid::Uuid;
-/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// # fn main() -> Result<(), uuid::Error> {
 /// let my_uuid = Uuid::parse_str("a1a2a3a4b1b2c1c2d1d2d3d4d5d6d7d8")?;
 ///
 /// assert_eq!(
@@ -454,7 +454,7 @@ impl Uuid {
     ///
     /// ```
     /// # use uuid::{Uuid, Variant};
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # fn main() -> Result<(), uuid::Error> {
     /// let my_uuid = Uuid::parse_str("02f09a3f-1624-3b1d-8409-44eff7708208")?;
     ///
     /// assert_eq!(Variant::RFC4122, my_uuid.get_variant());
@@ -489,7 +489,7 @@ impl Uuid {
     ///
     /// ```
     /// # use uuid::Uuid;
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # fn main() -> Result<(), uuid::Error> {
     /// let my_uuid = Uuid::parse_str("02f09a3f-1624-3b1d-8409-44eff7708208")?;
     ///
     /// assert_eq!(3, my_uuid.get_version_num());
@@ -519,7 +519,7 @@ impl Uuid {
     ///
     /// ```
     /// # use uuid::{Uuid, Version};
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # fn main() -> Result<(), uuid::Error> {
     /// let my_uuid = Uuid::parse_str("02f09a3f-1624-3b1d-8409-44eff7708208")?;
     ///
     /// assert_eq!(Some(Version::Md5), my_uuid.get_version());
@@ -569,7 +569,7 @@ impl Uuid {
     ///
     /// ```
     /// # use uuid::Uuid;
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # fn main() -> Result<(), uuid::Error> {
     /// let uuid = Uuid::nil();
     ///
     /// assert_eq!(uuid.as_fields(), (0, 0, 0, &[0u8; 8]));
@@ -616,7 +616,7 @@ impl Uuid {
     /// ```
     /// use uuid::Uuid;
     ///
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # fn main() -> Result<(), uuid::Error> {
     /// let uuid = Uuid::parse_str("a1a2a3a4-b1b2-c1c2-d1d2-d3d4d5d6d7d8")?;
     ///
     /// assert_eq!(
@@ -653,7 +653,7 @@ impl Uuid {
     ///
     /// ```
     /// # use uuid::Uuid;
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # fn main() -> Result<(), uuid::Error> {
     /// let uuid = Uuid::parse_str("a1a2a3a4-b1b2-c1c2-d1d2-d3d4d5d6d7d8")?;
     ///
     /// assert_eq!(
@@ -697,7 +697,7 @@ impl Uuid {
     ///
     /// ```
     /// # use uuid::Uuid;
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # fn main() -> Result<(), uuid::Error> {
     /// let uuid = Uuid::parse_str("a1a2a3a4-b1b2-c1c2-d1d2-d3d4d5d6d7d8")?;
     ///
     /// assert_eq!(
@@ -736,7 +736,7 @@ impl Uuid {
     ///
     /// ```
     /// # use uuid::Uuid;
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # fn main() -> Result<(), uuid::Error> {
     /// let uuid = Uuid::parse_str("a1a2a3a4-b1b2-c1c2-d1d2-d3d4d5d6d7d8")?;
     /// assert_eq!(
     ///     uuid.as_u64_pair(),
@@ -810,7 +810,7 @@ impl Uuid {
     /// ```
     /// use uuid::Uuid;
     ///
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # fn main() -> Result<(), uuid::Error> {
     /// let uuid = Uuid::parse_str("a1a2a3a4-b1b2-c1c2-d1d2-d3d4d5d6d7d8")?;
     ///
     /// assert_eq!(

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -51,7 +51,7 @@ impl Uuid {
     ///
     /// ```
     /// # use uuid::{Uuid, Version, Variant};
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # fn main() -> Result<(), uuid::Error> {
     /// let uuid = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000")?;
     ///
     /// assert_eq!(Some(Version::Random), uuid.get_version());
@@ -84,7 +84,7 @@ impl Uuid {
     ///
     /// ```
     /// # use uuid::{Uuid, Version, Variant};
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # fn main() -> Result<(), uuid::Error> {
     /// let uuid = Uuid::try_parse("550e8400-e29b-41d4-a716-446655440000")?;
     ///
     /// assert_eq!(Some(Version::Random), uuid.get_version());
@@ -112,7 +112,7 @@ impl Uuid {
     ///
     /// ```
     /// # use uuid::{Uuid, Version, Variant};
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # fn main() -> Result<(), uuid::Error> {
     /// let uuid = Uuid::try_parse_ascii(b"550e8400-e29b-41d4-a716-446655440000")?;
     ///
     /// assert_eq!(Some(Version::Random), uuid.get_version());

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -18,7 +18,7 @@ pub(crate) fn bytes() -> [u8; 16] {
     }
 }
 
-#[cfg(any(feature = "v1", feature = "v7"))]
+#[cfg(any(feature = "v1", feature = "v6", feature = "v7"))]
 pub(crate) fn u16() -> u16 {
     #[cfg(not(feature = "fast-rng"))]
     {

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -1,4 +1,4 @@
-#[cfg(feature = "v4")]
+#[cfg(any(feature = "v4", feature = "v7"))]
 pub(crate) fn bytes() -> [u8; 16] {
     #[cfg(not(feature = "fast-rng"))]
     {
@@ -18,7 +18,7 @@ pub(crate) fn bytes() -> [u8; 16] {
     }
 }
 
-#[cfg(feature = "v1")]
+#[cfg(any(feature = "v1", feature = "v7"))]
 pub(crate) fn u16() -> u16 {
     #[cfg(not(feature = "fast-rng"))]
     {

--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -39,6 +39,7 @@ impl Timestamp {
 
     /// Construct a `Timestamp` from the current time of day
     /// according to Rust's SystemTime
+    #[cfg(feature = "std")]
     pub fn now() -> Self {
         let dur = std::time::SystemTime::UNIX_EPOCH
             .elapsed()
@@ -111,7 +112,7 @@ impl<'a, T: ClockSequence + ?Sized> ClockSequence for &'a T {
 }
 
 /// For features v1 and v1, constructs a `Context` struct which implements the `ClockSequence` trait
-#[cfg(any(feature = "v1", feature = "v6"))]
+#[cfg(any(feature = "v1", feature = "v6", feature = "v7"))]
 pub mod context {
     use std::sync::atomic::{AtomicU16, Ordering};
     /// A thread-safe, stateful context for the v1 generator to help ensure

--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -69,11 +69,13 @@ impl Timestamp {
 
     /// Construct a `Timestamp` from the current time of day
     /// according to Rust's SystemTime
+    /// NOTE: This function will panic if the current system time is earlier than
+    /// the Unix Epoch of 1970-01-01 00:00:00  So please use caution when time travelling.
     #[cfg(all(feature = "std", not(any(feature = "v1", feature = "v6"))))]
     pub fn now() -> Self {
         let dur = std::time::SystemTime::UNIX_EPOCH
             .elapsed()
-            .expect("Getting elapsed time since UNIX_EPOCH.  If this fails, we've somehow violated causality");
+            .expect("Getting elapsed time since UNIX_EPOCH failed. This is due to a system time that is somehow earlier than Unix Epoch.");
         Timestamp {
             seconds: dur.as_secs(),
             nanos: dur.subsec_nanos(),

--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -1,0 +1,169 @@
+/// Contains the `Timestamp` struct and `ClockSequence` traits
+/// as well as an implementation of ClockSequence for Context (only for features v1 and v6)
+
+/// The number of 100 ns ticks between the UUID epoch
+/// `1582-10-15 00:00:00` and the Unix epoch `1970-01-01 00:00:00`.
+pub const UUID_TICKS_BETWEEN_EPOCHS: u64 = 0x01B2_1DD2_1381_4000;
+/// Stores the number of seconds since epoch,
+/// as well as the fractional nanoseconds of that second
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct Timestamp {
+    pub(crate) seconds: u64,
+    pub(crate) nanos: u32,
+}
+
+impl Timestamp {
+    /// Construct a `Timestamp` from its raw component values: an RFC4122
+    /// timestamp and counter.
+    ///
+    /// RFC4122, which defines the V1 UUID, specifies a 60-byte timestamp format
+    /// as the number of 100-nanosecond intervals elapsed since 00:00:00.00,
+    /// 15 Oct 1582, "the date of the Gregorian reform of the Christian
+    /// calendar."
+    pub const fn from_rfc4122(ticks: u64) -> Self {
+        let (seconds, nanos) = Self::rfc4122_to_unix(ticks);
+        Timestamp { seconds, nanos }
+    }
+
+    /// Construct a `Timestamp` from a unix timestamp
+    ///
+    /// A unix timestamp represents the elapsed time since Jan 1 1970. Libc's
+    /// `clock_gettime` and other popular implementations traditionally
+    /// represent this duration as a `timespec`: a struct with `u64` and
+    /// `u32` fields representing the seconds, and "subsecond" or fractional
+    /// nanoseconds elapsed since the timestamp's second began,
+    /// respectively.
+    pub fn from_unix(seconds: u64, nanos: u32) -> Self {
+        Timestamp { seconds, nanos }
+    }
+
+    /// Construct a `Timestamp` from the current time of day
+    /// according to Rust's SystemTime
+    pub fn now() -> Self {
+        let dur = std::time::SystemTime::UNIX_EPOCH
+            .elapsed()
+            .expect("Getting elapsed time since UNIX_EPOCH.  If this fails, we've somehow violated causality");
+        Timestamp {
+            seconds: dur.as_secs(),
+            nanos: dur.subsec_nanos(),
+        }
+    }
+
+    /// Returns the raw RFC4122 timestamp "tick" values stored by the
+    /// `Timestamp`.
+    ///
+    /// The ticks represent the  number of 100-nanosecond intervals
+    /// since 00:00:00.00, 15 Oct 1582.
+    pub const fn to_rfc4122(&self) -> u64 {
+        Self::unix_to_rfc4122_ticks(self.seconds, self.nanos)
+    }
+
+    /// Returns the timestamp converted to the seconds and fractional
+    /// nanoseconds since Jan 1 1970.
+    pub const fn to_unix(&self) -> (u64, u32) {
+        (self.seconds, self.nanos)
+    }
+
+    /// Returns the timestamp converted into nanoseconds elapsed since Jan 1
+    /// 1970.
+    pub const fn to_unix_nanos(&self) -> u32 {
+        self.nanos
+    }
+
+    /// internal utility functions for converting between Unix and Uuid-epoch
+    /// convert unix-timestamp into rfc4122 ticks
+    const fn unix_to_rfc4122_ticks(seconds: u64, nanos: u32) -> u64 {
+        let ticks = UUID_TICKS_BETWEEN_EPOCHS
+            + seconds * 10_000_000
+            + nanos as u64 / 100;
+
+        ticks
+    }
+
+    /// convert rfc4122 ticks into unix-timestamp
+    const fn rfc4122_to_unix(ticks: u64) -> (u64, u32) {
+        (
+            (ticks - UUID_TICKS_BETWEEN_EPOCHS) / 10_000_000,
+            ((ticks - UUID_TICKS_BETWEEN_EPOCHS) % 10_000_000) as u32 * 100,
+        )
+    }
+}
+
+/// A trait that abstracts over generation of UUID v1 "Clock Sequence" values.
+///
+/// # References
+///
+/// * [Clock Sequence in RFC4122](https://datatracker.ietf.org/doc/html/rfc4122#section-4.1.5)
+pub trait ClockSequence {
+    /// The primitive type you wish out output
+    type Output;
+    /// Return an arbitrary width number that will be used as the "clock sequence" in
+    /// the UUID. The number must be different if the time has changed since
+    /// the last time a clock sequence was requested.
+    fn next(&self, ts: &Timestamp) -> Self::Output;
+}
+
+impl<'a, T: ClockSequence + ?Sized> ClockSequence for &'a T {
+    type Output = T::Output;
+    fn next(&self, ts: &Timestamp) -> Self::Output {
+        (**self).next(ts)
+    }
+}
+
+/// For features v1 and v1, constructs a `Context` struct which implements the `ClockSequence` trait
+#[cfg(any(feature = "v1", feature = "v6"))]
+pub mod context {
+    use std::sync::atomic::{AtomicU16, Ordering};
+    /// A thread-safe, stateful context for the v1 generator to help ensure
+    /// process-wide uniqueness.
+    #[derive(Debug)]
+    pub struct Context {
+        count: AtomicU16,
+    }
+
+    impl Context {
+        /// Creates a thread-safe, internally mutable context to help ensure
+        /// uniqueness.
+        ///
+        /// This is a context which can be shared across threads. It maintains an
+        /// internal counter that is incremented at every request, the value ends
+        /// up in the clock_seq portion of the UUID (the fourth group). This
+        /// will improve the probability that the UUID is unique across the
+        /// process.
+        pub const fn new(count: u16) -> Self {
+            Self {
+                count: AtomicU16::new(count),
+            }
+        }
+
+        /// Creates a thread-safe, internally mutable context that's seeded with a
+        /// random value.
+        ///
+        /// This method requires either the `rng` or `fast-rng` feature to also be
+        /// enabled.
+        ///
+        /// This is a context which can be shared across threads. It maintains an
+        /// internal counter that is incremented at every request, the value ends
+        /// up in the clock_seq portion of the UUID (the fourth group). This
+        /// will improve the probability that the UUID is unique across the
+        /// process.
+        #[cfg(feature = "rng")]
+        pub fn new_random() -> Self {
+            Self {
+                count: AtomicU16::new(crate::rng::u16()),
+            }
+        }
+    }
+
+    impl super::ClockSequence for Context {
+        type Output = u16;
+        fn next(&self, _: &super::Timestamp) -> Self::Output {
+            // RFC4122 reserves 2 bits of the clock sequence so the actual
+            // maximum value is smaller than `u16::MAX`. Since we unconditionally
+            // increment the clock sequence we want to wrap once it becomes larger
+            // than what we can represent in a "u14". Otherwise there'd be patches
+            // where the clock sequence doesn't change regardless of the timestamp
+            self.count.fetch_add(1, Ordering::AcqRel) % (u16::MAX >> 2)
+        }
+    }
+}

--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -112,14 +112,14 @@ impl<'a, T: ClockSequence + ?Sized> ClockSequence for &'a T {
 }
 
 /// For features v1 and v1, constructs a `Context` struct which implements the `ClockSequence` trait
-#[cfg(any(feature = "v1", feature = "v6", feature = "v7"))]
+#[cfg(any(feature = "v1", feature = "v6"))]
 pub mod context {
-    use std::sync::atomic::{AtomicU16, Ordering};
+    use private_atomic::{Atomic, Ordering};
     /// A thread-safe, stateful context for the v1 generator to help ensure
     /// process-wide uniqueness.
     #[derive(Debug)]
     pub struct Context {
-        count: AtomicU16,
+        count: Atomic<u16>,
     }
 
     impl Context {
@@ -133,7 +133,7 @@ pub mod context {
         /// process.
         pub const fn new(count: u16) -> Self {
             Self {
-                count: AtomicU16::new(count),
+                count: Atomic::<u16>::new(count),
             }
         }
 
@@ -151,7 +151,7 @@ pub mod context {
         #[cfg(feature = "rng")]
         pub fn new_random() -> Self {
             Self {
-                count: AtomicU16::new(crate::rng::u16()),
+                count: Atomic::<u16>::new(crate::rng::u16()),
             }
         }
     }

--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -79,6 +79,9 @@ impl Timestamp {
             nanos: dur.subsec_nanos(),
         }
     }
+
+    /// Construct a `Timestamp` from the current time of day
+    /// according to Rust's SystemTime
     #[cfg(all(feature = "std", any(feature = "v1", feature = "v6")))]
     pub fn now(context: impl ClockSequence<Output = u16>) -> Self {
         let dur = std::time::SystemTime::UNIX_EPOCH

--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -33,7 +33,7 @@ impl Timestamp {
     /// `u32` fields representing the seconds, and "subsecond" or fractional
     /// nanoseconds elapsed since the timestamp's second began,
     /// respectively.
-    pub fn from_unix(seconds: u64, nanos: u32) -> Self {
+    pub const fn from_unix(seconds: u64, nanos: u32) -> Self {
         Timestamp { seconds, nanos }
     }
 

--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -10,6 +10,8 @@ pub const UUID_TICKS_BETWEEN_EPOCHS: u64 = 0x01B2_1DD2_1381_4000;
 pub struct Timestamp {
     pub(crate) seconds: u64,
     pub(crate) nanos: u32,
+    #[cfg(any(feature = "v1", feature = "v6"))]
+    pub(crate) counter: u16,
 }
 
 impl Timestamp {
@@ -20,9 +22,21 @@ impl Timestamp {
     /// as the number of 100-nanosecond intervals elapsed since 00:00:00.00,
     /// 15 Oct 1582, "the date of the Gregorian reform of the Christian
     /// calendar."
-    pub const fn from_rfc4122(ticks: u64) -> Self {
+    pub const fn from_rfc4122(ticks: u64, _counter: u16) -> Self {
         let (seconds, nanos) = Self::rfc4122_to_unix(ticks);
-        Timestamp { seconds, nanos }
+
+        #[cfg(any(feature = "v1", feature = "v6"))]
+        {
+            Timestamp {
+                seconds,
+                nanos,
+                counter: _counter,
+            }
+        }
+        #[cfg(not(any(feature = "v1", feature = "v6")))]
+        {
+            Timestamp { seconds, nanos }
+        }
     }
 
     /// Construct a `Timestamp` from a unix timestamp
@@ -33,13 +47,29 @@ impl Timestamp {
     /// `u32` fields representing the seconds, and "subsecond" or fractional
     /// nanoseconds elapsed since the timestamp's second began,
     /// respectively.
-    pub const fn from_unix(seconds: u64, nanos: u32) -> Self {
-        Timestamp { seconds, nanos }
+    pub fn from_unix(
+        _context: impl ClockSequence<Output = u16>,
+        seconds: u64,
+        nanos: u32,
+    ) -> Self {
+        #[cfg(any(feature = "v1", feature = "v6"))]
+        {
+            let counter = _context.generate_sequence(seconds, nanos);
+            Timestamp {
+                seconds,
+                nanos,
+                counter,
+            }
+        }
+        #[cfg(not(any(feature = "v1", feature = "v6")))]
+        {
+            Timestamp { seconds, nanos }
+        }
     }
 
     /// Construct a `Timestamp` from the current time of day
     /// according to Rust's SystemTime
-    #[cfg(feature = "std")]
+    #[cfg(all(feature = "std", not(any(feature = "v1", feature = "v6"))))]
     pub fn now() -> Self {
         let dur = std::time::SystemTime::UNIX_EPOCH
             .elapsed()
@@ -49,14 +79,30 @@ impl Timestamp {
             nanos: dur.subsec_nanos(),
         }
     }
+    #[cfg(all(feature = "std", any(feature = "v1", feature = "v6")))]
+    pub fn now(context: impl ClockSequence<Output = u16>) -> Self {
+        let dur = std::time::SystemTime::UNIX_EPOCH
+            .elapsed()
+            .expect("Getting elapsed time since UNIX_EPOCH.  If this fails, we've somehow violated causality");
+        Timestamp {
+            seconds: dur.as_secs(),
+            nanos: dur.subsec_nanos(),
+            counter: context
+                .generate_sequence(dur.as_secs(), dur.subsec_nanos()),
+        }
+    }
 
     /// Returns the raw RFC4122 timestamp "tick" values stored by the
     /// `Timestamp`.
     ///
     /// The ticks represent the  number of 100-nanosecond intervals
     /// since 00:00:00.00, 15 Oct 1582.
-    pub const fn to_rfc4122(&self) -> u64 {
-        Self::unix_to_rfc4122_ticks(self.seconds, self.nanos)
+    #[cfg(any(feature = "v1", feature = "v6"))]
+    pub const fn to_rfc4122(&self) -> (u64, u16) {
+        (
+            Self::unix_to_rfc4122_ticks(self.seconds, self.nanos),
+            self.counter,
+        )
     }
 
     /// Returns the timestamp converted to the seconds and fractional
@@ -101,13 +147,21 @@ pub trait ClockSequence {
     /// Return an arbitrary width number that will be used as the "clock sequence" in
     /// the UUID. The number must be different if the time has changed since
     /// the last time a clock sequence was requested.
-    fn next(&self, ts: &Timestamp) -> Self::Output;
+    fn generate_sequence(
+        &self,
+        seconds: u64,
+        subsec_nanos: u32,
+    ) -> Self::Output;
 }
 
 impl<'a, T: ClockSequence + ?Sized> ClockSequence for &'a T {
     type Output = T::Output;
-    fn next(&self, ts: &Timestamp) -> Self::Output {
-        (**self).next(ts)
+    fn generate_sequence(
+        &self,
+        seconds: u64,
+        subsec_nanos: u32,
+    ) -> Self::Output {
+        (**self).generate_sequence(seconds, subsec_nanos)
     }
 }
 
@@ -158,7 +212,11 @@ pub mod context {
 
     impl super::ClockSequence for Context {
         type Output = u16;
-        fn next(&self, _: &super::Timestamp) -> Self::Output {
+        fn generate_sequence(
+            &self,
+            _seconds: u64,
+            _nanos: u32,
+        ) -> Self::Output {
             // RFC4122 reserves 2 bits of the clock sequence so the actual
             // maximum value is smaller than `u16::MAX`. Since we unconditionally
             // increment the clock sequence we want to wrap once it becomes larger

--- a/src/v4.rs
+++ b/src/v4.rs
@@ -34,8 +34,8 @@ impl Uuid {
 #[cfg(test)]
 mod tests {
     use super::*;
-
     use crate::{Variant, Version};
+    use std::string::ToString;
 
     #[cfg(target_arch = "wasm32")]
     use wasm_bindgen_test::*;

--- a/src/v6.rs
+++ b/src/v6.rs
@@ -54,9 +54,10 @@ impl Uuid {
     /// The timestamp can also be created manually as per RFC4122:
     ///
     /// ```
-    /// # use uuid::{Uuid, Timestamp, Context};
+    /// # use uuid::{Uuid, Timestamp, Context, ClockSequence};
+    /// # fn random_seed() -> u16 { 42 }
     /// let context = Context::new(random_seed());
-    /// let ts = Timestamp::from_rfc4122(14976241191231231313, context.generate_sequence() );
+    /// let ts = Timestamp::from_rfc4122(14976241191231231313, context.generate_sequence(0, 0) );
     ///
     /// let uuid = Uuid::new_v6(ts, &[1, 2, 3, 4, 5, 6]);
     ///
@@ -114,10 +115,7 @@ mod tests {
         let node = [1, 2, 3, 4, 5, 6];
         let context = Context::new(0);
 
-        let uuid = Uuid::new_v6(
-            Timestamp::from_unix(context, time, time_fraction),
-            &node,
-        );
+        let uuid = Uuid::new_v6(Timestamp::from_unix(context, time, time_fraction), &node);
 
         assert_eq!(uuid.get_version(), Some(Version::SortMac));
         assert_eq!(uuid.get_variant(), Variant::RFC4122);
@@ -131,8 +129,7 @@ mod tests {
         assert_eq!(ts.0 - 0x01B2_1DD2_1381_4000, 14_968_545_358_129_460);
 
         // Ensure parsing the same UUID produces the same timestamp
-        let parsed =
-            Uuid::parse_str("1e74ba22-0616-6934-8000-010203040506").unwrap();
+        let parsed = Uuid::parse_str("1e74ba22-0616-6934-8000-010203040506").unwrap();
 
         assert_eq!(
             uuid.get_timestamp().unwrap(),
@@ -150,31 +147,19 @@ mod tests {
         // This context will wrap
         let context = Context::new((u16::MAX >> 2) - 1);
 
-        let uuid1 = Uuid::new_v6(
-            Timestamp::from_unix(&context, time, time_fraction),
-            &node,
-        );
+        let uuid1 = Uuid::new_v6(Timestamp::from_unix(&context, time, time_fraction), &node);
 
         let time: u64 = 1_496_854_536;
 
-        let uuid2 = Uuid::new_v6(
-            Timestamp::from_unix(&context, time, time_fraction),
-            &node,
-        );
+        let uuid2 = Uuid::new_v6(Timestamp::from_unix(&context, time, time_fraction), &node);
 
         assert_eq!(uuid1.get_timestamp().unwrap().to_rfc4122().1, 16382);
         assert_eq!(uuid2.get_timestamp().unwrap().to_rfc4122().1, 0);
 
         let time = 1_496_854_535;
 
-        let uuid3 = Uuid::new_v6(
-            Timestamp::from_unix(&context, time, time_fraction),
-            &node,
-        );
-        let uuid4 = Uuid::new_v6(
-            Timestamp::from_unix(&context, time, time_fraction),
-            &node,
-        );
+        let uuid3 = Uuid::new_v6(Timestamp::from_unix(&context, time, time_fraction), &node);
+        let uuid4 = Uuid::new_v6(Timestamp::from_unix(&context, time, time_fraction), &node);
 
         assert_eq!(uuid3.get_timestamp().unwrap().counter, 1);
         assert_eq!(uuid4.get_timestamp().unwrap().counter, 2);

--- a/src/v6.rs
+++ b/src/v6.rs
@@ -1,6 +1,6 @@
 //! The implementation for Version 1 UUIDs.
 //!
-//! Note that you need to enable the `v1` Cargo feature
+//! Note that you need to enable the `v6` Cargo feature
 //! in order to use this module.
 
 use crate::timestamp::{ClockSequence, Timestamp};

--- a/src/v7.rs
+++ b/src/v7.rs
@@ -50,6 +50,9 @@ impl Uuid {
     }
 }
 
+/// Dummy struct and ClockSequence implementation to ease the construction of v7
+/// using a Timestamp
+#[derive(Debug)]
 pub struct NullSequence {}
 
 impl super::ClockSequence for NullSequence {
@@ -73,11 +76,7 @@ mod tests {
         let time: u64 = 1_496_854_535;
         let time_fraction: u32 = 812_946_000;
 
-        let uuid = Uuid::new_v7(Timestamp::from_unix(
-            NullSequence {},
-            time,
-            time_fraction,
-        ));
+        let uuid = Uuid::new_v7(Timestamp::from_unix(NullSequence {}, time, time_fraction));
         let uustr = uuid.hyphenated().to_string();
 
         assert_eq!(uuid.get_version(), Some(Version::SortRand));

--- a/src/v7.rs
+++ b/src/v7.rs
@@ -1,6 +1,6 @@
 //! The implementation for Version 1 UUIDs.
 //!
-//! Note that you need to enable the `v1` Cargo feature
+//! Note that you need to enable the `v7` Cargo feature
 //! in order to use this module.
 
 use crate::rng::{bytes, u16};

--- a/src/v7.rs
+++ b/src/v7.rs
@@ -21,8 +21,8 @@ impl Uuid {
     ///
     /// ```rust
     /// # use uuid::{Uuid, Timestamp};
-    ///
-    /// let ts = Timestamp::from_unix(1497624119, 1234);
+    /// # use uuid::v7::NullSequence;
+    /// let ts = Timestamp::from_unix(NullSequence {}, 1497624119, 1234);
     ///
     /// let uuid = Uuid::new_v7(ts);
     ///
@@ -50,6 +50,15 @@ impl Uuid {
     }
 }
 
+pub struct NullSequence {}
+
+impl super::ClockSequence for NullSequence {
+    type Output = u16;
+    fn generate_sequence(&self, _seconds: u64, _nanos: u32) -> Self::Output {
+        0
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -64,7 +73,11 @@ mod tests {
         let time: u64 = 1_496_854_535;
         let time_fraction: u32 = 812_946_000;
 
-        let uuid = Uuid::new_v7(Timestamp::from_unix(time, time_fraction));
+        let uuid = Uuid::new_v7(Timestamp::from_unix(
+            NullSequence {},
+            time,
+            time_fraction,
+        ));
         let uustr = uuid.hyphenated().to_string();
 
         assert_eq!(uuid.get_version(), Some(Version::SortRand));

--- a/src/v7.rs
+++ b/src/v7.rs
@@ -6,6 +6,7 @@
 use crate::rng::{bytes, u16};
 use crate::timestamp::Timestamp;
 use crate::{Uuid, Version};
+use core::convert::TryInto;
 
 impl Uuid {
     /// Create a new UUID (version 7) using a time value + random number

--- a/src/v7.rs
+++ b/src/v7.rs
@@ -1,0 +1,78 @@
+//! The implementation for Version 1 UUIDs.
+//!
+//! Note that you need to enable the `v1` Cargo feature
+//! in order to use this module.
+
+use crate::rng::{bytes, u16};
+use crate::timestamp::Timestamp;
+use crate::{Uuid, Version};
+
+impl Uuid {
+    /// Create a new UUID (version 7) using a time value + random number
+    ///
+    /// Note that usage of this method requires the `v7` feature of this crate
+    /// to be enabled.
+    ///
+    /// # Examples
+    ///
+    /// A v7 UUID can be created from a unix [`Timestamp`] plus a 128 bit
+    /// random number. When supplied as such, the data will be
+    ///
+    /// ```rust
+    /// # use uuid::{Uuid, Timestamp};
+    ///
+    /// let ts = Timestamp::from_unix(1497624119, 1234);
+    ///
+    /// let uuid = Uuid::new_v7(ts);
+    ///
+    /// assert!(
+    ///     uuid.hyphenated().to_string().starts_with("015cb15a-86d8-7")
+    /// );
+    /// ```
+    ///
+    /// The timestamp can also be created automatically from the current SystemTime
+    ///
+    /// let ts = Timestamp::now();
+    ///
+    /// let uuid = Uuid::new_v7(ts);
+    ///
+    /// [`Timestamp`]: v1/struct.Timestamp.html
+    pub fn new_v7(ts: Timestamp) -> Self {
+        let millis = ts.seconds * 1000 + (ts.nanos as u64) / 1_000_000;
+        let ms_high = ((millis >> 16) & 0xFFFF_FFFF) as u32;
+        let ms_low = (millis & 0xFFFF) as u16;
+        let ver_rand = u16() & 0xFFF | (0x7 << 12);
+        let mut rnd = bytes();
+        rnd[0] = (rnd[0] & 0x3F) | 0x80;
+        let buf: [u8; 8] = (&rnd[0..8]).try_into().unwrap();
+        Uuid::from_fields(ms_high, ms_low, ver_rand, &buf)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::{Variant, Version};
+    use std::string::ToString;
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::*;
+
+    #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    fn test_new_v7() {
+        let time: u64 = 1_496_854_535;
+        let time_fraction: u32 = 812_946_000;
+
+        let uuid = Uuid::new_v7(Timestamp::from_unix(time, time_fraction));
+        let uustr = uuid.hyphenated().to_string();
+
+        assert_eq!(uuid.get_version(), Some(Version::SortRand));
+        assert_eq!(uuid.get_variant(), Variant::RFC4122);
+        assert!(uustr.starts_with("015c837b-9e84-7"));
+
+        // Ensure parsing the same UUID produces the same timestamp
+        let parsed = Uuid::parse_str(uustr.as_str()).unwrap();
+
+        assert_eq!(uuid, parsed,);
+    }
+}

--- a/src/v8.rs
+++ b/src/v8.rs
@@ -1,0 +1,50 @@
+use crate::{Builder, Uuid, Variant, Version};
+
+impl Uuid {
+    /// Creates a custom UUID comprised almost entirely of user-supplied bytes
+    ///
+    /// This will inject the UUID Version at 4 bits starting at the 48th bit
+    /// and the Variant into 2 bits 64th bit.
+    /// So if there are bits are supplied in the input buffer, they will not be
+    /// visible in the result
+    /// # Examples
+    ///
+    /// Basic usage:
+    ///
+    /// ```
+    /// # use uuid::{Uuid, Version};
+    /// let buf: [u8; 16] = *b"abcdefghijklmnop";
+    /// let uuid = Uuid::new_v8(buf);
+    ///
+    /// assert_eq!(Some(Version::Custom), uuid.get_version());
+    /// ```
+    ///
+    /// [`getrandom`]: https://crates.io/crates/getrandom
+    /// [from_random_bytes]: struct.Builder.html#method.from_random_bytes
+    pub fn new_v8(buf: [u8; 16]) -> Uuid {
+        Builder(Uuid::from_bytes(buf))
+            .with_variant(Variant::RFC4122)
+            .with_version(Version::Custom)
+            .into_uuid()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::rng::bytes;
+    use std::string::ToString;
+
+    #[cfg(target_arch = "wasm32")]
+    use wasm_bindgen_test::*;
+
+    #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    fn test_new() {
+        let buf = bytes();
+        let uuid = Uuid::new_v8(buf);
+        assert_eq!(uuid.get_version(), Some(Version::Custom));
+        assert_eq!(uuid.get_variant(), Variant::RFC4122);
+        assert_eq!(uuid.get_version_num(), 8)
+    }
+}

--- a/src/v8.rs
+++ b/src/v8.rs
@@ -18,9 +18,6 @@ impl Uuid {
     ///
     /// assert_eq!(Some(Version::Custom), uuid.get_version());
     /// ```
-    ///
-    /// [`getrandom`]: https://crates.io/crates/getrandom
-    /// [from_random_bytes]: struct.Builder.html#method.from_random_bytes
     pub fn new_v8(buf: [u8; 16]) -> Uuid {
         Builder(Uuid::from_bytes(buf))
             .with_variant(Variant::RFC4122)
@@ -32,7 +29,6 @@ impl Uuid {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::rng::bytes;
     use std::string::ToString;
 
     #[cfg(target_arch = "wasm32")]
@@ -41,10 +37,17 @@ mod tests {
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_new() {
-        let buf = bytes();
+        let buf: [u8; 16] = [
+            0xf, 0xe, 0xd, 0xc, 0xb, 0xa, 0x9, 0x8, 0x7, 0x6, 0x5, 0x4, 0x3,
+            0x2, 0x1, 0x0,
+        ];
         let uuid = Uuid::new_v8(buf);
         assert_eq!(uuid.get_version(), Some(Version::Custom));
         assert_eq!(uuid.get_variant(), Variant::RFC4122);
-        assert_eq!(uuid.get_version_num(), 8)
+        assert_eq!(uuid.get_version_num(), 8);
+        assert_eq!(
+            uuid.hyphenated().to_string(),
+            "0f0e0d0c-0b0a-8908-8706-050403020100"
+        );
     }
 }

--- a/src/v8.rs
+++ b/src/v8.rs
@@ -19,7 +19,7 @@ impl Uuid {
     /// assert_eq!(Some(Version::Custom), uuid.get_version());
     /// ```
     pub fn new_v8(buf: [u8; 16]) -> Uuid {
-        Builder(Uuid::from_bytes(buf))
+        Builder::from_bytes(buf)
             .with_variant(Variant::RFC4122)
             .with_version(Version::Custom)
             .into_uuid()


### PR DESCRIPTION
**I'm submitting a feature** 

# Description 
This addresses all requested features in #523

Adds v6, v7 and v8 features and modules. 
It also adds a Timestamp::now()  which does what you might expect and uses std::time::SystemTime. 
I added some basic tests for each, but they could certainly use more tests and more eyes. 

## Breaking changes
This refactors Timestamp to make it more generally applicable to all (time based) UUIDs. 
It also breaks context/sequence out of Timestamp, since that only applies to v1 and v6.  
This changes the API for v1 and v6, to require a Context to be supplied at creation. 
Updates the crate to Edition 2021

## Dependency Changes 
Removes a dependency on atomic and instead uses std::sync::atomic since it now supports the necessary types.  

# Related Issue(s)
#523 