### PR TITLE
Always use hyphenated format regardless of flags

### DIFF
--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -42,22 +42,14 @@ impl fmt::Display for Variant {
 
 impl fmt::LowerHex for Uuid {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if f.alternate() {
-            fmt::LowerHex::fmt(self.as_simple(), f)
-        } else {
-            fmt::LowerHex::fmt(self.as_hyphenated(), f)
-        }
+        fmt::LowerHex::fmt(self.as_hyphenated(), f)
     }
 }
 
 impl fmt::UpperHex for Uuid {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        if f.alternate() {
-            fmt::UpperHex::fmt(self.as_simple(), f)
-        } else {
-            fmt::UpperHex::fmt(self.as_hyphenated(), f)
-        }
+        fmt::UpperHex::fmt(self.as_hyphenated(), f)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1219,8 +1219,8 @@ mod tests {
         check!(buf, "{:X}", u, 36, |c| c.is_uppercase()
             || c.is_digit(10)
             || c == '-');
-        check!(buf, "{:#x}", u, 32, |c| c.is_lowercase() || c.is_digit(10));
-        check!(buf, "{:#X}", u, 32, |c| c.is_uppercase() || c.is_digit(10));
+        check!(buf, "{:#x}", u, 36, |c| c.is_lowercase() || c.is_digit(10) || c == '-');
+        check!(buf, "{:#X}", u, 36, |c| c.is_uppercase() || c.is_digit(10) || c == '-');
 
         check!(buf, "{:X}", u.hyphenated(), 36, |c| c.is_uppercase()
             || c.is_digit(10)


### PR DESCRIPTION
Closes #652 

The main use for alternate formatting is to pretty-print complex structs. It's surprising to have UUIDs change their format when pretty-printing, so this PR just always uses hyphenated formatting.