### PR TITLE
Add #[inline] for Uuid::from_bytes[_ref] and Uuid::{as,into}_bytes

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -412,6 +412,7 @@ impl Uuid {
     /// # Ok(())
     /// # }
     /// ```
+    #[inline]
     pub const fn from_bytes(bytes: Bytes) -> Uuid {
         Uuid(bytes)
     }
@@ -480,6 +481,7 @@ impl Uuid {
     /// # Ok(())
     /// # }
     /// ```
+    #[inline]
     pub fn from_bytes_ref(bytes: &Bytes) -> &Uuid {
         // SAFETY: `Bytes` and `Uuid` have the same ABI
         unsafe { &*(bytes as *const Bytes as *const Uuid) }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -778,6 +778,7 @@ impl Uuid {
     ///     &bytes1 as *const [u8; 16] as *const u8,
     /// ));
     /// ```
+    #[inline]
     pub const fn as_bytes(&self) -> &Bytes {
         &self.0
     }
@@ -797,6 +798,7 @@ impl Uuid {
     /// let uuid = Uuid::from_bytes(bytes);
     /// assert_eq!(bytes, uuid.into_bytes());
     /// ```
+    #[inline]
     pub const fn into_bytes(self) -> Bytes {
         self.0
     }


### PR DESCRIPTION
[As seen in this playground](https://play.rust-lang.org/?version=stable&mode=release&edition=2021&gist=caa6418cf6c80c8ccbf8c5521fccb5b4), neither `from_bytes` nor `from_bytes_ref` are currently inlined by the compiler even though they are `const`, resulting in less efficient generated code for these trivial functions, even with Thin LTO enabled. There's a slippery slope here for what counts as "trivial", but the functions that *do not change representations* are a pretty safe bet.

(I didn't include the Builder versions of the same functions, because the *next* thing you do with a Builder is likely to be a function call anyway, but it could go either way.)