### PR TITLE
Fixed wasm tests not running due to incorrect attribute target

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -165,7 +165,7 @@ version = "1.0.56"
 package = "wasm-bindgen"
 version = "0.2"
 
-[target.'cfg(target = "wasm32-unknown-unknown")'.dev-dependencies.wasm-bindgen-test]
+[target.'cfg(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"))'.dev-dependencies.wasm-bindgen-test]
 version = "0.3"
 
 [dev-dependencies.trybuild]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -949,7 +949,7 @@ mod tests {
 
     use crate::std::string::{String, ToString};
 
-    #[cfg(target = "wasm32-unknown-unknown")]
+    #[cfg(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"))]
     use wasm_bindgen_test::*;
 
     macro_rules! check {
@@ -976,7 +976,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target = "wasm32-unknown-unknown", wasm_bindgen_test)]
+    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
     fn test_uuid_compare() {
         let uuid1 = new();
         let uuid2 = new2();
@@ -989,7 +989,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target = "wasm32-unknown-unknown", wasm_bindgen_test)]
+    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
     fn test_uuid_default() {
         let default_uuid = Uuid::default();
         let nil_uuid = Uuid::nil();
@@ -998,7 +998,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target = "wasm32-unknown-unknown", wasm_bindgen_test)]
+    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
     fn test_uuid_display() {
         use crate::std::fmt::Write;
 
@@ -1014,7 +1014,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target = "wasm32-unknown-unknown", wasm_bindgen_test)]
+    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
     fn test_uuid_lowerhex() {
         use crate::std::fmt::Write;
 
@@ -1028,7 +1028,7 @@ mod tests {
 
     // noinspection RsAssertEqual
     #[test]
-    #[cfg_attr(target = "wasm32-unknown-unknown", wasm_bindgen_test)]
+    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
     fn test_uuid_operator_eq() {
         let uuid1 = new();
         let uuid1_dup = uuid1.clone();
@@ -1045,7 +1045,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target = "wasm32-unknown-unknown", wasm_bindgen_test)]
+    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
     fn test_uuid_to_string() {
         use crate::std::fmt::Write;
 
@@ -1061,7 +1061,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target = "wasm32-unknown-unknown", wasm_bindgen_test)]
+    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
     fn test_non_conforming() {
         let from_bytes =
             Uuid::from_bytes([4, 54, 67, 12, 43, 2, 2, 76, 32, 50, 87, 5, 1, 33, 43, 87]);
@@ -1070,7 +1070,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target = "wasm32-unknown-unknown", wasm_bindgen_test)]
+    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
     fn test_nil() {
         let nil = Uuid::nil();
         let not_nil = new();
@@ -1091,7 +1091,7 @@ mod tests {
 
     #[test]
     #[cfg(uuid_unstable)]
-    #[cfg_attr(target = "wasm32-unknown-unknown", wasm_bindgen_test)]
+    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
     fn test_max() {
         let max = Uuid::max();
         let not_max = new();
@@ -1111,7 +1111,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target = "wasm32-unknown-unknown", wasm_bindgen_test)]
+    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
     fn test_predefined_namespaces() {
         assert_eq!(
             Uuid::NAMESPACE_DNS.hyphenated().to_string(),
@@ -1133,7 +1133,7 @@ mod tests {
 
     #[cfg(feature = "v3")]
     #[test]
-    #[cfg_attr(target = "wasm32-unknown-unknown", wasm_bindgen_test)]
+    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
     fn test_get_version_v3() {
         let uuid = Uuid::new_v3(&Uuid::NAMESPACE_DNS, "rust-lang.org".as_bytes());
 
@@ -1142,7 +1142,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target = "wasm32-unknown-unknown", wasm_bindgen_test)]
+    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
     fn test_get_variant() {
         let uuid1 = new();
         let uuid2 = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
@@ -1160,7 +1160,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target = "wasm32-unknown-unknown", wasm_bindgen_test)]
+    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
     fn test_to_simple_string() {
         let uuid1 = new();
         let s = uuid1.simple().to_string();
@@ -1170,7 +1170,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target = "wasm32-unknown-unknown", wasm_bindgen_test)]
+    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
     fn test_hyphenated_string() {
         let uuid1 = new();
         let s = uuid1.hyphenated().to_string();
@@ -1180,7 +1180,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target = "wasm32-unknown-unknown", wasm_bindgen_test)]
+    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
     fn test_upper_lower_hex() {
         use std::fmt::Write;
 
@@ -1233,7 +1233,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target = "wasm32-unknown-unknown", wasm_bindgen_test)]
+    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
     fn test_to_urn_string() {
         let uuid1 = new();
         let ss = uuid1.urn().to_string();
@@ -1245,7 +1245,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target = "wasm32-unknown-unknown", wasm_bindgen_test)]
+    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
     fn test_to_simple_string_matching() {
         let uuid1 = new();
 
@@ -1258,7 +1258,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target = "wasm32-unknown-unknown", wasm_bindgen_test)]
+    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
     fn test_string_roundtrip() {
         let uuid = new();
 
@@ -1272,7 +1272,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target = "wasm32-unknown-unknown", wasm_bindgen_test)]
+    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
     fn test_from_fields() {
         let d1: u32 = 0xa1a2a3a4;
         let d2: u16 = 0xb1b2;
@@ -1287,7 +1287,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target = "wasm32-unknown-unknown", wasm_bindgen_test)]
+    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
     fn test_from_fields_le() {
         let d1: u32 = 0xa4a3a2a1;
         let d2: u16 = 0xb2b1;
@@ -1302,7 +1302,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target = "wasm32-unknown-unknown", wasm_bindgen_test)]
+    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
     fn test_as_fields() {
         let u = new();
         let (d1, d2, d3, d4) = u.as_fields();
@@ -1315,7 +1315,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target = "wasm32-unknown-unknown", wasm_bindgen_test)]
+    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
     fn test_fields_roundtrip() {
         let d1_in: u32 = 0xa1a2a3a4;
         let d2_in: u16 = 0xb1b2;
@@ -1332,7 +1332,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target = "wasm32-unknown-unknown", wasm_bindgen_test)]
+    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
     fn test_fields_le_roundtrip() {
         let d1_in: u32 = 0xa4a3a2a1;
         let d2_in: u16 = 0xb2b1;
@@ -1349,7 +1349,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target = "wasm32-unknown-unknown", wasm_bindgen_test)]
+    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
     fn test_fields_le_are_actually_le() {
         let d1_in: u32 = 0xa1a2a3a4;
         let d2_in: u16 = 0xb1b2;
@@ -1366,7 +1366,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target = "wasm32-unknown-unknown", wasm_bindgen_test)]
+    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
     fn test_from_u128() {
         let v_in: u128 = 0xa1a2a3a4b1b2c1c2d1d2d3d4d5d6d7d8;
 
@@ -1378,7 +1378,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target = "wasm32-unknown-unknown", wasm_bindgen_test)]
+    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
     fn test_from_u128_le() {
         let v_in: u128 = 0xd8d7d6d5d4d3d2d1c2c1b2b1a4a3a2a1;
 
@@ -1390,7 +1390,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target = "wasm32-unknown-unknown", wasm_bindgen_test)]
+    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
     fn test_from_u64_pair() {
         let high_in: u64 = 0xa1a2a3a4b1b2c1c2;
         let low_in: u64 = 0xd1d2d3d4d5d6d7d8;
@@ -1403,7 +1403,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target = "wasm32-unknown-unknown", wasm_bindgen_test)]
+    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
     fn test_u128_roundtrip() {
         let v_in: u128 = 0xa1a2a3a4b1b2c1c2d1d2d3d4d5d6d7d8;
 
@@ -1414,7 +1414,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target = "wasm32-unknown-unknown", wasm_bindgen_test)]
+    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
     fn test_u128_le_roundtrip() {
         let v_in: u128 = 0xd8d7d6d5d4d3d2d1c2c1b2b1a4a3a2a1;
 
@@ -1425,7 +1425,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target = "wasm32-unknown-unknown", wasm_bindgen_test)]
+    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
     fn test_u64_pair_roundtrip() {
         let high_in: u64 = 0xa1a2a3a4b1b2c1c2;
         let low_in: u64 = 0xd1d2d3d4d5d6d7d8;
@@ -1438,7 +1438,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target = "wasm32-unknown-unknown", wasm_bindgen_test)]
+    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
     fn test_u128_le_is_actually_le() {
         let v_in: u128 = 0xa1a2a3a4b1b2c1c2d1d2d3d4d5d6d7d8;
 
@@ -1449,7 +1449,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target = "wasm32-unknown-unknown", wasm_bindgen_test)]
+    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
     fn test_from_slice() {
         let b = [
             0xa1, 0xa2, 0xa3, 0xa4, 0xb1, 0xb2, 0xc1, 0xc2, 0xd1, 0xd2, 0xd3, 0xd4, 0xd5, 0xd6,
@@ -1463,7 +1463,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target = "wasm32-unknown-unknown", wasm_bindgen_test)]
+    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
     fn test_from_bytes() {
         let b = [
             0xa1, 0xa2, 0xa3, 0xa4, 0xb1, 0xb2, 0xc1, 0xc2, 0xd1, 0xd2, 0xd3, 0xd4, 0xd5, 0xd6,
@@ -1477,7 +1477,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target = "wasm32-unknown-unknown", wasm_bindgen_test)]
+    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
     fn test_as_bytes() {
         let u = new();
         let ub = u.as_bytes();
@@ -1490,7 +1490,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target = "wasm32-unknown-unknown", wasm_bindgen_test)]
+    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
     fn test_bytes_roundtrip() {
         let b_in: crate::Bytes = [
             0xa1, 0xa2, 0xa3, 0xa4, 0xb1, 0xb2, 0xc1, 0xc2, 0xd1, 0xd2, 0xd3, 0xd4, 0xd5, 0xd6,
@@ -1505,7 +1505,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target = "wasm32-unknown-unknown", wasm_bindgen_test)]
+    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
     fn test_bytes_le_roundtrip() {
         let b = [
             0xa1, 0xa2, 0xa3, 0xa4, 0xb1, 0xb2, 0xc1, 0xc2, 0xd1, 0xd2, 0xd3, 0xd4, 0xd5, 0xd6,
@@ -1522,7 +1522,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target = "wasm32-unknown-unknown", wasm_bindgen_test)]
+    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
     fn test_iterbytes_impl_for_uuid() {
         let mut set = std::collections::HashSet::new();
         let id1 = new();

--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -262,7 +262,7 @@ pub(crate) const fn decode_unix_timestamp_millis(uuid: &Uuid) -> u64 {
     millis
 }
 
-#[cfg(all(feature = "std", feature = "js", target = "wasm32-unknown-unknown"))]
+#[cfg(all(feature = "std", feature = "js", all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown")))]
 fn now() -> (u64, u32) {
     use wasm_bindgen::prelude::*;
 
@@ -280,7 +280,7 @@ fn now() -> (u64, u32) {
     dbg!((secs, nanos))
 }
 
-#[cfg(all(feature = "std", any(not(feature = "js"), not(target = "wasm32-unknown-unknown"))))]
+#[cfg(all(feature = "std", any(not(feature = "js"), not(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown")))))]
 fn now() -> (u64, u32) {
     let dur = std::time::SystemTime::UNIX_EPOCH
         .elapsed()

--- a/src/v1.rs
+++ b/src/v1.rs
@@ -100,11 +100,11 @@ mod tests {
     use super::*;
 
     use crate::{std::string::ToString, Variant, Version};
-    #[cfg(target = "wasm32-unknown-unknown")]
+    #[cfg(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"))]
     use wasm_bindgen_test::*;
 
     #[test]
-    #[cfg_attr(target = "wasm32-unknown-unknown", wasm_bindgen_test)]
+    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
     fn test_new() {
         let time: u64 = 1_496_854_535;
         let time_fraction: u32 = 812_946_000;
@@ -134,7 +134,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target = "wasm32-unknown-unknown", wasm_bindgen_test)]
+    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
     #[cfg(all(feature = "std", feature = "rng"))]
     fn test_now() {
         let node = [1, 2, 3, 4, 5, 6];
@@ -146,7 +146,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target = "wasm32-unknown-unknown", wasm_bindgen_test)]
+    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
     fn test_new_context() {
         let time: u64 = 1_496_854_535;
         let time_fraction: u32 = 812_946_000;

--- a/src/v3.rs
+++ b/src/v3.rs
@@ -42,7 +42,7 @@ impl Uuid {
 mod tests {
     use super::*;
 
-    #[cfg(target = "wasm32-unknown-unknown")]
+    #[cfg(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"))]
     use wasm_bindgen_test::*;
 
     use crate::{std::string::ToString, Variant, Version};
@@ -131,7 +131,7 @@ mod tests {
     ];
 
     #[test]
-    #[cfg_attr(target = "wasm32-unknown-unknown", wasm_bindgen_test)]
+    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
     fn test_new() {
         for &(ref ns, ref name, _) in FIXTURE {
             let uuid = Uuid::new_v3(*ns, name.as_bytes());
@@ -141,7 +141,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target = "wasm32-unknown-unknown", wasm_bindgen_test)]
+    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
     fn test_hyphenated_string() {
         for &(ref ns, ref name, ref expected) in FIXTURE {
             let uuid = Uuid::new_v3(*ns, name.as_bytes());

--- a/src/v4.rs
+++ b/src/v4.rs
@@ -40,11 +40,11 @@ mod tests {
     use super::*;
     use crate::{Variant, Version};
 
-    #[cfg(target = "wasm32-unknown-unknown")]
+    #[cfg(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"))]
     use wasm_bindgen_test::*;
 
     #[test]
-    #[cfg_attr(target = "wasm32-unknown-unknown", wasm_bindgen_test)]
+    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
     fn test_new() {
         let uuid = Uuid::new_v4();
 
@@ -53,7 +53,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target = "wasm32-unknown-unknown", wasm_bindgen_test)]
+    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
     fn test_get_version() {
         let uuid = Uuid::new_v4();
 

--- a/src/v5.rs
+++ b/src/v5.rs
@@ -41,7 +41,7 @@ impl Uuid {
 mod tests {
     use super::*;
 
-    #[cfg(target = "wasm32-unknown-unknown")]
+    #[cfg(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"))]
     use wasm_bindgen_test::*;
 
     use crate::{std::string::ToString, Variant, Version};
@@ -130,7 +130,7 @@ mod tests {
     ];
 
     #[test]
-    #[cfg_attr(target = "wasm32-unknown-unknown", wasm_bindgen_test)]
+    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
     fn test_get_version() {
         let uuid = Uuid::new_v5(&Uuid::NAMESPACE_DNS, "rust-lang.org".as_bytes());
 
@@ -139,7 +139,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target = "wasm32-unknown-unknown", wasm_bindgen_test)]
+    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
     fn test_hyphenated() {
         for &(ref ns, ref name, ref expected) in FIXTURE {
             let uuid = Uuid::new_v5(*ns, name.as_bytes());
@@ -149,7 +149,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target = "wasm32-unknown-unknown", wasm_bindgen_test)]
+    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
     fn test_new() {
         for &(ref ns, ref name, ref u) in FIXTURE {
             let uuid = Uuid::new_v5(*ns, name.as_bytes());

--- a/src/v6.rs
+++ b/src/v6.rs
@@ -102,11 +102,11 @@ mod tests {
     use crate::{Context, Variant, Version};
     use std::string::ToString;
 
-    #[cfg(target = "wasm32-unknown-unknown")]
+    #[cfg(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"))]
     use wasm_bindgen_test::*;
 
     #[test]
-    #[cfg_attr(target = "wasm32-unknown-unknown", wasm_bindgen_test)]
+    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
     fn test_new() {
         let time: u64 = 1_496_854_535;
         let time_fraction: u32 = 812_946_000;
@@ -136,7 +136,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target = "wasm32-unknown-unknown", wasm_bindgen_test)]
+    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
     #[cfg(all(feature = "std", feature = "rng"))]
     fn test_now() {
         let node = [1, 2, 3, 4, 5, 6];
@@ -148,7 +148,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target = "wasm32-unknown-unknown", wasm_bindgen_test)]
+    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
     fn test_new_context() {
         let time: u64 = 1_496_854_535;
         let time_fraction: u32 = 812_946_000;

--- a/src/v7.rs
+++ b/src/v7.rs
@@ -57,11 +57,11 @@ impl Uuid {
 mod tests {
     use super::*;
     use crate::{std::string::ToString, NoContext, Variant, Version};
-    #[cfg(target = "wasm32-unknown-unknown")]
+    #[cfg(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"))]
     use wasm_bindgen_test::*;
 
     #[test]
-    #[cfg_attr(target = "wasm32-unknown-unknown", wasm_bindgen_test)]
+    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
     fn test_new() {
         let ts: u64 = 1645557742000;
 
@@ -82,7 +82,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target = "wasm32-unknown-unknown", wasm_bindgen_test)]
+    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
     #[cfg(feature = "std")]
     fn test_now() {
         let uuid = Uuid::now_v7();
@@ -92,7 +92,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target = "wasm32-unknown-unknown", wasm_bindgen_test)]
+    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
     fn test_sorting() {
         let time1: u64 = 1_496_854_535;
         let time_fraction1: u32 = 812_000_000;
@@ -108,7 +108,7 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(target = "wasm32-unknown-unknown", wasm_bindgen_test)]
+    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
     fn test_new_timestamp_roundtrip() {
         let time: u64 = 1_496_854_535;
         let time_fraction: u32 = 812_000_000;

--- a/src/v8.rs
+++ b/src/v8.rs
@@ -36,11 +36,11 @@ mod tests {
     use crate::{Variant, Version};
     use std::string::ToString;
 
-    #[cfg(target = "wasm32-unknown-unknown")]
+    #[cfg(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"))]
     use wasm_bindgen_test::*;
 
     #[test]
-    #[cfg_attr(target = "wasm32-unknown-unknown", wasm_bindgen_test)]
+    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
     fn test_new() {
         let buf: [u8; 16] = [
             0xf, 0xe, 0xd, 0xc, 0xb, 0xa, 0x9, 0x8, 0x7, 0x6, 0x5, 0x4, 0x3, 0x2, 0x1, 0x0,


### PR DESCRIPTION
Fixes #687 by replacing

```rust
target = "wasm32-unknown-unknown"
```

with

```rust
all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown")
```