### PR TITLE
Add impl From<Uuid> for String under the std feature flag

### DIFF
--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -16,6 +16,9 @@ use crate::{
     Uuid, Variant,
 };
 
+#[cfg(feature = "std")]
+use crate::std::string::{String, ToString};
+
 impl std::fmt::Debug for Uuid {
     #[inline]
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -26,6 +29,13 @@ impl std::fmt::Debug for Uuid {
 impl fmt::Display for Uuid {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         fmt::LowerHex::fmt(self, f)
+    }
+}
+
+#[cfg(feature = "std")]
+impl From<Uuid> for String {
+    fn from(uuid: Uuid) -> Self {
+        uuid.to_string()
     }
 }
 


### PR DESCRIPTION
This PR adds the implementation of `From<Uuid> for String` under the "std" feature flag. The motivation for this is that it allows Uuids to be easily converted to a string when using crates like sqlx where it utilize the `Into` and `From` traits for conversions.