### PR TITLE
Replace MIPS with Miri and add clippy to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,7 +68,7 @@ jobs:
       run: cargo hack test --lib --all-features
 
   stable:
-    name: "Tests / Stable"
+    name: Tests / Stable
     runs-on: ubuntu-latest
     steps:
     - name: Checkout sources
@@ -78,7 +78,7 @@ jobs:
       run: cargo test --all-features
 
   msrv:
-    name: "Build / MSRV"
+    name: Build / MSRV
     runs-on: ubuntu-latest
     steps:
     - name: Checkout sources
@@ -134,18 +134,38 @@ jobs:
       - name: Fast RNG
         run: cargo test --target wasm32-wasi --features "v4 fast-rng"
 
-  mips:
-    name: Tests / MIPS (Big Endian)
+  miri:
+    name: Tests / Miri
     runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
         uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
 
-      - name: Install Cross
-        run: cargo install cross
+      - name: Install Miri
+        run: |
+          rustup toolchain install nightly --component miri
+          cargo +nightly miri setup
 
       - name: Default features
-        run: cross test --target mips-unknown-linux-gnu
+        run: cargo +nightly miri test
+
+      - name: BE
+        run: cargo +nightly miri test --target s390x-unknown-linux-gnu
+
+  clippy:
+    name: Build / Clippy
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
+
+      - name: Install Clippy
+        run: |
+          rustup update beta
+          rustup component add clippy --toolchain beta
+
+      - name: Default features
+        run: cargo +beta clippy --all-features
 
   embedded:
     name: Build / Embedded

--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -145,11 +145,9 @@ impl Timestamp {
 
     #[cfg(any(feature = "v1", feature = "v6"))]
     const fn unix_to_rfc4122_ticks(seconds: u64, nanos: u32) -> u64 {
-        let ticks = UUID_TICKS_BETWEEN_EPOCHS
+        UUID_TICKS_BETWEEN_EPOCHS
             .wrapping_add(seconds.wrapping_mul(10_000_000))
-            .wrapping_add(nanos as u64 / 100);
-
-        ticks
+            .wrapping_add(nanos as u64 / 100)
     }
 
     const fn rfc4122_to_unix(ticks: u64) -> (u64, u32) {


### PR DESCRIPTION
This PR performs some housekeeping on our CI by replacing MIPS with Miri for testing any endian-dependent code and adding `clippy` too so we can keep up with changing lints better.