### PR TITLE
implement Arbitrary::size_hint

### DIFF
--- a/src/external/arbitrary_support.rs
+++ b/src/external/arbitrary_support.rs
@@ -11,6 +11,10 @@ impl Arbitrary<'_> for Uuid {
 
         Ok(Builder::from_random_bytes(b).into_uuid())
     }
+
+    fn size_hint(depth: usize) -> (usize, Option<usize>) {
+        (16, Some(16))
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This makes generating from non-arbitrary crates work much better, as they know how many bytes are needed to arbitrary-generate an uuid.

**I'm submitting a** bug fix
# Description

Without `Arbitrary::size_hint` implemented, the default implementation returns `(0, None)`, which means that `Uuid` needs any number of bytes between `0` and `usize::MAX` to generate.

In turn, when trying to use it from `bolero::gen_arbitrary()`, generation ended up very slow, because bolero was generating much more data than actually required.

With this change, `uuid` claims that it always needs exactly 16 bytes to generate an `Uuid`, which is true and makes `bolero::gen_arbitrary` generate exactly 16 bytes for it.

# Related Issue(s)

- https://github.com/camshaft/bolero/issues/111