### PR TITLE
Optionally implement `defmt::Format`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,11 @@ version = "2"
 optional = true
 version = "1"
 
+# Public: Used in trait impls on `Uuid`
+[dependencies.defmt]
+optional = true
+version = "0.3"
+
 # Public (unstable): Used in `zerocopy` derive
 # Unstable: also need RUSTFLAGS="--cfg uuid_unstable" to work
 # This feature may break between releases, or be removed entirely before

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,7 +81,10 @@ version = "2"
 optional = true
 version = "1"
 
-# Public: Used in trait impls on `Uuid`
+# Public (unstable): Used in trait impls on `Uuid`
+# Unstable: also need RUSTFLAGS="--cfg uuid_unstable" to work
+# This feature may break between releases, or be removed entirely before
+# stabilization.
 [dependencies.defmt]
 optional = true
 version = "0.3"
@@ -89,7 +92,7 @@ version = "0.3"
 # Public (unstable): Used in `zerocopy` derive
 # Unstable: also need RUSTFLAGS="--cfg uuid_unstable" to work
 # This feature may break between releases, or be removed entirely before
-# stabilization. 
+# stabilization.
 # See: https://github.com/uuid-rs/uuid/issues/588
 [dependencies.zerocopy]
 optional = true

--- a/src/external/defmt_support.rs
+++ b/src/external/defmt_support.rs
@@ -1,0 +1,19 @@
+// Copyright 2022 The Uuid Project Developers.
+//
+// See the COPYRIGHT file at the top-level directory of this distribution.
+//
+// Licensed under the Apache License, Version 2.0 <LICENSE-APACHE or
+// http://www.apache.org/licenses/LICENSE-2.0> or the MIT license
+// <LICENSE-MIT or http://opensource.org/licenses/MIT>, at your
+// option. This file may not be copied, modified, or distributed
+// except according to those terms.
+
+use crate::{Uuid, fmt::Hyphenated};
+
+impl defmt::Format for Uuid {
+    fn format(&self, f: defmt::Formatter<'_>) {
+        let mut buf = [0u8; Hyphenated::LENGTH];
+        let s = self.as_hyphenated().encode_lower(&mut buf);
+        defmt::write!(f, "{=str}", s);
+    }
+}

--- a/src/external/mod.rs
+++ b/src/external/mod.rs
@@ -4,3 +4,5 @@ pub(crate) mod arbitrary_support;
 pub(crate) mod serde_support;
 #[cfg(feature = "slog")]
 pub(crate) mod slog_support;
+#[cfg(feature = "defmt")]
+pub(crate) mod defmt_support;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -99,6 +99,7 @@
 //!
 //! * `zerocopy` - adds support for zero-copy deserialization using the
 //!   `zerocopy` library.
+//! * `defmt` - adds support for formatting UUIDs with the [`defmt`] library.
 //!
 //! Unstable features may break between minor releases.
 //!
@@ -194,6 +195,7 @@
 //! [`v1::ClockSequence`]: v1/trait.ClockSequence.html
 //! [`v1::Context`]: v1/struct.Context.html
 //! [`getrandom`'s docs]: https://docs.rs/getrandom
+//! [`defmt`]: https://crates.io/crates/defmt
 
 #![no_std]
 #![deny(missing_debug_implementations, missing_docs)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -211,9 +211,11 @@ extern crate std;
 #[macro_use]
 extern crate core as std;
 
-// Check that unstable features are accompanied by a the `uuid_unstable` cfg
+// Check that unstable features are accompanied by the `uuid_unstable` cfg
 #[cfg(all(not(uuid_unstable), feature = "zerocopy"))]
 compile_error!("The `zerocopy` feature is unstable and may break between releases. Please also pass `RUSTFLAGS=\"--cfg uuid_unstable\"` to allow it.");
+#[cfg(all(not(uuid_unstable), feature = "defmt"))]
+compile_error!("The `defmt` feature is unstable and may break between releases. Please also pass `RUSTFLAGS=\"--cfg uuid_unstable\"` to allow it.");
 
 #[cfg(feature = "zerocopy")]
 use zerocopy::{AsBytes, FromBytes, Unaligned};


### PR DESCRIPTION
**I'm submitting a feature**

# Description
Make `Uuid` work seamlessly with [`defmt`](https://github.com/knurling-rs/defmt).

Potential issues:
- Testing. Not sure how to test this. Does this even need testing?
- `defmt` only supports the latest stable Rust version. Is this a dealbreaker with your MSRV policy?