### PR TITLE
Fix up lost re-export of v1 Timestamp

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -54,7 +54,7 @@ impl Uuid {
     ///
     /// # References
     ///
-    /// * [Nil UUID in RFC4122]: https://tools.ietf.org/html/rfc4122.html#section-4.1.7
+    /// * [Nil UUID in RFC4122](https://tools.ietf.org/html/rfc4122.html#section-4.1.7)
     ///
     /// # Examples
     ///
@@ -80,7 +80,7 @@ impl Uuid {
     ///
     /// # References
     ///
-    /// * [Max UUID in Draft RFC: New UUID Formats, Version 4]: https://datatracker.ietf.org/doc/html/draft-peabody-dispatch-new-uuid-format-04#section-5.4
+    /// * [Max UUID in Draft RFC: New UUID Formats, Version 4](https://datatracker.ietf.org/doc/html/draft-peabody-dispatch-new-uuid-format-04#section-5.4)
     ///
     /// # Examples
     ///

--- a/src/v1.rs
+++ b/src/v1.rs
@@ -3,9 +3,10 @@
 //! This module is soft-deprecated. Instead of using the `Context` type re-exported here,
 //! use the one from the crate root.
 
-use crate::{Builder, Timestamp, Uuid};
+use crate::{Builder, Uuid};
 
-pub use crate::timestamp::context::Context;
+#[deprecated(note = "use types from the crate root instead")]
+pub use crate::{timestamp::context::Context, Timestamp};
 
 impl Uuid {
     /// Create a new version 1 UUID using the current system time and node ID.


### PR DESCRIPTION
Closes #635 

This fixes an accidental breaking API change in a lost import from the `v1` module.