### PR TITLE
Stabilize UUIDv6-v8 support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,10 +85,10 @@ jobs:
       uses: actions/checkout@8e5e7e5ab8b370d6c329ec480221332ada57f0ab
 
     - name: Install Rust toolchain
-      run: rustup update 1.57.0
+      run: rustup update 1.60.0
 
     - name: Version features
-      run: cargo +1.57.0 build --manifest-path tests/smoke-test/Cargo.toml
+      run: cargo +1.60.0 build --manifest-path tests/smoke-test/Cargo.toml
 
   wasm_bindgen:
     name: Tests / WebAssembly (wasm-bindgen)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,10 +147,10 @@ jobs:
           cargo +nightly miri setup
 
       - name: Default features
-        run: cargo +nightly miri test
+        run: cargo +nightly miri test --lib
 
       - name: BE
-        run: cargo +nightly miri test --target s390x-unknown-linux-gnu
+        run: cargo +nightly miri test --target s390x-unknown-linux-gnu --lib
 
   clippy:
     name: Build / Clippy

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,7 +28,7 @@ name = "uuid"
 readme = "README.md"
 repository = "https://github.com/uuid-rs/uuid"
 version = "1.5.0" # remember to update html_root_url in lib.rs
-rust-version = "1.57.0"
+rust-version = "1.60.0"
 
 [package.metadata.docs.rs]
 rustc-args = ["--cfg", "uuid_unstable"]

--- a/benches/v7.rs
+++ b/benches/v7.rs
@@ -1,0 +1,11 @@
+#![cfg(all(feature = "v7", feature = "std"))]
+#![feature(test)]
+extern crate test;
+
+use test::Bencher;
+use uuid::Uuid;
+
+#[bench]
+fn now_v7(b: &mut Bencher) {
+    b.iter(|| Uuid::now_v7());
+}

--- a/examples/sortable_uuid.rs
+++ b/examples/sortable_uuid.rs
@@ -2,7 +2,7 @@
 //!
 //! If you enable the `v7` feature you can generate sortable UUIDs.
 
-#[cfg(all(uuid_unstable, feature = "v7"))]
+#[cfg(feature = "v7")]
 fn main() {
     use uuid::Uuid;
 
@@ -13,5 +13,5 @@ fn main() {
     println!("{}", uuid);
 }
 
-#[cfg(not(all(uuid_unstable, feature = "v7")))]
+#[cfg(not(feature = "v7"))]
 fn main() {}

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -95,7 +95,6 @@ impl Uuid {
     ///     uuid.hyphenated().to_string(),
     /// );
     /// ```
-    #[cfg(uuid_unstable)]
     pub const fn max() -> Self {
         Uuid::from_bytes([0xFF; 16])
     }
@@ -600,7 +599,6 @@ impl Builder {
     /// Creates a `Builder` for a version 6 UUID using the supplied timestamp and node ID.
     ///
     /// This method will encode the ticks, counter, and node ID in a sortable UUID.
-    #[cfg(uuid_unstable)]
     pub const fn from_sorted_rfc4122_timestamp(
         ticks: u64,
         counter: u16,
@@ -638,7 +636,6 @@ impl Builder {
     /// # Ok(())
     /// # }
     /// ```
-    #[cfg(uuid_unstable)]
     pub const fn from_unix_timestamp_millis(millis: u64, random_bytes: &[u8; 10]) -> Self {
         Builder(timestamp::encode_unix_timestamp_millis(
             millis,
@@ -650,7 +647,6 @@ impl Builder {
     ///
     /// This method won't interpret the given bytes in any way, except to set the appropriate
     /// bits for the UUID version and variant.
-    #[cfg(uuid_unstable)]
     pub const fn from_custom_bytes(custom_bytes: Bytes) -> Self {
         Builder::from_bytes(custom_bytes)
             .with_variant(Variant::RFC4122)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -251,11 +251,11 @@ mod v3;
 mod v4;
 #[cfg(feature = "v5")]
 mod v5;
-#[cfg(all(uuid_unstable, feature = "v6"))]
+#[cfg(feature = "v6")]
 mod v6;
-#[cfg(all(uuid_unstable, feature = "v7"))]
+#[cfg(feature = "v7")]
 mod v7;
-#[cfg(all(uuid_unstable, feature = "v8"))]
+#[cfg(feature = "v8")]
 mod v8;
 
 #[cfg(feature = "md5")]
@@ -312,16 +312,12 @@ pub enum Version {
     /// Version 5: SHA-1 hash.
     Sha1 = 5,
     /// Version 6: Sortable Timestamp and node ID.
-    #[cfg(uuid_unstable)]
     SortMac = 6,
     /// Version 7: Timestamp and random.
-    #[cfg(uuid_unstable)]
     SortRand = 7,
     /// Version 8: Custom.
-    #[cfg(uuid_unstable)]
     Custom = 8,
     /// The "max" (all ones) UUID.
-    #[cfg(uuid_unstable)]
     Max = 0xff,
 }
 
@@ -575,13 +571,9 @@ impl Uuid {
             3 => Some(Version::Md5),
             4 => Some(Version::Random),
             5 => Some(Version::Sha1),
-            #[cfg(uuid_unstable)]
             6 => Some(Version::SortMac),
-            #[cfg(uuid_unstable)]
             7 => Some(Version::SortRand),
-            #[cfg(uuid_unstable)]
             8 => Some(Version::Custom),
-            #[cfg(uuid_unstable)]
             0xf => Some(Version::Max),
             _ => None,
         }
@@ -851,7 +843,6 @@ impl Uuid {
     }
 
     /// Tests if the UUID is max (all ones).
-    #[cfg(uuid_unstable)]
     pub const fn is_max(&self) -> bool {
         self.as_u128() == u128::MAX
     }
@@ -911,13 +902,11 @@ impl Uuid {
 
                 Some(Timestamp::from_rfc4122(ticks, counter))
             }
-            #[cfg(uuid_unstable)]
             Some(Version::SortMac) => {
                 let (ticks, counter) = timestamp::decode_sorted_rfc4122_timestamp(self);
 
                 Some(Timestamp::from_rfc4122(ticks, counter))
             }
-            #[cfg(uuid_unstable)]
             Some(Version::SortRand) => {
                 let millis = timestamp::decode_unix_timestamp_millis(self);
 
@@ -1184,7 +1173,6 @@ mod tests {
     }
 
     #[test]
-    #[cfg(uuid_unstable)]
     #[cfg_attr(
         all(
             target_arch = "wasm32",

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -16,14 +16,7 @@ macro_rules! define_uuid_macro {
             ($uuid:literal) => {{
                 const OUTPUT: $crate::Uuid = match $crate::Uuid::try_parse($uuid) {
                     $crate::__macro_support::Ok(u) => u,
-                    $crate::__macro_support::Err(_) => {
-                        // here triggers const_err
-                        // const_panic requires 1.57
-                        #[allow(unconditional_panic)]
-                        let _ = ["invalid uuid representation"][1];
-
-                        loop {} // -> never type
-                    }
+                    $crate::__macro_support::Err(e) => panic!("{}", e),
                 };
                 OUTPUT
             }};

--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -204,7 +204,6 @@ pub(crate) const fn decode_rfc4122_timestamp(uuid: &Uuid) -> (u64, u16) {
     (ticks, counter)
 }
 
-#[cfg(uuid_unstable)]
 pub(crate) const fn encode_sorted_rfc4122_timestamp(
     ticks: u64,
     counter: u16,
@@ -228,7 +227,6 @@ pub(crate) const fn encode_sorted_rfc4122_timestamp(
     Uuid::from_fields(time_high, time_mid, time_low_and_version, &d4)
 }
 
-#[cfg(uuid_unstable)]
 pub(crate) const fn decode_sorted_rfc4122_timestamp(uuid: &Uuid) -> (u64, u16) {
     let bytes = uuid.as_bytes();
 
@@ -246,7 +244,6 @@ pub(crate) const fn decode_sorted_rfc4122_timestamp(uuid: &Uuid) -> (u64, u16) {
     (ticks, counter)
 }
 
-#[cfg(uuid_unstable)]
 pub(crate) const fn encode_unix_timestamp_millis(millis: u64, random_bytes: &[u8; 10]) -> Uuid {
     let millis_high = ((millis >> 16) & 0xFFFF_FFFF) as u32;
     let millis_low = (millis & 0xFFFF) as u16;
@@ -268,7 +265,6 @@ pub(crate) const fn encode_unix_timestamp_millis(millis: u64, random_bytes: &[u8
     Uuid::from_fields(millis_high, millis_low, random_and_version, &d4)
 }
 
-#[cfg(uuid_unstable)]
 pub(crate) const fn decode_unix_timestamp_millis(uuid: &Uuid) -> u64 {
     let bytes = uuid.as_bytes();
 


### PR DESCRIPTION
Closes #523

This PR lets you use the `v6`, `v7`, and `v8` variants without also having to set the `UUID_UNSTABLE` environment variable. It means it's now feasible for libraries to use these formats, and for applications to simplify their builds.

I've added a benchmark for `v4` vs `v7` that users can run if they're interested in the potential impact of switching from fully random to sortable UUIDs.