### PR TITLE
Get doc tests to pass without std and shrink build runs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -66,10 +66,10 @@ jobs:
       run: cargo test --all-features --examples
 
     - name: Each version feature
-      run: cargo hack test --each-feature --optional-deps $STABLE_DEP_FEATURES
+      run: cargo hack test --lib --each-feature --optional-deps $STABLE_DEP_FEATURES
     
     - name: All version features
-      run: cargo hack test --features "$VERSION_FEATURES" --each-feature --optional-deps "$STABLE_DEP_FEATURES"
+      run: cargo hack test --lib --features "$VERSION_FEATURES" --each-feature --optional-deps "$STABLE_DEP_FEATURES"
 
   msrv:
     name: "Tests / MSRV / OS: ${{ matrix.os }}"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,9 @@
 name: Continuous integration
 
+env:
+  VERSION_FEATURES: "v1 v3 v4 v5"
+  STABLE_DEP_FEATURES: "serde arbitrary"
+
 on:
   pull_request:
   push:
@@ -61,8 +65,11 @@ jobs:
     - name: Examples
       run: cargo test --all-features --examples
 
-    - name: Powerset
-      run: cargo hack test --feature-powerset --lib --optional-deps "serde arbitrary" --depth 3
+    - name: Each version feature
+      run: cargo hack test --each-feature --optional-deps $STABLE_DEP_FEATURES
+    
+    - name: All version features
+      run: cargo hack test --features "$VERSION_FEATURES" --each-feature --optional-deps "$STABLE_DEP_FEATURES"
 
   msrv:
     name: "Tests / MSRV / OS: ${{ matrix.os }}"
@@ -86,7 +93,7 @@ jobs:
         override: true
 
     - name: Version features
-      run: cargo test --features "v1 v3 v4 v5 serde"
+      run: cargo test --features "$VERSION_FEATURES $STABLE_DEP_FEATURES"
 
   wasm:
     name: Tests / WebAssembly
@@ -102,7 +109,7 @@ jobs:
         run: wasm-pack test --node
 
       - name: Version features
-        run: wasm-pack test --node -- --features "js v1 v3 v4 v5"
+        run: wasm-pack test --node -- --features "$VERION_FEATURES $STABLE_DEP_FEATURES js"
       
       - name: Fast RNG
         run: wasm-pack test --node -- --features "js v4 fast-rng"
@@ -174,4 +181,4 @@ jobs:
         run: cargo install cargo-hack
 
       - name: Powerset
-        run: cargo hack check --feature-powerset -Z avoid-dev-deps
+        run: cargo hack check --each-feature -Z avoid-dev-deps

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,8 @@ default = ["std"]
 std = []
 macro-diagnostics = ["private_uuid-macro-internal"]
 
+# NOTE: When adding new features, check the `ci.yml` workflow
+# and include them where necessary (you can follow along with existing features)
 v1 = ["private_atomic"]
 v3 = ["md5"]
 v4 = ["rng"]

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -283,7 +283,7 @@ impl Uuid {
     /// Basic usage:
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # fn main() -> Result<(), uuid::Error> {
     /// # use uuid::Uuid;
     /// let bytes = [
     ///     0xa1, 0xa2, 0xa3, 0xa4,
@@ -324,7 +324,7 @@ impl Uuid {
     /// Basic usage:
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # fn main() -> Result<(), uuid::Error> {
     /// # use uuid::Uuid;
     /// let bytes = [
     ///     0xa1, 0xa2, 0xa3, 0xa4,
@@ -359,7 +359,7 @@ impl Uuid {
     /// Basic usage:
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # fn main() -> Result<(), uuid::Error> {
     /// # use uuid::Uuid;
     /// let bytes = [
     ///     0xa1, 0xa2, 0xa3, 0xa4,
@@ -390,7 +390,7 @@ impl Uuid {
     /// Basic usage:
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # fn main() -> Result<(), uuid::Error> {
     /// # use uuid::Uuid;
     /// let bytes = [
     ///     0xa1, 0xa2, 0xa3, 0xa4,
@@ -422,7 +422,7 @@ impl Uuid {
     /// Basic usage:
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # fn main() -> Result<(), uuid::Error> {
     /// # use uuid::Uuid;
     /// let bytes = [
     ///     0xa1, 0xa2, 0xa3, 0xa4,
@@ -491,7 +491,7 @@ impl Builder {
     /// Basic usage:
     ///
     /// ```
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # fn main() -> Result<(), uuid::Error> {
     /// # use uuid::{Builder, Uuid};
     /// let bytes = [
     ///     0xa1, 0xa2, 0xa3, 0xa4,
@@ -565,7 +565,7 @@ impl Builder {
     ///
     /// ```
     /// # use uuid::Builder;
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # fn main() -> Result<(), uuid::Error> {
     /// let bytes = [
     ///     0xa1, 0xa2, 0xa3, 0xa4,
     ///     0xb1, 0xb2,
@@ -600,7 +600,7 @@ impl Builder {
     ///
     /// ```
     /// # use uuid::Builder;
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # fn main() -> Result<(), uuid::Error> {
     /// let bytes = [
     ///     0xa1, 0xa2, 0xa3, 0xa4,
     ///     0xb1, 0xb2,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -157,7 +157,7 @@
 //!
 //! ```
 //! # use uuid::Uuid;
-//! # fn main() -> Result<(), Box<dyn std::error::Error>> {
+//! # fn main() -> Result<(), uuid::Error> {
 //! let my_uuid = Uuid::parse_str("a1a2a3a4b1b2c1c2d1d2d3d4d5d6d7d8")?;
 //!
 //! println!("{}", my_uuid.urn());
@@ -308,7 +308,7 @@ pub enum Variant {
 ///
 /// ```
 /// # use uuid::Uuid;
-/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// # fn main() -> Result<(), uuid::Error> {
 /// let my_uuid = Uuid::parse_str("a1a2a3a4b1b2c1c2d1d2d3d4d5d6d7d8")?;
 ///
 /// println!("{}", my_uuid.urn());
@@ -345,7 +345,7 @@ pub enum Variant {
 ///
 /// ```
 /// # use uuid::Uuid;
-/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// # fn main() -> Result<(), uuid::Error> {
 /// let my_uuid = Uuid::parse_str("a1a2a3a4b1b2c1c2d1d2d3d4d5d6d7d8")?;
 ///
 /// assert_eq!(
@@ -360,7 +360,7 @@ pub enum Variant {
 ///
 /// ```
 /// # use uuid::Uuid;
-/// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+/// # fn main() -> Result<(), uuid::Error> {
 /// let my_uuid = Uuid::parse_str("a1a2a3a4b1b2c1c2d1d2d3d4d5d6d7d8")?;
 ///
 /// assert_eq!(
@@ -436,7 +436,7 @@ impl Uuid {
     ///
     /// ```
     /// # use uuid::{Uuid, Variant};
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # fn main() -> Result<(), uuid::Error> {
     /// let my_uuid = Uuid::parse_str("02f09a3f-1624-3b1d-8409-44eff7708208")?;
     ///
     /// assert_eq!(Variant::RFC4122, my_uuid.get_variant());
@@ -471,7 +471,7 @@ impl Uuid {
     ///
     /// ```
     /// # use uuid::Uuid;
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # fn main() -> Result<(), uuid::Error> {
     /// let my_uuid = Uuid::parse_str("02f09a3f-1624-3b1d-8409-44eff7708208")?;
     ///
     /// assert_eq!(3, my_uuid.get_version_num());
@@ -501,7 +501,7 @@ impl Uuid {
     ///
     /// ```
     /// # use uuid::{Uuid, Version};
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # fn main() -> Result<(), uuid::Error> {
     /// let my_uuid = Uuid::parse_str("02f09a3f-1624-3b1d-8409-44eff7708208")?;
     ///
     /// assert_eq!(Some(Version::Md5), my_uuid.get_version());
@@ -548,7 +548,7 @@ impl Uuid {
     ///
     /// ```
     /// # use uuid::Uuid;
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # fn main() -> Result<(), uuid::Error> {
     /// let uuid = Uuid::nil();
     ///
     /// assert_eq!(uuid.as_fields(), (0, 0, 0, &[0u8; 8]));
@@ -595,7 +595,7 @@ impl Uuid {
     /// ```
     /// use uuid::Uuid;
     ///
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # fn main() -> Result<(), uuid::Error> {
     /// let uuid = Uuid::parse_str("a1a2a3a4-b1b2-c1c2-d1d2-d3d4d5d6d7d8")?;
     ///
     /// assert_eq!(
@@ -632,7 +632,7 @@ impl Uuid {
     ///
     /// ```
     /// # use uuid::Uuid;
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # fn main() -> Result<(), uuid::Error> {
     /// let uuid = Uuid::parse_str("a1a2a3a4-b1b2-c1c2-d1d2-d3d4d5d6d7d8")?;
     ///
     /// assert_eq!(
@@ -676,7 +676,7 @@ impl Uuid {
     ///
     /// ```
     /// # use uuid::Uuid;
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # fn main() -> Result<(), uuid::Error> {
     /// let uuid = Uuid::parse_str("a1a2a3a4-b1b2-c1c2-d1d2-d3d4d5d6d7d8")?;
     ///
     /// assert_eq!(
@@ -715,7 +715,7 @@ impl Uuid {
     ///
     /// ```
     /// # use uuid::Uuid;
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # fn main() -> Result<(), uuid::Error> {
     /// let uuid = Uuid::parse_str("a1a2a3a4-b1b2-c1c2-d1d2-d3d4d5d6d7d8")?;
     /// assert_eq!(
     ///     uuid.as_u64_pair(),
@@ -789,7 +789,7 @@ impl Uuid {
     /// ```
     /// use uuid::Uuid;
     ///
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # fn main() -> Result<(), uuid::Error> {
     /// let uuid = Uuid::parse_str("a1a2a3a4-b1b2-c1c2-d1d2-d3d4d5d6d7d8")?;
     ///
     /// assert_eq!(

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -51,7 +51,7 @@ impl Uuid {
     ///
     /// ```
     /// # use uuid::{Uuid, Version, Variant};
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # fn main() -> Result<(), uuid::Error> {
     /// let uuid = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000")?;
     ///
     /// assert_eq!(Some(Version::Random), uuid.get_version());
@@ -84,7 +84,7 @@ impl Uuid {
     ///
     /// ```
     /// # use uuid::{Uuid, Version, Variant};
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # fn main() -> Result<(), uuid::Error> {
     /// let uuid = Uuid::try_parse("550e8400-e29b-41d4-a716-446655440000")?;
     ///
     /// assert_eq!(Some(Version::Random), uuid.get_version());
@@ -112,7 +112,7 @@ impl Uuid {
     ///
     /// ```
     /// # use uuid::{Uuid, Version, Variant};
-    /// # fn main() -> Result<(), Box<dyn std::error::Error>> {
+    /// # fn main() -> Result<(), uuid::Error> {
     /// let uuid = Uuid::try_parse_ascii(b"550e8400-e29b-41d4-a716-446655440000")?;
     ///
     /// assert_eq!(Some(Version::Random), uuid.get_version());


### PR DESCRIPTION
For #611 

Our build requirements explode when new features are added. What we really want is just to make sure that each feature works independently, and that they all work together. This PR does that by avoiding using the feature powerset in CI. I've also made sure our doc tests actually work when the `std` feature is disabled.