### PR TITLE
Add bitcode support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: Continuous integration
 
 env:
   VERSION_FEATURES: "v1 v3 v4 v5 v6 v7 v8"
-  DEP_FEATURES: "slog serde arbitrary borsh zerocopy bytemuck"
+  DEP_FEATURES: "slog serde arbitrary borsh zerocopy bytemuck bitcode"
 
 on:
   pull_request:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -99,6 +99,11 @@ version = "2"
 optional = true
 version = "1.1.3"
 
+# Public: Used in trait impls on `Uuid`
+[dependencies.bitcode]
+version = "0.5.1"
+optional = true
+
 # Public (unstable): Used in `zerocopy` derive
 # Unstable: also need RUSTFLAGS="--cfg uuid_unstable" to work
 # This feature may break between releases, or be removed entirely before

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -114,6 +114,7 @@
 //!   This feature requires more dependencies to compile, but is just as suitable for
 //!   UUIDs as the default algorithm.
 //! * `bytemuck` - adds a `Pod` trait implementation to `Uuid` for byte manipulation
+//! * `bitcode` - adds the ability to encode and decode a UUID using `bitcode`.
 //!
 //! # Unstable features
 //!
@@ -439,6 +440,7 @@ pub enum Variant {
     all(uuid_unstable, feature = "zerocopy"),
     derive(AsBytes, FromBytes, Unaligned)
 )]
+#[cfg_attr(feature = "bitcode", derive(bitcode::Encode, bitcode::Decode))]
 #[cfg_attr(
     feature = "borsh",
     derive(borsh_derive::BorshDeserialize, borsh_derive::BorshSerialize)


### PR DESCRIPTION
This pr adds support for [`bitcode`](https://github.com/SoftbearStudios/bitcode), commonly used by bevy games for it's more compact representation.