### PR TITLE
Fix some timestamp generation

### DIFF
--- a/src/external/arbitrary_support.rs
+++ b/src/external/arbitrary_support.rs
@@ -12,7 +12,7 @@ impl Arbitrary<'_> for Uuid {
         Ok(Builder::from_random_bytes(b).into_uuid())
     }
 
-    fn size_hint(depth: usize) -> (usize, Option<usize>) {
+    fn size_hint(_: usize) -> (usize, Option<usize>) {
         (16, Some(16))
     }
 }

--- a/src/external/borsh_support.rs
+++ b/src/external/borsh_support.rs
@@ -1,8 +1,8 @@
 #[cfg(test)]
 mod borsh_tests {
     use crate::Uuid;
-    use std::string::ToString;
     use borsh::{BorshDeserialize, BorshSerialize};
+    use std::string::ToString;
 
     #[test]
     fn test_serialize() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -437,7 +437,8 @@ pub enum Variant {
     all(uuid_unstable, feature = "zerocopy"),
     derive(AsBytes, FromBytes, Unaligned)
 )]
-#[cfg_attr(all(uuid_unstable, feature = "borsh"),
+#[cfg_attr(
+    all(uuid_unstable, feature = "borsh"),
     derive(borsh::BorshDeserialize, borsh::BorshSerialize)
 )]
 #[repr(transparent)]
@@ -954,7 +955,11 @@ mod tests {
 
     use crate::std::string::{String, ToString};
 
-    #[cfg(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"))]
+    #[cfg(all(
+        target_arch = "wasm32",
+        target_vendor = "unknown",
+        target_os = "unknown"
+    ))]
     use wasm_bindgen_test::*;
 
     macro_rules! check {
@@ -981,7 +986,14 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
+    #[cfg_attr(
+        all(
+            target_arch = "wasm32",
+            target_vendor = "unknown",
+            target_os = "unknown"
+        ),
+        wasm_bindgen_test
+    )]
     fn test_uuid_compare() {
         let uuid1 = new();
         let uuid2 = new2();
@@ -994,7 +1006,14 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
+    #[cfg_attr(
+        all(
+            target_arch = "wasm32",
+            target_vendor = "unknown",
+            target_os = "unknown"
+        ),
+        wasm_bindgen_test
+    )]
     fn test_uuid_default() {
         let default_uuid = Uuid::default();
         let nil_uuid = Uuid::nil();
@@ -1003,7 +1022,14 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
+    #[cfg_attr(
+        all(
+            target_arch = "wasm32",
+            target_vendor = "unknown",
+            target_os = "unknown"
+        ),
+        wasm_bindgen_test
+    )]
     fn test_uuid_display() {
         use crate::std::fmt::Write;
 
@@ -1019,7 +1045,14 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
+    #[cfg_attr(
+        all(
+            target_arch = "wasm32",
+            target_vendor = "unknown",
+            target_os = "unknown"
+        ),
+        wasm_bindgen_test
+    )]
     fn test_uuid_lowerhex() {
         use crate::std::fmt::Write;
 
@@ -1033,7 +1066,14 @@ mod tests {
 
     // noinspection RsAssertEqual
     #[test]
-    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
+    #[cfg_attr(
+        all(
+            target_arch = "wasm32",
+            target_vendor = "unknown",
+            target_os = "unknown"
+        ),
+        wasm_bindgen_test
+    )]
     fn test_uuid_operator_eq() {
         let uuid1 = new();
         let uuid1_dup = uuid1.clone();
@@ -1050,7 +1090,14 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
+    #[cfg_attr(
+        all(
+            target_arch = "wasm32",
+            target_vendor = "unknown",
+            target_os = "unknown"
+        ),
+        wasm_bindgen_test
+    )]
     fn test_uuid_to_string() {
         use crate::std::fmt::Write;
 
@@ -1066,7 +1113,14 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
+    #[cfg_attr(
+        all(
+            target_arch = "wasm32",
+            target_vendor = "unknown",
+            target_os = "unknown"
+        ),
+        wasm_bindgen_test
+    )]
     fn test_non_conforming() {
         let from_bytes =
             Uuid::from_bytes([4, 54, 67, 12, 43, 2, 2, 76, 32, 50, 87, 5, 1, 33, 43, 87]);
@@ -1075,7 +1129,14 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
+    #[cfg_attr(
+        all(
+            target_arch = "wasm32",
+            target_vendor = "unknown",
+            target_os = "unknown"
+        ),
+        wasm_bindgen_test
+    )]
     fn test_nil() {
         let nil = Uuid::nil();
         let not_nil = new();
@@ -1096,7 +1157,14 @@ mod tests {
 
     #[test]
     #[cfg(uuid_unstable)]
-    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
+    #[cfg_attr(
+        all(
+            target_arch = "wasm32",
+            target_vendor = "unknown",
+            target_os = "unknown"
+        ),
+        wasm_bindgen_test
+    )]
     fn test_max() {
         let max = Uuid::max();
         let not_max = new();
@@ -1116,7 +1184,14 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
+    #[cfg_attr(
+        all(
+            target_arch = "wasm32",
+            target_vendor = "unknown",
+            target_os = "unknown"
+        ),
+        wasm_bindgen_test
+    )]
     fn test_predefined_namespaces() {
         assert_eq!(
             Uuid::NAMESPACE_DNS.hyphenated().to_string(),
@@ -1138,7 +1213,14 @@ mod tests {
 
     #[cfg(feature = "v3")]
     #[test]
-    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
+    #[cfg_attr(
+        all(
+            target_arch = "wasm32",
+            target_vendor = "unknown",
+            target_os = "unknown"
+        ),
+        wasm_bindgen_test
+    )]
     fn test_get_version_v3() {
         let uuid = Uuid::new_v3(&Uuid::NAMESPACE_DNS, "rust-lang.org".as_bytes());
 
@@ -1147,7 +1229,14 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
+    #[cfg_attr(
+        all(
+            target_arch = "wasm32",
+            target_vendor = "unknown",
+            target_os = "unknown"
+        ),
+        wasm_bindgen_test
+    )]
     fn test_get_variant() {
         let uuid1 = new();
         let uuid2 = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000").unwrap();
@@ -1165,7 +1254,14 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
+    #[cfg_attr(
+        all(
+            target_arch = "wasm32",
+            target_vendor = "unknown",
+            target_os = "unknown"
+        ),
+        wasm_bindgen_test
+    )]
     fn test_to_simple_string() {
         let uuid1 = new();
         let s = uuid1.simple().to_string();
@@ -1175,7 +1271,14 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
+    #[cfg_attr(
+        all(
+            target_arch = "wasm32",
+            target_vendor = "unknown",
+            target_os = "unknown"
+        ),
+        wasm_bindgen_test
+    )]
     fn test_hyphenated_string() {
         let uuid1 = new();
         let s = uuid1.hyphenated().to_string();
@@ -1185,7 +1288,14 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
+    #[cfg_attr(
+        all(
+            target_arch = "wasm32",
+            target_vendor = "unknown",
+            target_os = "unknown"
+        ),
+        wasm_bindgen_test
+    )]
     fn test_upper_lower_hex() {
         use std::fmt::Write;
 
@@ -1238,7 +1348,14 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
+    #[cfg_attr(
+        all(
+            target_arch = "wasm32",
+            target_vendor = "unknown",
+            target_os = "unknown"
+        ),
+        wasm_bindgen_test
+    )]
     fn test_to_urn_string() {
         let uuid1 = new();
         let ss = uuid1.urn().to_string();
@@ -1250,7 +1367,14 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
+    #[cfg_attr(
+        all(
+            target_arch = "wasm32",
+            target_vendor = "unknown",
+            target_os = "unknown"
+        ),
+        wasm_bindgen_test
+    )]
     fn test_to_simple_string_matching() {
         let uuid1 = new();
 
@@ -1263,7 +1387,14 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
+    #[cfg_attr(
+        all(
+            target_arch = "wasm32",
+            target_vendor = "unknown",
+            target_os = "unknown"
+        ),
+        wasm_bindgen_test
+    )]
     fn test_string_roundtrip() {
         let uuid = new();
 
@@ -1277,7 +1408,14 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
+    #[cfg_attr(
+        all(
+            target_arch = "wasm32",
+            target_vendor = "unknown",
+            target_os = "unknown"
+        ),
+        wasm_bindgen_test
+    )]
     fn test_from_fields() {
         let d1: u32 = 0xa1a2a3a4;
         let d2: u16 = 0xb1b2;
@@ -1292,7 +1430,14 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
+    #[cfg_attr(
+        all(
+            target_arch = "wasm32",
+            target_vendor = "unknown",
+            target_os = "unknown"
+        ),
+        wasm_bindgen_test
+    )]
     fn test_from_fields_le() {
         let d1: u32 = 0xa4a3a2a1;
         let d2: u16 = 0xb2b1;
@@ -1307,7 +1452,14 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
+    #[cfg_attr(
+        all(
+            target_arch = "wasm32",
+            target_vendor = "unknown",
+            target_os = "unknown"
+        ),
+        wasm_bindgen_test
+    )]
     fn test_as_fields() {
         let u = new();
         let (d1, d2, d3, d4) = u.as_fields();
@@ -1320,7 +1472,14 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
+    #[cfg_attr(
+        all(
+            target_arch = "wasm32",
+            target_vendor = "unknown",
+            target_os = "unknown"
+        ),
+        wasm_bindgen_test
+    )]
     fn test_fields_roundtrip() {
         let d1_in: u32 = 0xa1a2a3a4;
         let d2_in: u16 = 0xb1b2;
@@ -1337,7 +1496,14 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
+    #[cfg_attr(
+        all(
+            target_arch = "wasm32",
+            target_vendor = "unknown",
+            target_os = "unknown"
+        ),
+        wasm_bindgen_test
+    )]
     fn test_fields_le_roundtrip() {
         let d1_in: u32 = 0xa4a3a2a1;
         let d2_in: u16 = 0xb2b1;
@@ -1354,7 +1520,14 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
+    #[cfg_attr(
+        all(
+            target_arch = "wasm32",
+            target_vendor = "unknown",
+            target_os = "unknown"
+        ),
+        wasm_bindgen_test
+    )]
     fn test_fields_le_are_actually_le() {
         let d1_in: u32 = 0xa1a2a3a4;
         let d2_in: u16 = 0xb1b2;
@@ -1371,7 +1544,14 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
+    #[cfg_attr(
+        all(
+            target_arch = "wasm32",
+            target_vendor = "unknown",
+            target_os = "unknown"
+        ),
+        wasm_bindgen_test
+    )]
     fn test_from_u128() {
         let v_in: u128 = 0xa1a2a3a4b1b2c1c2d1d2d3d4d5d6d7d8;
 
@@ -1383,7 +1563,14 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
+    #[cfg_attr(
+        all(
+            target_arch = "wasm32",
+            target_vendor = "unknown",
+            target_os = "unknown"
+        ),
+        wasm_bindgen_test
+    )]
     fn test_from_u128_le() {
         let v_in: u128 = 0xd8d7d6d5d4d3d2d1c2c1b2b1a4a3a2a1;
 
@@ -1395,7 +1582,14 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
+    #[cfg_attr(
+        all(
+            target_arch = "wasm32",
+            target_vendor = "unknown",
+            target_os = "unknown"
+        ),
+        wasm_bindgen_test
+    )]
     fn test_from_u64_pair() {
         let high_in: u64 = 0xa1a2a3a4b1b2c1c2;
         let low_in: u64 = 0xd1d2d3d4d5d6d7d8;
@@ -1408,7 +1602,14 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
+    #[cfg_attr(
+        all(
+            target_arch = "wasm32",
+            target_vendor = "unknown",
+            target_os = "unknown"
+        ),
+        wasm_bindgen_test
+    )]
     fn test_u128_roundtrip() {
         let v_in: u128 = 0xa1a2a3a4b1b2c1c2d1d2d3d4d5d6d7d8;
 
@@ -1419,7 +1620,14 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
+    #[cfg_attr(
+        all(
+            target_arch = "wasm32",
+            target_vendor = "unknown",
+            target_os = "unknown"
+        ),
+        wasm_bindgen_test
+    )]
     fn test_u128_le_roundtrip() {
         let v_in: u128 = 0xd8d7d6d5d4d3d2d1c2c1b2b1a4a3a2a1;
 
@@ -1430,7 +1638,14 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
+    #[cfg_attr(
+        all(
+            target_arch = "wasm32",
+            target_vendor = "unknown",
+            target_os = "unknown"
+        ),
+        wasm_bindgen_test
+    )]
     fn test_u64_pair_roundtrip() {
         let high_in: u64 = 0xa1a2a3a4b1b2c1c2;
         let low_in: u64 = 0xd1d2d3d4d5d6d7d8;
@@ -1443,7 +1658,14 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
+    #[cfg_attr(
+        all(
+            target_arch = "wasm32",
+            target_vendor = "unknown",
+            target_os = "unknown"
+        ),
+        wasm_bindgen_test
+    )]
     fn test_u128_le_is_actually_le() {
         let v_in: u128 = 0xa1a2a3a4b1b2c1c2d1d2d3d4d5d6d7d8;
 
@@ -1454,7 +1676,14 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
+    #[cfg_attr(
+        all(
+            target_arch = "wasm32",
+            target_vendor = "unknown",
+            target_os = "unknown"
+        ),
+        wasm_bindgen_test
+    )]
     fn test_from_slice() {
         let b = [
             0xa1, 0xa2, 0xa3, 0xa4, 0xb1, 0xb2, 0xc1, 0xc2, 0xd1, 0xd2, 0xd3, 0xd4, 0xd5, 0xd6,
@@ -1468,7 +1697,14 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
+    #[cfg_attr(
+        all(
+            target_arch = "wasm32",
+            target_vendor = "unknown",
+            target_os = "unknown"
+        ),
+        wasm_bindgen_test
+    )]
     fn test_from_bytes() {
         let b = [
             0xa1, 0xa2, 0xa3, 0xa4, 0xb1, 0xb2, 0xc1, 0xc2, 0xd1, 0xd2, 0xd3, 0xd4, 0xd5, 0xd6,
@@ -1482,7 +1718,14 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
+    #[cfg_attr(
+        all(
+            target_arch = "wasm32",
+            target_vendor = "unknown",
+            target_os = "unknown"
+        ),
+        wasm_bindgen_test
+    )]
     fn test_as_bytes() {
         let u = new();
         let ub = u.as_bytes();
@@ -1495,7 +1738,14 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
+    #[cfg_attr(
+        all(
+            target_arch = "wasm32",
+            target_vendor = "unknown",
+            target_os = "unknown"
+        ),
+        wasm_bindgen_test
+    )]
     fn test_bytes_roundtrip() {
         let b_in: crate::Bytes = [
             0xa1, 0xa2, 0xa3, 0xa4, 0xb1, 0xb2, 0xc1, 0xc2, 0xd1, 0xd2, 0xd3, 0xd4, 0xd5, 0xd6,
@@ -1510,7 +1760,14 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
+    #[cfg_attr(
+        all(
+            target_arch = "wasm32",
+            target_vendor = "unknown",
+            target_os = "unknown"
+        ),
+        wasm_bindgen_test
+    )]
     fn test_bytes_le_roundtrip() {
         let b = [
             0xa1, 0xa2, 0xa3, 0xa4, 0xb1, 0xb2, 0xc1, 0xc2, 0xd1, 0xd2, 0xd3, 0xd4, 0xd5, 0xd6,
@@ -1527,7 +1784,14 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
+    #[cfg_attr(
+        all(
+            target_arch = "wasm32",
+            target_vendor = "unknown",
+            target_os = "unknown"
+        ),
+        wasm_bindgen_test
+    )]
     fn test_iterbytes_impl_for_uuid() {
         let mut set = std::collections::HashSet::new();
         let id1 = new();

--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -447,6 +447,13 @@ pub mod context {
 mod tests {
     use super::*;
 
+    #[cfg(all(
+        target_arch = "wasm32",
+        target_vendor = "unknown",
+        target_os = "unknown"
+    ))]
+    use wasm_bindgen_test::*;
+
     #[test]
     #[cfg_attr(
         all(

--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -277,7 +277,7 @@ fn now() -> (u64, u32) {
     let secs = (now / 1_000.0) as u64;
     let nanos = ((now % 1_000.0) * 1_000_000.0) as u32;
 
-    dbg!((secs, nanos))
+    (secs, nanos)
 }
 
 #[cfg(all(feature = "std", any(not(feature = "js"), not(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown")))))]

--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -145,7 +145,9 @@ impl Timestamp {
 
     #[cfg(any(feature = "v1", feature = "v6"))]
     const fn unix_to_rfc4122_ticks(seconds: u64, nanos: u32) -> u64 {
-        let ticks = UUID_TICKS_BETWEEN_EPOCHS.wrapping_add(seconds.wrapping_mul(10_000_000)).wrapping_add(nanos as u64 / 100);
+        let ticks = UUID_TICKS_BETWEEN_EPOCHS
+            .wrapping_add(seconds.wrapping_mul(10_000_000))
+            .wrapping_add(nanos as u64 / 100);
 
         ticks
     }
@@ -282,7 +284,15 @@ pub(crate) const fn decode_unix_timestamp_millis(uuid: &Uuid) -> u64 {
     millis
 }
 
-#[cfg(all(feature = "std", feature = "js", all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown")))]
+#[cfg(all(
+    feature = "std",
+    feature = "js",
+    all(
+        target_arch = "wasm32",
+        target_vendor = "unknown",
+        target_os = "unknown"
+    )
+))]
 fn now() -> (u64, u32) {
     use wasm_bindgen::prelude::*;
 
@@ -301,11 +311,21 @@ fn now() -> (u64, u32) {
     (secs, nanos)
 }
 
-#[cfg(all(feature = "std", any(not(feature = "js"), not(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown")))))]
+#[cfg(all(
+    feature = "std",
+    any(
+        not(feature = "js"),
+        not(all(
+            target_arch = "wasm32",
+            target_vendor = "unknown",
+            target_os = "unknown"
+        ))
+    )
+))]
 fn now() -> (u64, u32) {
-    let dur = std::time::SystemTime::UNIX_EPOCH
-        .elapsed()
-        .expect("Getting elapsed time since UNIX_EPOCH. If this fails, we've somehow violated causality");
+    let dur = std::time::SystemTime::UNIX_EPOCH.elapsed().expect(
+        "Getting elapsed time since UNIX_EPOCH. If this fails, we've somehow violated causality",
+    );
 
     (dur.as_secs(), dur.subsec_nanos())
 }
@@ -428,7 +448,14 @@ mod tests {
     use super::*;
 
     #[test]
-    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
+    #[cfg_attr(
+        all(
+            target_arch = "wasm32",
+            target_vendor = "unknown",
+            target_os = "unknown"
+        ),
+        wasm_bindgen_test
+    )]
     fn rfc4122_unix_does_not_panic() {
         // Ensure timestamp conversions never panic
         Timestamp::unix_to_rfc4122_ticks(u64::MAX, 0);

--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -428,10 +428,11 @@ mod tests {
     use super::*;
 
     #[test]
-    fn rfc4122_unix_wraps() {
+    fn rfc4122_unix_does_not_panic() {
         // Ensure timestamp conversions never panic
         Timestamp::unix_to_rfc4122_ticks(u64::MAX, 0);
         Timestamp::unix_to_rfc4122_ticks(0, u32::MAX);
+        Timestamp::unix_to_rfc4122_ticks(u64::MAX, u32::MAX);
 
         Timestamp::rfc4122_to_unix(u64::MAX);
     }

--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -428,6 +428,7 @@ mod tests {
     use super::*;
 
     #[test]
+    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
     fn rfc4122_unix_does_not_panic() {
         // Ensure timestamp conversions never panic
         Timestamp::unix_to_rfc4122_ticks(u64::MAX, 0);

--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -72,6 +72,11 @@ impl Timestamp {
 
     /// Construct a `Timestamp` from an RFC4122 timestamp and counter, as used
     /// in versions 1 and 6 UUIDs.
+    ///
+    /// # Overflow
+    ///
+    /// If conversion from RFC4122 ticks to the internal timestamp format would overflow
+    /// it will wrap.
     pub const fn from_rfc4122(ticks: u64, counter: u16) -> Self {
         #[cfg(not(any(feature = "v1", feature = "v6")))]
         {
@@ -89,6 +94,11 @@ impl Timestamp {
     }
 
     /// Construct a `Timestamp` from a Unix timestamp, as used in version 7 UUIDs.
+    ///
+    /// # Overflow
+    ///
+    /// If conversion from RFC4122 ticks to the internal timestamp format would overflow
+    /// it will wrap.
     pub fn from_unix(context: impl ClockSequence<Output = u16>, seconds: u64, nanos: u32) -> Self {
         #[cfg(not(any(feature = "v1", feature = "v6")))]
         {
@@ -110,6 +120,11 @@ impl Timestamp {
 
     /// Get the value of the timestamp as an RFC4122 timestamp and counter,
     /// as used in versions 1 and 6 UUIDs.
+    ///
+    /// # Overflow
+    ///
+    /// If conversion from RFC4122 ticks to the internal timestamp format would overflow
+    /// it will wrap.
     #[cfg(any(feature = "v1", feature = "v6"))]
     pub const fn to_rfc4122(&self) -> (u64, u16) {
         (
@@ -119,21 +134,26 @@ impl Timestamp {
     }
 
     /// Get the value of the timestamp as a Unix timestamp, as used in version 7 UUIDs.
+    ///
+    /// # Overflow
+    ///
+    /// If conversion from RFC4122 ticks to the internal timestamp format would overflow
+    /// it will wrap.
     pub const fn to_unix(&self) -> (u64, u32) {
         (self.seconds, self.nanos)
     }
 
     #[cfg(any(feature = "v1", feature = "v6"))]
     const fn unix_to_rfc4122_ticks(seconds: u64, nanos: u32) -> u64 {
-        let ticks = UUID_TICKS_BETWEEN_EPOCHS + seconds * 10_000_000 + nanos as u64 / 100;
+        let ticks = UUID_TICKS_BETWEEN_EPOCHS.wrapping_add(seconds.wrapping_mul(10_000_000)).wrapping_add(nanos as u64 / 100);
 
         ticks
     }
 
     const fn rfc4122_to_unix(ticks: u64) -> (u64, u32) {
         (
-            (ticks - UUID_TICKS_BETWEEN_EPOCHS) / 10_000_000,
-            ((ticks - UUID_TICKS_BETWEEN_EPOCHS) % 10_000_000) as u32 * 100,
+            ticks.wrapping_sub(UUID_TICKS_BETWEEN_EPOCHS) / 10_000_000,
+            (ticks.wrapping_sub(UUID_TICKS_BETWEEN_EPOCHS) % 10_000_000) as u32 * 100,
         )
     }
 
@@ -268,6 +288,7 @@ fn now() -> (u64, u32) {
 
     #[wasm_bindgen]
     extern "C" {
+        // NOTE: This signature works around https://bugzilla.mozilla.org/show_bug.cgi?id=1787770
         #[wasm_bindgen(js_namespace = Date, catch)]
         fn now() -> Result<f64, JsValue>;
     }
@@ -399,5 +420,19 @@ pub mod context {
             // where the clock sequence doesn't change regardless of the timestamp
             self.count.fetch_add(1, Ordering::AcqRel) % (u16::MAX >> 2)
         }
+    }
+}
+
+#[cfg(all(test, any(feature = "v1", feature = "v6")))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn rfc4122_unix_wraps() {
+        // Ensure timestamp conversions never panic
+        Timestamp::unix_to_rfc4122_ticks(u64::MAX, 0);
+        Timestamp::unix_to_rfc4122_ticks(0, u32::MAX);
+
+        Timestamp::rfc4122_to_unix(u64::MAX);
     }
 }

--- a/src/v1.rs
+++ b/src/v1.rs
@@ -100,11 +100,22 @@ mod tests {
     use super::*;
 
     use crate::{std::string::ToString, Variant, Version};
-    #[cfg(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"))]
+    #[cfg(all(
+        target_arch = "wasm32",
+        target_vendor = "unknown",
+        target_os = "unknown"
+    ))]
     use wasm_bindgen_test::*;
 
     #[test]
-    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
+    #[cfg_attr(
+        all(
+            target_arch = "wasm32",
+            target_vendor = "unknown",
+            target_os = "unknown"
+        ),
+        wasm_bindgen_test
+    )]
     fn test_new() {
         let time: u64 = 1_496_854_535;
         let time_fraction: u32 = 812_946_000;
@@ -134,7 +145,14 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
+    #[cfg_attr(
+        all(
+            target_arch = "wasm32",
+            target_vendor = "unknown",
+            target_os = "unknown"
+        ),
+        wasm_bindgen_test
+    )]
     #[cfg(all(feature = "std", feature = "rng"))]
     fn test_now() {
         let node = [1, 2, 3, 4, 5, 6];
@@ -146,7 +164,14 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
+    #[cfg_attr(
+        all(
+            target_arch = "wasm32",
+            target_vendor = "unknown",
+            target_os = "unknown"
+        ),
+        wasm_bindgen_test
+    )]
     fn test_new_context() {
         let time: u64 = 1_496_854_535;
         let time_fraction: u32 = 812_946_000;

--- a/src/v3.rs
+++ b/src/v3.rs
@@ -42,7 +42,11 @@ impl Uuid {
 mod tests {
     use super::*;
 
-    #[cfg(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"))]
+    #[cfg(all(
+        target_arch = "wasm32",
+        target_vendor = "unknown",
+        target_os = "unknown"
+    ))]
     use wasm_bindgen_test::*;
 
     use crate::{std::string::ToString, Variant, Version};
@@ -131,7 +135,14 @@ mod tests {
     ];
 
     #[test]
-    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
+    #[cfg_attr(
+        all(
+            target_arch = "wasm32",
+            target_vendor = "unknown",
+            target_os = "unknown"
+        ),
+        wasm_bindgen_test
+    )]
     fn test_new() {
         for &(ref ns, ref name, _) in FIXTURE {
             let uuid = Uuid::new_v3(*ns, name.as_bytes());
@@ -141,7 +152,14 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
+    #[cfg_attr(
+        all(
+            target_arch = "wasm32",
+            target_vendor = "unknown",
+            target_os = "unknown"
+        ),
+        wasm_bindgen_test
+    )]
     fn test_hyphenated_string() {
         for &(ref ns, ref name, ref expected) in FIXTURE {
             let uuid = Uuid::new_v3(*ns, name.as_bytes());

--- a/src/v4.rs
+++ b/src/v4.rs
@@ -40,11 +40,22 @@ mod tests {
     use super::*;
     use crate::{Variant, Version};
 
-    #[cfg(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"))]
+    #[cfg(all(
+        target_arch = "wasm32",
+        target_vendor = "unknown",
+        target_os = "unknown"
+    ))]
     use wasm_bindgen_test::*;
 
     #[test]
-    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
+    #[cfg_attr(
+        all(
+            target_arch = "wasm32",
+            target_vendor = "unknown",
+            target_os = "unknown"
+        ),
+        wasm_bindgen_test
+    )]
     fn test_new() {
         let uuid = Uuid::new_v4();
 
@@ -53,7 +64,14 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
+    #[cfg_attr(
+        all(
+            target_arch = "wasm32",
+            target_vendor = "unknown",
+            target_os = "unknown"
+        ),
+        wasm_bindgen_test
+    )]
     fn test_get_version() {
         let uuid = Uuid::new_v4();
 

--- a/src/v5.rs
+++ b/src/v5.rs
@@ -41,7 +41,11 @@ impl Uuid {
 mod tests {
     use super::*;
 
-    #[cfg(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"))]
+    #[cfg(all(
+        target_arch = "wasm32",
+        target_vendor = "unknown",
+        target_os = "unknown"
+    ))]
     use wasm_bindgen_test::*;
 
     use crate::{std::string::ToString, Variant, Version};
@@ -130,7 +134,14 @@ mod tests {
     ];
 
     #[test]
-    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
+    #[cfg_attr(
+        all(
+            target_arch = "wasm32",
+            target_vendor = "unknown",
+            target_os = "unknown"
+        ),
+        wasm_bindgen_test
+    )]
     fn test_get_version() {
         let uuid = Uuid::new_v5(&Uuid::NAMESPACE_DNS, "rust-lang.org".as_bytes());
 
@@ -139,7 +150,14 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
+    #[cfg_attr(
+        all(
+            target_arch = "wasm32",
+            target_vendor = "unknown",
+            target_os = "unknown"
+        ),
+        wasm_bindgen_test
+    )]
     fn test_hyphenated() {
         for &(ref ns, ref name, ref expected) in FIXTURE {
             let uuid = Uuid::new_v5(*ns, name.as_bytes());
@@ -149,7 +167,14 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
+    #[cfg_attr(
+        all(
+            target_arch = "wasm32",
+            target_vendor = "unknown",
+            target_os = "unknown"
+        ),
+        wasm_bindgen_test
+    )]
     fn test_new() {
         for &(ref ns, ref name, ref u) in FIXTURE {
             let uuid = Uuid::new_v5(*ns, name.as_bytes());

--- a/src/v6.rs
+++ b/src/v6.rs
@@ -102,11 +102,22 @@ mod tests {
     use crate::{Context, Variant, Version};
     use std::string::ToString;
 
-    #[cfg(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"))]
+    #[cfg(all(
+        target_arch = "wasm32",
+        target_vendor = "unknown",
+        target_os = "unknown"
+    ))]
     use wasm_bindgen_test::*;
 
     #[test]
-    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
+    #[cfg_attr(
+        all(
+            target_arch = "wasm32",
+            target_vendor = "unknown",
+            target_os = "unknown"
+        ),
+        wasm_bindgen_test
+    )]
     fn test_new() {
         let time: u64 = 1_496_854_535;
         let time_fraction: u32 = 812_946_000;
@@ -136,7 +147,14 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
+    #[cfg_attr(
+        all(
+            target_arch = "wasm32",
+            target_vendor = "unknown",
+            target_os = "unknown"
+        ),
+        wasm_bindgen_test
+    )]
     #[cfg(all(feature = "std", feature = "rng"))]
     fn test_now() {
         let node = [1, 2, 3, 4, 5, 6];
@@ -148,7 +166,14 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
+    #[cfg_attr(
+        all(
+            target_arch = "wasm32",
+            target_vendor = "unknown",
+            target_os = "unknown"
+        ),
+        wasm_bindgen_test
+    )]
     fn test_new_context() {
         let time: u64 = 1_496_854_535;
         let time_fraction: u32 = 812_946_000;

--- a/src/v7.rs
+++ b/src/v7.rs
@@ -3,7 +3,7 @@
 //! Note that you need to enable the `v7` Cargo feature
 //! in order to use this module.
 
-use crate::{std::convert::TryInto, rng, timestamp::Timestamp, Builder, Uuid};
+use crate::{rng, std::convert::TryInto, timestamp::Timestamp, Builder, Uuid};
 
 impl Uuid {
     /// Create a new version 7 UUID using the current time value and random bytes.
@@ -57,11 +57,22 @@ impl Uuid {
 mod tests {
     use super::*;
     use crate::{std::string::ToString, NoContext, Variant, Version};
-    #[cfg(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"))]
+    #[cfg(all(
+        target_arch = "wasm32",
+        target_vendor = "unknown",
+        target_os = "unknown"
+    ))]
     use wasm_bindgen_test::*;
 
     #[test]
-    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
+    #[cfg_attr(
+        all(
+            target_arch = "wasm32",
+            target_vendor = "unknown",
+            target_os = "unknown"
+        ),
+        wasm_bindgen_test
+    )]
     fn test_new() {
         let ts: u64 = 1645557742000;
 
@@ -82,7 +93,14 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
+    #[cfg_attr(
+        all(
+            target_arch = "wasm32",
+            target_vendor = "unknown",
+            target_os = "unknown"
+        ),
+        wasm_bindgen_test
+    )]
     #[cfg(feature = "std")]
     fn test_now() {
         let uuid = Uuid::now_v7();
@@ -92,7 +110,14 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
+    #[cfg_attr(
+        all(
+            target_arch = "wasm32",
+            target_vendor = "unknown",
+            target_os = "unknown"
+        ),
+        wasm_bindgen_test
+    )]
     fn test_sorting() {
         let time1: u64 = 1_496_854_535;
         let time_fraction1: u32 = 812_000_000;
@@ -108,7 +133,14 @@ mod tests {
     }
 
     #[test]
-    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
+    #[cfg_attr(
+        all(
+            target_arch = "wasm32",
+            target_vendor = "unknown",
+            target_os = "unknown"
+        ),
+        wasm_bindgen_test
+    )]
     fn test_new_timestamp_roundtrip() {
         let time: u64 = 1_496_854_535;
         let time_fraction: u32 = 812_000_000;

--- a/src/v8.rs
+++ b/src/v8.rs
@@ -36,11 +36,22 @@ mod tests {
     use crate::{Variant, Version};
     use std::string::ToString;
 
-    #[cfg(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"))]
+    #[cfg(all(
+        target_arch = "wasm32",
+        target_vendor = "unknown",
+        target_os = "unknown"
+    ))]
     use wasm_bindgen_test::*;
 
     #[test]
-    #[cfg_attr(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"), wasm_bindgen_test)]
+    #[cfg_attr(
+        all(
+            target_arch = "wasm32",
+            target_vendor = "unknown",
+            target_os = "unknown"
+        ),
+        wasm_bindgen_test
+    )]
     fn test_new() {
         let buf: [u8; 16] = [
             0xf, 0xe, 0xd, 0xc, 0xb, 0xa, 0x9, 0x8, 0x7, 0x6, 0x5, 0x4, 0x3, 0x2, 0x1, 0x0,

--- a/tests/smoke-test/src/main.rs
+++ b/tests/smoke-test/src/main.rs
@@ -1,1 +1,1 @@
-fn main() { }
+fn main() {}


### PR DESCRIPTION
Closes #680 

This PR makes `Timestamp` conversions explicitly wrap rather than panic on overflow.

I've also fixed up a warning in `arbitrary`, and removed a random `dbg!` statement that shouldn't be there.