### PR TITLE
Faster as_u128 and to_u128_le

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -687,22 +687,7 @@ impl Uuid {
     /// # }
     /// ```
     pub const fn as_u128(&self) -> u128 {
-        (self.as_bytes()[0] as u128) << 120
-            | (self.as_bytes()[1] as u128) << 112
-            | (self.as_bytes()[2] as u128) << 104
-            | (self.as_bytes()[3] as u128) << 96
-            | (self.as_bytes()[4] as u128) << 88
-            | (self.as_bytes()[5] as u128) << 80
-            | (self.as_bytes()[6] as u128) << 72
-            | (self.as_bytes()[7] as u128) << 64
-            | (self.as_bytes()[8] as u128) << 56
-            | (self.as_bytes()[9] as u128) << 48
-            | (self.as_bytes()[10] as u128) << 40
-            | (self.as_bytes()[11] as u128) << 32
-            | (self.as_bytes()[12] as u128) << 24
-            | (self.as_bytes()[13] as u128) << 16
-            | (self.as_bytes()[14] as u128) << 8
-            | (self.as_bytes()[15] as u128)
+        u128::from_be_bytes(*self.as_bytes())
     }
 
     /// Returns a 128bit little-endian value containing the value.
@@ -731,22 +716,7 @@ impl Uuid {
     /// # }
     /// ```
     pub const fn to_u128_le(&self) -> u128 {
-        (self.as_bytes()[0] as u128)
-            | (self.as_bytes()[1] as u128) << 8
-            | (self.as_bytes()[2] as u128) << 16
-            | (self.as_bytes()[3] as u128) << 24
-            | (self.as_bytes()[4] as u128) << 32
-            | (self.as_bytes()[5] as u128) << 40
-            | (self.as_bytes()[6] as u128) << 48
-            | (self.as_bytes()[7] as u128) << 56
-            | (self.as_bytes()[8] as u128) << 64
-            | (self.as_bytes()[9] as u128) << 72
-            | (self.as_bytes()[10] as u128) << 80
-            | (self.as_bytes()[11] as u128) << 88
-            | (self.as_bytes()[12] as u128) << 96
-            | (self.as_bytes()[13] as u128) << 104
-            | (self.as_bytes()[14] as u128) << 112
-            | (self.as_bytes()[15] as u128) << 120
+        u128::from_le_bytes(*self.as_bytes())
     }
 
     /// Returns two 64bit values containing the value.


### PR DESCRIPTION
**I'm submitting an** improvement

# Description

Implement `as_u128` and `to_u128_le` using `u128::from_be_bytes` and `u128::from_le_bytes`, respectively.

This is faster because it avoids the array indexing and shift operations. Depending on the machine endianess, `from_be_bytes`/`from_le_bytes` will either be a no-op or a single [`intrinsics::bswap`](https://doc.rust-lang.org/std/intrinsics/fn.bswap.html) (which on most platforms is just a couple of instructions). It's also a simpler implementation that simply relies on the std u128 functions.

In my informal testing, this was consistently about 3x faster.

```rust
use std::hint::black_box;
use std::time::Instant;
use uuid::Uuid;

fn main() {
    let uuid = Uuid::new_v4();
    let bytes = uuid.as_bytes();

    macro_rules! time {
        ($name:literal, $expr:expr) => {
            let instant = Instant::now();
            for _ in 0..1_000_000_000 {
                black_box($expr);
            }
            println!("{}: {:?}", $name, instant.elapsed());
        };
    }

    time!("as_u128", uuid.as_u128());
    time!("to_u128_le", uuid.to_u128_le());
    time!("from_be_bytes", u128::from_be_bytes(bytes.clone()));
    time!("from_le_bytes", u128::from_le_bytes(bytes.clone()));
}
```

```
as_u128: 962.951375ms
to_u128_le: 967.881416ms
from_be_bytes: 321.645584ms
from_le_bytes: 321.529417ms
```