### PR TITLE
Prepare for 1.7.0 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,7 +30,7 @@ homepage = "https://github.com/uuid-rs/uuid"
 name = "uuid"
 readme = "README.md"
 repository = "https://github.com/uuid-rs/uuid"
-version = "1.6.1" # remember to update html_root_url in lib.rs
+version = "1.7.0" # remember to update html_root_url in lib.rs
 rust-version = "1.60.0"
 
 [package.metadata.docs.rs]
@@ -146,7 +146,7 @@ version = "1"
 
 # Public: Re-exported
 [dependencies.uuid-macro-internal]
-version = "1.6.1"
+version = "1.7.0"
 path = "macros"
 optional = true
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Add the following to your `Cargo.toml`:
 
 ```toml
 [dependencies.uuid]
-version = "1.6.1"
+version = "1.7.0"
 features = [
     "v4",                # Lets you generate random UUIDs
     "fast-rng",          # Use a faster (but still sufficiently random) RNG
@@ -65,11 +65,11 @@ assert_eq!(Some(Version::Random), my_uuid.get_version());
 If you'd like to parse UUIDs _really_ fast, check out the [`uuid-simd`](https://github.com/nugine/uuid-simd)
 library.
 
-For more details on using `uuid`, [see the library documentation](https://docs.rs/uuid/1.6.1/uuid).
+For more details on using `uuid`, [see the library documentation](https://docs.rs/uuid/1.7.0/uuid).
 
 ## References
 
-* [`uuid` library docs](https://docs.rs/uuid/1.6.1/uuid).
+* [`uuid` library docs](https://docs.rs/uuid/1.7.0/uuid).
 * [Wikipedia: Universally Unique Identifier](http://en.wikipedia.org/wiki/Universally_unique_identifier).
 * [RFC4122: A Universally Unique IDentifier (UUID) URN Namespace](http://tools.ietf.org/html/rfc4122).
 

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uuid-macro-internal"
-version = "1.6.1"
+version = "1.7.0"
 edition = "2018"
 authors = [
     "QnnOkabayashi"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,7 +39,7 @@
 //!
 //! ```toml
 //! [dependencies.uuid]
-//! version = "1.6.1"
+//! version = "1.7.0"
 //! features = [
 //!     "v4",                # Lets you generate random UUIDs
 //!     "fast-rng",          # Use a faster (but still sufficiently random) RNG
@@ -141,7 +141,7 @@
 //!
 //! ```toml
 //! [dependencies.uuid]
-//! version = "1.6.1"
+//! version = "1.7.0"
 //! features = [
 //!     "v4",
 //!     "v7",
@@ -156,7 +156,7 @@
 //!
 //! ```toml
 //! [dependencies.uuid]
-//! version = "1.6.1"
+//! version = "1.7.0"
 //! default-features = false
 //! ```
 //!
@@ -214,7 +214,7 @@
 #![doc(
     html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
     html_favicon_url = "https://www.rust-lang.org/favicon.ico",
-    html_root_url = "https://docs.rs/uuid/1.6.1"
+    html_root_url = "https://docs.rs/uuid/1.7.0"
 )]
 
 #[cfg(any(feature = "std", test))]


### PR DESCRIPTION
## What's Changed
* Add missing test for invalid parse_str by @CXWorks in https://github.com/uuid-rs/uuid/pull/723
* Upgrade borsh unstable dependency to v1.0 and make it stable by @bgeron in https://github.com/uuid-rs/uuid/pull/724
* Reduce the package size of uuid by @KodrAus in https://github.com/uuid-rs/uuid/pull/726
* Make use of newer Cargo features for specifying dependencies by @KodrAus in https://github.com/uuid-rs/uuid/pull/727

## New Contributors
* @CXWorks made their first contribution in https://github.com/uuid-rs/uuid/pull/723
* @bgeron made their first contribution in https://github.com/uuid-rs/uuid/pull/724