### PR TITLE
Fix incorrect reference to `try_parse`'s error messages in its doc comment

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -71,7 +71,7 @@ impl Uuid {
     /// hyphens.
     ///
     /// This function is similar to [`parse_str`], in fact `parse_str` shares
-    /// the same underlying parser. The difference is that if `try_parse`
+    /// the same underlying parser. The difference is that if `parse_str`
     /// fails, it won't generate very useful error messages. The `parse_str`
     /// function will eventually be deprecated in favor or `try_parse`.
     ///


### PR DESCRIPTION
**I'm submitting a** bug fix

# Description

The doc comment for `try_parse` says "if `try_parse` fails it won't generate very useful error messages". It should instead by `parse_str`. Sorry for the tiny PR, it just made me scratch my head for a moment when I came across it!

# Related Issue(s)

None
