### PR TITLE
Prepare for 1.3.0 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ homepage = "https://github.com/uuid-rs/uuid"
 name = "uuid"
 readme = "README.md"
 repository = "https://github.com/uuid-rs/uuid"
-version = "1.2.2" # remember to update html_root_url in lib.rs
+version = "1.3.0" # remember to update html_root_url in lib.rs
 
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "uuid_unstable"]
@@ -134,7 +134,7 @@ version = "1"
 # Use the `macro-diagnostics` feature instead
 [dependencies.uuid-macro-internal]
 package = "uuid-macro-internal"
-version = "1.2.2"
+version = "1.3.0"
 path = "macros"
 optional = true
 

--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Add the following to your `Cargo.toml`:
 
 ```toml
 [dependencies.uuid]
-version = "1.2.2"
+version = "1.3.0"
 features = [
     "v4",                # Lets you generate random UUIDs
     "fast-rng",          # Use a faster (but still sufficiently random) RNG
@@ -66,7 +66,7 @@ assert_eq!(Some(Version::Random), my_uuid.get_version());
 If you'd like to parse UUIDs _really_ fast, check out the [`uuid-simd`](https://github.com/nugine/uuid-simd)
 library.
 
-For more details on using `uuid`, [see the library documentation](https://docs.rs/uuid/1.2.2/uuid).
+For more details on using `uuid`, [see the library documentation](https://docs.rs/uuid/1.3.0/uuid).
 
 ## Minimum Supported Rust Version (MSRV)
 
@@ -75,7 +75,7 @@ CI. It may be bumped in minor releases as necessary.
 
 ## References
 
-* [`uuid` library docs](https://docs.rs/uuid/1.2.2/uuid).
+* [`uuid` library docs](https://docs.rs/uuid/1.3.0/uuid).
 * [Wikipedia: Universally Unique Identifier](http://en.wikipedia.org/wiki/Universally_unique_identifier).
 * [RFC4122: A Universally Unique IDentifier (UUID) URN Namespace](http://tools.ietf.org/html/rfc4122).
 

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uuid-macro-internal"
-version = "1.2.2"
+version = "1.3.0"
 edition = "2018"
 authors = [
     "QnnOkabayashi"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@
 //!
 //! ```toml
 //! [dependencies.uuid]
-//! version = "1.2.2"
+//! version = "1.3.0"
 //! features = [
 //!     "v4",                # Lets you generate random UUIDs
 //!     "fast-rng",          # Use a faster (but still sufficiently random) RNG
@@ -138,7 +138,7 @@
 //!
 //! ```toml
 //! [dependencies.uuid]
-//! version = "1.2.2"
+//! version = "1.3.0"
 //! features = [
 //!     "v4",
 //!     "v7",
@@ -153,7 +153,7 @@
 //!
 //! ```toml
 //! [dependencies.uuid]
-//! version = "1.2.2"
+//! version = "1.3.0"
 //! default-features = false
 //! ```
 //!
@@ -211,7 +211,7 @@
 #![doc(
     html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
     html_favicon_url = "https://www.rust-lang.org/favicon.ico",
-    html_root_url = "https://docs.rs/uuid/1.2.2"
+    html_root_url = "https://docs.rs/uuid/1.3.0"
 )]
 
 #[cfg(any(feature = "std", test))]


### PR DESCRIPTION
Includes:

- #656 
- #657 
- #658 
- #654 

The main change to call out here is that the alternate debug format for `Uuid` (that is, `{:#?}`) is now the same hyphenated format used in regular debug.