### PR TITLE
Added conversion for Vec<u8>

### DIFF
--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -11,10 +11,17 @@
 
 //! Adapters for alternative string formats.
 
+use alloc::vec::Vec;
 use crate::{
     std::{borrow::Borrow, fmt, ptr, str},
     Uuid, Variant,
 };
+
+impl From<Uuid> for Vec<u8>{
+    fn from(value: Uuid) -> Self {
+        value.as_bytes().to_vec()
+    }
+}
 
 impl std::fmt::Debug for Uuid {
     #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -272,6 +272,7 @@ mod macros;
 #[doc(hidden)]
 #[cfg(feature = "macro-diagnostics")]
 pub extern crate uuid_macro_internal;
+extern crate alloc;
 
 #[doc(hidden)]
 pub mod __macro_support {


### PR DESCRIPTION
Hello,

An `impl From<Uuid> for Vec<u8>` is quite useful for crates like Diesel which need such a conversion to work with its codegen of database models.



