### PR TITLE
Add a Natvis definition for `Uuid` along with tests and documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,6 +3,7 @@ name: Continuous integration
 env:
   VERSION_FEATURES: "v1 v3 v4 v5 v6 v7"
   STABLE_DEP_FEATURES: "serde arbitrary"
+  ALL_FEATURES: "arbitrary default fast-rng js macro-diagnostics md5 rng serde sha1 slog std v1 v3 v4 v5 v6 v7 v8 zerocopy"
 
 on:
   pull_request:
@@ -59,16 +60,20 @@ jobs:
       run: cargo install cargo-hack
 
     - name: Docs
-      run: cargo test --all-features --doc
+      run: cargo test --features "$ALL_FEATURES" --doc
 
     - name: Examples
-      run: cargo test --all-features --examples
+      run: cargo test --features "$ALL_FEATURES" --examples
 
     - name: Each version feature
-      run: cargo hack test --lib --each-feature --optional-deps $STABLE_DEP_FEATURES
+      run: cargo hack test --lib --each-feature --exclude-features "debugger_visualizer" --optional-deps $STABLE_DEP_FEATURES
 
     - name: All version features
-      run: cargo hack test --lib --each-feature --features "$VERSION_FEATURES" --optional-deps "$STABLE_DEP_FEATURES"
+      run: cargo hack test --lib --each-feature --exclude-features "debugger_visualizer" --features "$VERSION_FEATURES" --optional-deps "$STABLE_DEP_FEATURES"
+
+    - name: Test debugger_visualizer
+      if: matrix.channel == 'nightly' && matrix.target == 'x86_64-msvc'
+      run: cargo test --test debugger_visualizer --features "debugger_visualizer" -- --test-threads=1
 
   msrv:
     name: "Tests / MSRV / OS: ${{ matrix.os }}"
@@ -177,7 +182,8 @@ jobs:
         run: cargo install cargo-hack
 
       - name: Powerset
-        run: cargo hack check --each-feature -Z avoid-dev-deps
+        run: cargo hack check --each-feature --exclude-features "debugger_visualizer" -Z avoid-dev-deps
+
   win_tests:
     name: "Tests / OS: Windows 2019 - ${{ matrix.channel }}-${{ matrix.rust_target }}"
     runs-on: windows-2019
@@ -210,16 +216,20 @@ jobs:
       run: cargo install cargo-hack
 
     - name: Docs
-      run: cargo test --all-features --doc
+      run: cargo test --features "$env:ALL_FEATURES" --doc
 
     - name: Examples
-      run: cargo test --all-features --examples
+      run: cargo test --features "$env:ALL_FEATURES" --examples
 
     - name: Each version feature
-      run: cargo hack test --lib --each-feature --optional-deps $env:STABLE_DEP_FEATURES
+      run: cargo hack test --lib --each-feature --exclude-features "debugger_visualizer" --optional-deps $env:STABLE_DEP_FEATURES
 
     - name: All version features
-      run: cargo hack test --lib --each-feature --features "$env:VERSION_FEATURES" --optional-deps "$env:STABLE_DEP_FEATURES"
+      run: cargo hack test --lib --each-feature --exclude-features "debugger_visualizer" --features "$env:VERSION_FEATURES" --optional-deps "$env:STABLE_DEP_FEATURES"
+
+    - name: Test debugger_visualizer
+      if: matrix.channel == 'nightly' && matrix.target == 'x86_64-msvc'
+      run: cargo test --test debugger_visualizer --features "debugger_visualizer" -- --test-threads=1
 
   win-msrv:
     name: "Tests / MSRV / OS: Windows 2019"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,6 +65,10 @@ fast-rng = ["rng", "private_rand"]
 sha1 = ["private_sha1_smol"]
 md5 = ["private_md-5"]
 
+# UNSTABLE FEATURES (requires Rust nightly)
+# Enable to use the #[debugger_visualizer] attribute.
+debugger_visualizer = []
+
 # Public: Used in trait impls on `Uuid`
 [dependencies.serde]
 default-features = false
@@ -142,6 +146,12 @@ version = "0.5"
 [dev-dependencies.bincode]
 version = "1.0"
 
+[dev-dependencies.debugger_test]
+version = "0.1.0"
+
+[dev-dependencies.debugger_test_parser]
+version = "0.1.0"
+
 [dev-dependencies.serde_derive]
 version = "1.0.79"
 
@@ -167,6 +177,17 @@ version = "1"
 [target.'cfg(windows)'.dev-dependencies.windows-sys]
 version = "0.36.1"
 features = ["Win32_System_Com"]
+
+[[test]]
+name = "debugger_visualizer"
+path = "tests/debugger_visualizer.rs"
+required-features = ["debugger_visualizer"]
+# Do not run these tests by default. These tests need to
+# be run with the additional rustc flag `--test-threads=1`
+# since each test causes a debugger to attach to the current
+# test process. If multiple debuggers try to attach at the same
+# time, the test will fail.
+test = false
 
 [workspace]
 members = [

--- a/debug_metadata/README.md
+++ b/debug_metadata/README.md
@@ -1,0 +1,112 @@
+## Debugger Visualizers
+
+Many languages and debuggers enable developers to control how a type is
+displayed in a debugger. These are called "debugger visualizations" or "debugger
+views".
+
+The Windows debuggers (WinDbg\CDB) support defining custom debugger visualizations using
+the `Natvis` framework. To use Natvis, developers write XML documents using the natvis
+schema that describe how debugger types should be displayed with the `.natvis` extension.
+(See: https://docs.microsoft.com/en-us/visualstudio/debugger/create-custom-views-of-native-objects?view=vs-2019)
+The Natvis files provide patterns which match type names a description of how to display
+those types.
+
+The Natvis schema can be found either online (See: https://code.visualstudio.com/docs/cpp/natvis#_schema)
+or locally at `<VS Installation Folder>\Xml\Schemas\1033\natvis.xsd`.
+
+The GNU debugger (GDB) supports defining custom debugger views using Pretty Printers.
+Pretty printers are written as python scripts that describe how a type should be displayed
+when loaded up in GDB/LLDB. (See: https://sourceware.org/gdb/onlinedocs/gdb/Pretty-Printing.html#Pretty-Printing)
+The pretty printers provide patterns, which match type names, and for matching
+types, descibe how to display those types. (For writing a pretty printer, see: https://sourceware.org/gdb/onlinedocs/gdb/Writing-a-Pretty_002dPrinter.html#Writing-a-Pretty_002dPrinter).
+
+### Embedding Visualizers
+
+Through the use of the currently unstable `#[debugger_visualizer]` attribute, the `uuid`
+crate can embed debugger visualizers into the crate metadata.
+
+Currently the two types of visualizers supported are Natvis and Pretty printers.
+
+For Natvis files, when linking an executable with a crate that includes Natvis files,
+the MSVC linker will embed the contents of all Natvis files into the generated `PDB`.
+
+For pretty printers, the compiler will encode the contents of the pretty printer
+in the `.debug_gdb_scripts` section of the `ELF` generated.
+
+### Testing Visualizers
+
+The `uuid` crate supports testing debugger visualizers defined for this crate. The entry point for
+these tests are `tests/debugger_visualizer.rs`. This test crate defines a single integration test
+which are defined using the `debugger_test` and `debugger_test_parser` crates. The `debugger_test` crate
+is a proc macro crate which defines a single proc macro attribute, `#[debugger_test]`. For more detailed
+information about this crate, see https://crates.io/crates/debugger_test. The CI pipeline for the `uuid`
+'crate has been updated to run the debugger visualizer tests to ensure debugger visualizers do not become
+broken/stale.
+
+The `#[debugger_test]` proc macro attribute may only be used on test functions and will run the
+function under the debugger specified by the `debugger` meta item.
+
+This proc macro attribute has 3 required values:
+
+1. The first required meta item, `debugger`, takes a string value which specifies the debugger to launch.
+2. The second required meta item, `commands`, takes a string of new line (`\n`) separated list of debugger
+commands to run.
+3. The third required meta item, `expected_statements`, takes a string of new line (`\n`) separated list of
+statements that must exist in the debugger output. Pattern matching through regular expressions is also
+supported by using the `pattern:` prefix for each expected statement.
+
+#### Example:
+
+```rust
+#[debugger_test(
+    debugger = "cdb",
+    commands = "command1\ncommand2\ncommand3",
+    expected_statements = "statement1\nstatement2\nstatement3")]
+fn test() {
+
+}
+```
+
+Using a multiline string is also supported, with a single debugger command/expected statement per line:
+
+```rust
+#[debugger_test(
+    debugger = "cdb",
+    commands = "
+command1
+command2
+command3",
+    expected_statements = "
+statement1
+pattern:statement[0-9]+
+statement3")]
+fn test() {
+
+}
+```
+
+In the example above, the second expected statement uses pattern matching through a regular expression
+by using the `pattern:` prefix.
+
+#### Testing Locally
+
+Currently, only Natvis visualizations have been defined for the `uuid` crate via `debug_metadata/uuid.natvis`,
+which means the debugger visualizer tests need to be run on Windows using the `*-pc-windows-msvc` targets.
+To run these tests locally, first ensure the debugging tools for Windows are installed or install them following
+the steps listed here, [Debugging Tools for Windows](https://docs.microsoft.com/en-us/windows-hardware/drivers/debugger/).
+Once the debugging tools have been installed, the tests can be run in the same manner as they are in the CI
+pipeline.
+
+#### Note
+
+When running the debugger visualizer tests, `tests/debugger_visualizer.rs`, they need to be run consecutively
+and not in parallel. This can be achieved by passing the flag `--test-threads=1` to rustc. This is due to
+how the debugger tests are run. Each test marked with the `#[debugger_test]` attribute launches a debugger
+and attaches it to the current test process. If tests are running in parallel, the test will try to attach
+a debugger to the current process which may already have a debugger attached causing the test to fail.
+
+For example:
+
+```
+cargo test --test debugger_visualizer --features debugger_visualizer -- --test-threads=1
+```

--- a/debug_metadata/uuid.natvis
+++ b/debug_metadata/uuid.natvis
@@ -1,0 +1,28 @@
+<AutoVisualizer xmlns="http://schemas.microsoft.com/vstudio/debugger/natvis/2010">
+  <Type Name="uuid::Uuid">
+    <!-- Use `&quot;&quot;` to 'stringify' the result of an expression. -->
+    <Intrinsic Name="print_char" Expression="value == 10 ? &quot;a&quot; : value == 11 ? &quot;b&quot; : value == 12 ? &quot;c&quot; : value == 13 ? &quot;d&quot; : value == 14 ? &quot;e&quot; : value == 15 ? &quot;f&quot; : &quot;&quot;">
+      <Parameter Name="value" Type="int" />
+    </Intrinsic>
+
+    <Intrinsic Name="get_value" Expression="value &lt; 10 ? value : print_char(value)">
+      <Parameter Name="value" Type="int" />
+    </Intrinsic>
+
+    <Intrinsic Name="print" Expression="(get_value(__0[index] >> 4) + &quot;&quot;) + (get_value(__0[index] &amp; 15) + &quot;&quot;)">
+      <Parameter Name="index" Type="int" />
+    </Intrinsic>
+
+    <Intrinsic Name="add_hyphen" Expression="index == 3 || index == 5 || index == 7 || index == 9 ? &quot;-&quot; : &quot;&quot;">
+      <Parameter Name="index" Type="int" />
+    </Intrinsic>
+
+    <Intrinsic Name="create_display_string" Expression="index == 16 ? &quot;&quot; : print(index) + &quot;&quot; + add_hyphen(index) + &quot;&quot; + create_display_string(index + 1) + &quot;&quot;">
+      <Parameter Name="index" Type="int" />
+    </Intrinsic>
+
+    <Intrinsic Name="display_string" Expression="create_display_string(0)" />
+
+    <DisplayString>"{display_string()}"</DisplayString>
+  </Type>
+</AutoVisualizer>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -202,6 +202,11 @@
     html_favicon_url = "https://www.rust-lang.org/favicon.ico",
     html_root_url = "https://docs.rs/uuid/1.1.2"
 )]
+#![cfg_attr(
+    feature = "debugger_visualizer",
+    feature(debugger_visualizer),
+    debugger_visualizer(natvis_file = "../debug_metadata/uuid.natvis")
+)]
 
 #[cfg(any(feature = "std", test))]
 #[macro_use]

--- a/tests/debugger_visualizer.rs
+++ b/tests/debugger_visualizer.rs
@@ -1,0 +1,39 @@
+use debugger_test::*;
+use uuid::*;
+
+#[inline(never)]
+fn __break() {}
+
+#[debugger_test(
+    debugger = "cdb",
+    commands = r#"
+.nvlist
+
+dx uuid
+
+dx uuid_empty
+"#,
+    expected_statements = r#"
+uuid             : "67e55044-10b1-426f-9247-bb680e5fe0c8" [Type: uuid::Uuid]
+
+uuid_empty       : "00000000-0000-0000-0000-000000000000" [Type: uuid::Uuid]
+"#
+)]
+fn test_debugger_visualizer() {
+    let uuid_str = "67e5504410b1426f9247bb680e5fe0c8";
+    let uuid_hyphenated_str = "67e55044-10b1-426f-9247-bb680e5fe0c8";
+
+    let uuid = Uuid::parse_str(uuid_str).unwrap();
+    assert_eq!(uuid_hyphenated_str, uuid.as_hyphenated().to_string());
+
+    let result = uuid.to_string();
+    assert_eq!(uuid_hyphenated_str, result);
+
+    let uuid_empty = Uuid::nil();
+    assert_eq!(
+        String::from("00000000-0000-0000-0000-000000000000"),
+        uuid_empty.to_string()
+    );
+
+    __break();
+}


### PR DESCRIPTION
**I'm submitting a** feature

# Description
This change adds Natvis visualizations for types in the `uuid` crate to help improve the debugging experience on Windows.

Natvis is a framework that can be used to specify how types should be viewed under a supported debugger, such as the Windows debugger (WinDbg) and the Visual Studio debugger.

The Rust compiler does have Natvis support for some types, but this is limited to some of the core libraries and not supported for external crates.

https://github.com/rust-lang/rfcs/pull/3191 proposes adding support for embedding debugging visualizations such as Natvis in a Rust crate. This RFC has been approved, merged and implemented.

This PR adds:

* Natvis visualizations for the `Uuid` type.
* Tests for testing visualizers embedded in the `uuid` crate.
* A new debugger_visualizer feature for the `uuid` crate to enable the unstable debugger_visualizer Rust feature.
* Changes to the CI pipeline to ensure debugger visualizer tests are run and do not break silently.
* Updates to the CI pipeline to separate testing stable features vs. unstable features.