### PR TITLE
Add missing test for invalid parse_str

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -472,6 +472,14 @@ mod tests {
                 index: 20,
             }))
         );
+
+        assert_eq!(
+            Uuid::parse_str("\u{bcf3c}"),
+            Err(Error(ErrorKind::Char {
+                character: '\u{bcf3c}',
+                index: 1
+            }))
+        );
     }
 
     #[test]


### PR DESCRIPTION
Hi,

Thanks for your time & patience to review this PR.

We are researchers focusing on Rust unit tests by LLM. By examine the existing code, we found a unit test can be added to improve the repo's overall unit test coverage(this project is already been well tested).
The code region to cover is:

https://github.com/uuid-rs/uuid/blob/c8891073248ddc7faa8c53ac9ceb629a341c7b9b/src/error.rs#L73-L79

Thanks again for reviewing.