### PR TITLE
make ClockSequence wrap correctly

### DIFF
--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -438,7 +438,7 @@ pub mod context {
             // increment the clock sequence we want to wrap once it becomes larger
             // than what we can represent in a "u14". Otherwise there'd be patches
             // where the clock sequence doesn't change regardless of the timestamp
-            self.count.fetch_add(1, Ordering::AcqRel) % (u16::MAX >> 2)
+            self.count.fetch_add(1, Ordering::AcqRel) & (u16::MAX >> 2)
         }
     }
 }

--- a/src/v1.rs
+++ b/src/v1.rs
@@ -178,7 +178,7 @@ mod tests {
         let node = [1, 2, 3, 4, 5, 6];
 
         // This context will wrap
-        let context = Context::new((u16::MAX >> 2) - 1);
+        let context = Context::new(u16::MAX >> 2);
 
         let uuid1 = Uuid::new_v1(Timestamp::from_unix(&context, time, time_fraction), &node);
 
@@ -186,7 +186,7 @@ mod tests {
 
         let uuid2 = Uuid::new_v1(Timestamp::from_unix(&context, time, time_fraction), &node);
 
-        assert_eq!(uuid1.get_timestamp().unwrap().to_rfc4122().1, 16382);
+        assert_eq!(uuid1.get_timestamp().unwrap().to_rfc4122().1, 16383);
         assert_eq!(uuid2.get_timestamp().unwrap().to_rfc4122().1, 0);
 
         let time = 1_496_854_535;

--- a/src/v6.rs
+++ b/src/v6.rs
@@ -180,7 +180,7 @@ mod tests {
         let node = [1, 2, 3, 4, 5, 6];
 
         // This context will wrap
-        let context = Context::new((u16::MAX >> 2) - 1);
+        let context = Context::new(u16::MAX >> 2);
 
         let uuid1 = Uuid::new_v6(Timestamp::from_unix(&context, time, time_fraction), &node);
 
@@ -188,7 +188,7 @@ mod tests {
 
         let uuid2 = Uuid::new_v6(Timestamp::from_unix(&context, time, time_fraction), &node);
 
-        assert_eq!(uuid1.get_timestamp().unwrap().to_rfc4122().1, 16382);
+        assert_eq!(uuid1.get_timestamp().unwrap().to_rfc4122().1, 16383);
         assert_eq!(uuid2.get_timestamp().unwrap().to_rfc4122().1, 0);
 
         let time = 1_496_854_535;


### PR DESCRIPTION
As pointed out in the original issue, the implementation of `ClockSequence` for `Context` incorrectly wrapped after `0x3ffe` instead of `0x3fff`.  Fixes #702.