### PR TITLE
[feat]: add (optional) defmt support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,8 @@ atomic = ["dep:atomic"]
 
 borsh = ["dep:borsh", "dep:borsh-derive"]
 
+defmt = ["dep:defmt"]
+
 # Public: Used in trait impls on `Uuid`
 [dependencies.bytemuck]
 version = "1.14.0"
@@ -159,6 +161,11 @@ version = "0.5"
 # Private
 [dependencies.wasm-bindgen]
 version = "0.2"
+optional = true
+
+# Private: used in no-std
+[dependencies.defmt]
+version = "0.3"
 optional = true
 
 [dev-dependencies.bincode]

--- a/src/external.rs
+++ b/src/external.rs
@@ -2,6 +2,8 @@
 pub(crate) mod arbitrary_support;
 #[cfg(feature = "borsh")]
 pub(crate) mod borsh_support;
+#[cfg(feature = "defmt")]
+pub(crate) mod defmt_support;
 #[cfg(feature = "serde")]
 pub(crate) mod serde_support;
 #[cfg(feature = "slog")]

--- a/src/external/defmt_support.rs
+++ b/src/external/defmt_support.rs
@@ -1,0 +1,9 @@
+use crate::{fmt::Hyphenated, Uuid};
+
+impl defmt::Format for Uuid {
+    fn format(&self, f: defmt::Formatter<'_>) {
+        let mut buf = [0u8; Hyphenated::LENGTH];
+        let s = self.as_hyphenated().encode_lower(&mut buf);
+        defmt::write!(f, "{=str}", s);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -448,7 +448,6 @@ pub enum Variant {
     feature = "bytemuck",
     derive(bytemuck::Zeroable, bytemuck::Pod, bytemuck::TransparentWrapper)
 )]
-#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Uuid(Bytes);
 
 impl Uuid {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -448,6 +448,7 @@ pub enum Variant {
     feature = "bytemuck",
     derive(bytemuck::Zeroable, bytemuck::Pod, bytemuck::TransparentWrapper)
 )]
+#[cfg_attr(feature = "defmt", derive(defmt::Format))]
 pub struct Uuid(Bytes);
 
 impl Uuid {


### PR DESCRIPTION
The [defmt](https://github.com/knurling-rs/defmt) is an important crate in the embedded world, it implements a highly efficient logging encoding using deferred formatting and string compression. But for that, they need a special format implementation.

This PR implements the `defmt::Format` for `Uuid` based on feature configuration.

Example output after run `probe run`
![image](https://github.com/uuid-rs/uuid/assets/32439070/fb36b01e-958e-47d2-99a9-cb61e00af9c2)