### PR TITLE
Only add `wasm-bindgen` as a dependency on `wasm32-unknown-unknown`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,7 +157,7 @@ optional = true
 version = "0.5"
 
 # Private
-[dependencies.wasm-bindgen]
+[target.'cfg(target = "wasm32-unknown-unknown")'.dependencies.wasm-bindgen]
 version = "0.2"
 optional = true
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,7 +157,7 @@ optional = true
 version = "0.5"
 
 # Private
-[target.'cfg(target = "wasm32-unknown-unknown")'.dependencies.wasm-bindgen]
+[target.'cfg(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"))'.dependencies.wasm-bindgen]
 version = "0.2"
 optional = true
 


### PR DESCRIPTION
When setting the `js` feature, `uuid` would previously pull in all of `wasm-bindgen` even when targeting a native build:

```
❯ cargo tree -p uuid --target aarch64-apple-darwin --no-default-features --features js
uuid v1.7.0 (/Users/emilk/code/forks/uuid)
└── wasm-bindgen v0.2.91
    ├── cfg-if v1.0.0
    └── wasm-bindgen-macro v0.2.91 (proc-macro)
        ├── quote v1.0.35
        │   └── proc-macro2 v1.0.78
        │       └── unicode-ident v1.0.12
        └── wasm-bindgen-macro-support v0.2.91
            ├── proc-macro2 v1.0.78 (*)
            ├── quote v1.0.35 (*)
            ├── syn v2.0.48
            │   ├── proc-macro2 v1.0.78 (*)
            │   ├── quote v1.0.35 (*)
            │   └── unicode-ident v1.0.12
            ├── wasm-bindgen-backend v0.2.91
            │   ├── bumpalo v3.14.0
            │   ├── log v0.4.20
            │   ├── once_cell v1.19.0
            │   ├── proc-macro2 v1.0.78 (*)
            │   ├── quote v1.0.35 (*)
            │   ├── syn v2.0.48 (*)
            │   └── wasm-bindgen-shared v0.2.91
            └── wasm-bindgen-shared v0.2.91
```

Now all of that dependency tree is gone when building for native.

Note that a user (me) cannot set the `js` feature only for some targets, but must opt-in to it on all targets.