### PR TITLE
Remove extern crate alloc

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -267,7 +267,6 @@ mod external;
 #[macro_use]
 mod macros;
 
-extern crate alloc;
 #[doc(hidden)]
 #[cfg(feature = "macro-diagnostics")]
 pub extern crate uuid_macro_internal;


### PR DESCRIPTION
Closes #643 #644 

This was erroneously added in `1.2.0`, but shouldn't be necessary at all.

Thanks @lulf for the report!