### PR TITLE
Hard deprecate Timestamp::to_unix_nanos

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,24 +22,24 @@ jobs:
     strategy:
       matrix:
         exclude:
-        - os: macos-10.15
+        - os: macos-latest
           rust_target: x86_64-gnu
-        - os: macos-10.15
+        - os: macos-latest
           rust_target: x86_64-msvc
-        - os: windows-2019
+        - os: windows-latest
           rust_target: x86_64-apple-darwin
-        - os: ubuntu-20.04
+        - os: ubuntu-latest
           rust_target: x86_64-msvc
-        - os: ubuntu-20.04
+        - os: ubuntu-latest
           rust_target: x86_64-apple-darwin
         channel:
         - stable
         - beta
         - nightly
         os:
-        - macos-10.15
-        - ubuntu-20.04
-        - windows-2019
+        - macos-latest
+        - ubuntu-latest
+        - windows-latest
         rust_target:
         - x86_64-gnu
         - x86_64-msvc
@@ -69,7 +69,7 @@ jobs:
 
   stable:
     name: "Tests / Stable"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout sources
       uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
@@ -79,7 +79,7 @@ jobs:
 
   msrv:
     name: "Tests / MSRV"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
     - name: Checkout sources
       uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab

--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -137,20 +137,14 @@ impl Timestamp {
         )
     }
 
-    #[deprecated(note = "use `to_unix` instead")]
+    #[deprecated(note = "use `to_unix` instead; this method will be removed in a future release")]
     /// Get the number of fractional nanoseconds in the Unix timestamp.
     ///
     /// This method is deprecated and probably doesn't do what you're expecting it to.
     /// It doesn't return the timestamp as nanoseconds since the Unix epoch, it returns
     /// the fractional seconds of the timestamp.
     pub const fn to_unix_nanos(&self) -> u32 {
-        // NOTE: This method never did what it said on the tin: instead of
-        // converting the timestamp into nanos it simply returned the nanoseconds
-        // part of the timestamp.
-        //
-        // We can't fix the behavior because the return type is too small to fit
-        // a useful value for nanoseconds since the epoch.
-        self.nanos
+        panic!("`Timestamp::to_unix_nanos` is deprecated and will be removed: use `Timestamp::to_unix` instead")
     }
 }
 


### PR DESCRIPTION
The `Timestamp::to_unix` method has been deprecated for some time now. I'd like to remove it entirely in a future release. I can't find any actual usages of it, since the method was never useful, so in a `2.x` release of `uuid` it will disappear. Note that since the plan is for `1.x` to re-export `2.x` that means this method will vanish in some future minor release of `1.x`. We don't want to do this often, but the alternative of letting multiple versions of the `Uuid` type float around is worse than having a single deprecated and useless method disappear.