### PR TITLE
feat: add `prost` support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,20 @@ rust-version = "1.57.0"
 rustc-args = ["--cfg", "uuid_unstable"]
 rustdoc-args = ["--cfg", "uuid_unstable"]
 targets = ["x86_64-unknown-linux-gnu"]
-features = ["serde", "arbitrary", "slog", "borsh", "v1", "v3", "v4", "v5", "v6", "v7", "v8"]
+features = [
+    "serde",
+    "arbitrary",
+    "slog",
+    "borsh",
+    "prost",
+    "v1",
+    "v3",
+    "v4",
+    "v5",
+    "v6",
+    "v7",
+    "v8",
+]
 
 [package.metadata.playground]
 features = ["serde", "v1", "v3", "v4", "v5", "v6", "v7", "v8"]
@@ -110,6 +123,10 @@ version = "0.6"
 [dependencies.borsh]
 optional = true
 version = "0.10.3"
+
+[dependencies.prost]
+optional = true
+version = "0.12"
 
 # Private
 # Don't depend on this optional feature directly: it may change at any time

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ homepage = "https://github.com/uuid-rs/uuid"
 name = "uuid"
 readme = "README.md"
 repository = "https://github.com/uuid-rs/uuid"
-version = "1.5.0" # remember to update html_root_url in lib.rs
+version = "1.5.1" # remember to update html_root_url in lib.rs
 rust-version = "1.57.0"
 
 [package.metadata.docs.rs]
@@ -39,7 +39,8 @@ features = [
     "arbitrary",
     "slog",
     "borsh",
-    "prost",
+    "prost-string",
+    "prost-bytes",
     "v1",
     "v3",
     "v4",
@@ -80,6 +81,9 @@ js = ["wasm-bindgen", "getrandom", "getrandom/js"]
 
 rng = ["getrandom"]
 fast-rng = ["rng", "rand"]
+
+prost-string = ["prost"]
+prost-bytes = ["prost"]
 
 sha1 = ["sha1_smol"]
 md5 = ["md-5"]

--- a/src/external.rs
+++ b/src/external.rs
@@ -6,3 +6,5 @@ pub(crate) mod borsh_support;
 pub(crate) mod serde_support;
 #[cfg(feature = "slog")]
 pub(crate) mod slog_support;
+#[cfg(all(feature = "std", feature = "prost"))]
+pub(crate) mod prost_support;

--- a/src/external.rs
+++ b/src/external.rs
@@ -6,5 +6,5 @@ pub(crate) mod borsh_support;
 pub(crate) mod serde_support;
 #[cfg(feature = "slog")]
 pub(crate) mod slog_support;
-#[cfg(all(feature = "std", feature = "prost"))]
+#[cfg(any(feature = "prost-string", feature = "prost-bytes"))]
 pub(crate) mod prost_support;

--- a/src/external/prost_support.rs
+++ b/src/external/prost_support.rs
@@ -1,21 +1,87 @@
+#[cfg(all(feature = "prost-string", feature = "prost-bytes"))]
+compile_error!("prost-bytes and prost-string features are mutually exclusive");
+
 use crate::Uuid;
 
 use prost::{
     bytes::{Buf, BufMut},
-    encoding::{string, *},
+    encoding::*,
     DecodeError, Message,
 };
-use std::string::String;
-use std::string::ToString;
 
 impl Message for Uuid {
+    #[cfg(feature = "prost-string")]
     fn encode_raw<B>(&self, buf: &mut B)
     where
         B: BufMut,
     {
-        string::encode(1, &self.to_string(), buf)
+        use crate::fmt::Hyphenated;
+
+        let mut uuid_buf = [0u8; Hyphenated::LENGTH];
+        self.as_hyphenated().encode_lower(&mut uuid_buf);
+
+        encode_key(1, WireType::LengthDelimited, buf);
+        buf.put_u8(Hyphenated::LENGTH as u8);
+        buf.put_slice(&uuid_buf[..]);
     }
 
+    #[cfg(feature = "prost-bytes")]
+    fn encode_raw<B>(&self, buf: &mut B)
+    where
+        B: BufMut,
+    {
+        encode_key(1, WireType::LengthDelimited, buf);
+        buf.put_u8(16);
+        buf.put_slice(self.as_bytes())
+    }
+
+    #[cfg(feature = "prost-string")]
+    fn merge_field<B>(
+        &mut self,
+        tag: u32,
+        wire_type: WireType,
+        buf: &mut B,
+        ctx: DecodeContext,
+    ) -> Result<(), DecodeError>
+    where
+        B: Buf,
+    {
+        if tag != 1 {
+            return skip_field(wire_type, tag, buf, ctx);
+        }
+
+        check_wire_type(WireType::LengthDelimited, wire_type)?;
+
+        if !buf.has_remaining() {
+            return Err(DecodeError::new("buffer underflow"));
+        }
+
+        let len = match buf.get_u8() {
+            len @ (32 | 36 | 38 | 45) => len,
+            _ => return Err(DecodeError::new("invalid uuid length")),
+        };
+
+        if buf.remaining() < len as usize {
+            return Err(DecodeError::new("buffer underflow"));
+        }
+
+        let mut uuid_buf = [0u8; 45];
+        let mut uuid_buf = &mut uuid_buf[..len as usize];
+
+        buf.copy_to_slice(&mut uuid_buf);
+
+        let uuid_str =
+            core::str::from_utf8(uuid_buf).map_err(|_| DecodeError::new("invaild utf8 string"))?;
+
+        *self = match Uuid::parse_str(uuid_str) {
+            Ok(uuid) => uuid,
+            Err(_) => return Err(DecodeError::new("invalid uuid string")),
+        };
+
+        Ok(())
+    }
+
+    #[cfg(feature = "prost-bytes")]
     fn merge_field<B>(
         &mut self,
         tag: u32,
@@ -27,14 +93,17 @@ impl Message for Uuid {
         B: Buf,
     {
         if tag == 1 {
-            let mut uuid_str = String::new();
+            check_wire_type(WireType::LengthDelimited, wire_type)?;
 
-            string::merge(wire_type, &mut uuid_str, buf, ctx)?;
+            if buf.remaining() < 17 {
+                return Err(DecodeError::new("buffer underflow"));
+            }
 
-            *self = match Uuid::parse_str(&uuid_str) {
-                Ok(uuid) => uuid,
-                Err(err) => return Err(DecodeError::new(err.to_string())),
-            };
+            if buf.get_u8() != 16 {
+                return Err(DecodeError::new("invalid uuid length"));
+            }
+
+            buf.copy_to_slice(&mut self.0);
 
             Ok(())
         } else {
@@ -42,10 +111,17 @@ impl Message for Uuid {
         }
     }
 
+    #[inline]
     fn encoded_len(&self) -> usize {
-        string::encoded_len(1, &self.to_string())
+        #[cfg(feature = "prost-string")]
+        const LEN: usize = crate::fmt::Hyphenated::LENGTH;
+        #[cfg(feature = "prost-bytes")]
+        const LEN: usize = 16;
+
+        key_len(1) + encoded_len_varint(LEN as u64) + LEN
     }
 
+    #[inline]
     fn clear(&mut self) {
         for b in &mut self.0 {
             *b = 0
@@ -58,7 +134,10 @@ mod prost_tests {
     use super::*;
 
     #[test]
-    fn test_serialize_deserialize() {
+    #[cfg(feature = "prost-string")]
+    fn test_serialize_deserialize_string() {
+        use std::string::ToString;
+
         const UUID_STR: &str = "f9168c5e-ceb2-4faa-b6bf-329bf39fa1e4";
 
         let epxected_uuid = Uuid::parse_str(UUID_STR).unwrap();
@@ -67,5 +146,23 @@ mod prost_tests {
         let actual_uuid = decoded_uuid.to_string();
 
         assert_eq!(UUID_STR, actual_uuid);
+    }
+
+    #[test]
+    #[cfg(feature = "prost-bytes")]
+    fn test_serialize_deserialize_bytes() {
+        const UUID_BUF: [u8; 16] = [
+            0x0f, 0x10, 0x8c, 0x6e,
+            0xb2, 0xce, 0xaa, 0x4f,
+            0xb6, 0xbf, 0x32, 0x9b,
+            0xf3, 0x9f, 0xa1, 0xe4,
+        ];
+
+        let expected_uuid = Uuid::from_bytes(UUID_BUF);
+        let encoded_uuid = expected_uuid.encode_to_vec();
+        let decoded_uuid = Uuid::decode(&encoded_uuid[..]).unwrap();
+        let actual_uuid = decoded_uuid.as_bytes();
+
+        assert_eq!(&UUID_BUF, actual_uuid);
     }
 }

--- a/src/external/prost_support.rs
+++ b/src/external/prost_support.rs
@@ -1,0 +1,71 @@
+use crate::Uuid;
+
+use prost::{
+    bytes::{Buf, BufMut},
+    encoding::{string, *},
+    DecodeError, Message,
+};
+use std::string::String;
+use std::string::ToString;
+
+impl Message for Uuid {
+    fn encode_raw<B>(&self, buf: &mut B)
+    where
+        B: BufMut,
+    {
+        string::encode(1, &self.to_string(), buf)
+    }
+
+    fn merge_field<B>(
+        &mut self,
+        tag: u32,
+        wire_type: WireType,
+        buf: &mut B,
+        ctx: DecodeContext,
+    ) -> Result<(), DecodeError>
+    where
+        B: Buf,
+    {
+        if tag == 1 {
+            let mut uuid_str = String::new();
+
+            string::merge(wire_type, &mut uuid_str, buf, ctx)?;
+
+            *self = match Uuid::parse_str(&uuid_str) {
+                Ok(uuid) => uuid,
+                Err(err) => return Err(DecodeError::new(err.to_string())),
+            };
+
+            Ok(())
+        } else {
+            skip_field(wire_type, tag, buf, ctx)
+        }
+    }
+
+    fn encoded_len(&self) -> usize {
+        string::encoded_len(1, &self.to_string())
+    }
+
+    fn clear(&mut self) {
+        for b in &mut self.0 {
+            *b = 0
+        }
+    }
+}
+
+#[cfg(test)]
+mod prost_tests {
+    use super::*;
+
+    #[test]
+    fn test_serialize_deserialize() {
+        const UUID_STR: &str = "f9168c5e-ceb2-4faa-b6bf-329bf39fa1e4";
+
+        let epxected_uuid = Uuid::parse_str(UUID_STR).unwrap();
+        let encoded_uuid = epxected_uuid.encode_to_vec();
+        let decoded_uuid = Uuid::decode(&encoded_uuid[..]).unwrap();
+        let actual_uuid = decoded_uuid.to_string();
+
+        assert_eq!(UUID_STR, actual_uuid);
+    }
+}


### PR DESCRIPTION
Pull request to add support for `prost` crate by implementing `prost::Message` for `uuid::Uuid`.

Resolves #715