### PR TITLE
doc: fix links in v6 module

### DIFF
--- a/src/v6.rs
+++ b/src/v6.rs
@@ -86,9 +86,9 @@ impl Uuid {
     ///
     /// * [Version 6 UUIDs in Draft RFC: New UUID Formats, Version 4](https://datatracker.ietf.org/doc/html/draft-peabody-dispatch-new-uuid-format-04#section-5.1)
     ///
-    /// [`Timestamp`]: v1/struct.Timestamp.html
-    /// [`ClockSequence`]: v1/trait.ClockSequence.html
-    /// [`Context`]: v1/struct.Context.html
+    /// [`Timestamp`]: timestamp/struct.Timestamp.html
+    /// [`ClockSequence`]: timestamp/trait.ClockSequence.html
+    /// [`Context`]: timestamp/context/struct.Context.html
     pub fn new_v6(ts: Timestamp, node_id: &[u8; 6]) -> Self {
         let (ticks, counter) = ts.to_rfc4122();
 


### PR DESCRIPTION
Fix links to `struct Timestamp`, `trait ClockSequence`, and `struct Context` under `timestamp` module.

Hello, I am new to GitHub work flow.
Is there any question / anything that needs to change again in this PR ?
Or should I first send review request to any of the maintainers of this repository ?
I don't find any contribution guide here, I don't know what else  I can do,
thanks
