### PR TITLE
Print uuids in examples

### DIFF
--- a/examples/random_uuid.rs
+++ b/examples/random_uuid.rs
@@ -2,14 +2,16 @@
 //!
 //! If you enable the `v4` feature you can generate random UUIDs.
 
-#[test]
 #[cfg(feature = "v4")]
-fn generate_random_uuid() {
+fn main() {
     use uuid::Uuid;
 
     let uuid = Uuid::new_v4();
 
     assert_eq!(Some(uuid::Version::Random), uuid.get_version());
+
+    println!("{}", uuid);
 }
 
+#[cfg(not(feature = "v4"))]
 fn main() {}

--- a/examples/sortable_uuid.rs
+++ b/examples/sortable_uuid.rs
@@ -2,14 +2,16 @@
 //!
 //! If you enable the `v7` feature you can generate sortable UUIDs.
 
-#[test]
 #[cfg(feature = "v7")]
-fn generate_sortable_uuid() {
+fn main() {
     use uuid::Uuid;
 
     let uuid = Uuid::now_v7();
 
     assert_eq!(Some(uuid::Version::SortRand), uuid.get_version());
+
+    println!("{}", uuid);
 }
 
+#[cfg(not(feature = "v7"))]
 fn main() {}

--- a/examples/sortable_uuid.rs
+++ b/examples/sortable_uuid.rs
@@ -2,7 +2,7 @@
 //!
 //! If you enable the `v7` feature you can generate sortable UUIDs.
 
-#[cfg(feature = "v7")]
+#[cfg(all(uuid_unstable, feature = "v7"))]
 fn main() {
     use uuid::Uuid;
 
@@ -13,5 +13,5 @@ fn main() {
     println!("{}", uuid);
 }
 
-#[cfg(not(feature = "v7"))]
+#[cfg(not(all(uuid_unstable, feature = "v7")))]
 fn main() {}


### PR DESCRIPTION
This PR just prints UUIDs in examples when they run so you can both tell that the example ran, and have a look at the result it produced.