### PR TITLE
Prepare for 1.2.0 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ homepage = "https://github.com/uuid-rs/uuid"
 name = "uuid"
 readme = "README.md"
 repository = "https://github.com/uuid-rs/uuid"
-version = "1.1.2" # remember to update html_root_url in lib.rs
+version = "1.2.0" # remember to update html_root_url in lib.rs
 
 [package.metadata.docs.rs]
 features = ["serde", "arbitrary", "slog", "v1", "v3", "v4", "v5"]
@@ -131,7 +131,7 @@ version = "1"
 # Use the `macro-diagnostics` feature instead
 [dependencies.uuid-macro-internal]
 package = "uuid-macro-internal"
-version = "1.1.2"
+version = "1.2.0"
 path = "macros"
 optional = true
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,10 +30,13 @@ repository = "https://github.com/uuid-rs/uuid"
 version = "1.2.0" # remember to update html_root_url in lib.rs
 
 [package.metadata.docs.rs]
-features = ["serde", "arbitrary", "slog", "v1", "v3", "v4", "v5"]
+rustc-args = ["--cfg", "uuid_unstable"]
+rustdoc-args = ["--cfg", "uuid_unstable"]
+targets = ["x86_64-unknown-linux-gnu"]
+features = ["serde", "arbitrary", "slog", "v1", "v3", "v4", "v5", "v6", "v7", "v8"]
 
 [package.metadata.playground]
-features = ["serde", "v1", "v3", "v4", "v5"]
+features = ["serde", "v1", "v3", "v4", "v5", "v6", "v7", "v8"]
 
 [badges.is-it-maintained-issue-resolution]
 repository = "uuid-rs/uuid"

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Add the following to your `Cargo.toml`:
 
 ```toml
 [dependencies.uuid]
-version = "1.1.2"
+version = "1.2.0"
 features = [
     "v4",                # Lets you generate random UUIDs
     "fast-rng",          # Use a faster (but still sufficiently random) RNG
@@ -66,7 +66,7 @@ assert_eq!(Some(Version::Random), my_uuid.get_version());
 If you'd like to parse UUIDs _really_ fast, check out the [`uuid-simd`](https://github.com/nugine/uuid-simd)
 library.
 
-For more details on using `uuid`, [see the library documentation](https://docs.rs/uuid/1.1.2/uuid).
+For more details on using `uuid`, [see the library documentation](https://docs.rs/uuid/1.2.0/uuid).
 
 ## Minimum Supported Rust Version (MSRV)
 
@@ -75,7 +75,7 @@ CI. It may be bumped in minor releases as necessary.
 
 ## References
 
-* [`uuid` library docs](https://docs.rs/uuid/1.1.2/uuid).
+* [`uuid` library docs](https://docs.rs/uuid/1.2.0/uuid).
 * [Wikipedia: Universally Unique Identifier](http://en.wikipedia.org/wiki/Universally_unique_identifier).
 * [RFC4122: A Universally Unique IDentifier (UUID) URN Namespace](http://tools.ietf.org/html/rfc4122).
 

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uuid-macro-internal"
-version = "1.1.2"
+version = "1.2.0"
 edition = "2018"
 authors = [
     "QnnOkabayashi"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@
 //!
 //! ```toml
 //! [dependencies.uuid]
-//! version = "1.1.2"
+//! version = "1.2.0"
 //! features = [
 //!     "v4",                # Lets you generate random UUIDs
 //!     "fast-rng",          # Use a faster (but still sufficiently random) RNG
@@ -138,7 +138,7 @@
 //!
 //! ```toml
 //! [dependencies.uuid]
-//! version = "1.1.2"
+//! version = "1.2.0"
 //! features = [
 //!     "v4",
 //!     "v7",
@@ -153,7 +153,7 @@
 //!
 //! ```toml
 //! [dependencies.uuid]
-//! version = "1.1.2"
+//! version = "1.2.0"
 //! default-features = false
 //! ```
 //!
@@ -211,7 +211,7 @@
 #![doc(
     html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
     html_favicon_url = "https://www.rust-lang.org/favicon.ico",
-    html_root_url = "https://docs.rs/uuid/1.1.2"
+    html_root_url = "https://docs.rs/uuid/1.2.0"
 )]
 
 #[cfg(any(feature = "std", test))]

--- a/src/v7.rs
+++ b/src/v7.rs
@@ -93,6 +93,22 @@ mod tests {
 
     #[test]
     #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
+    fn test_sorting() {
+        let time1: u64 = 1_496_854_535;
+        let time_fraction1: u32 = 812_000_000;
+
+        let time2 = time1 + 4000;
+        let time_fraction2 = time_fraction1;
+
+        let uuid1 = Uuid::new_v7(Timestamp::from_unix(NoContext, time1, time_fraction1));
+        let uuid2 = Uuid::new_v7(Timestamp::from_unix(NoContext, time2, time_fraction2));
+
+        assert!(uuid1.as_bytes() < uuid2.as_bytes());
+        assert!(uuid1.to_string() < uuid2.to_string());
+    }
+
+    #[test]
+    #[cfg_attr(target_arch = "wasm32", wasm_bindgen_test)]
     fn test_new_timestamp_roundtrip() {
         let time: u64 = 1_496_854_535;
         let time_fraction: u32 = 812_000_000;


### PR DESCRIPTION
This includes:

- #630
- #631
- #633
- #610
- #616
- #611
- #626
- #628
- #625

The MSRV has been bumped to `1.57.0`.