### PR TITLE
impl AsRef<Uuid> for Uuid

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -933,6 +933,7 @@ impl Default for Uuid {
 }
 
 impl AsRef<Uuid> for Uuid {
+    #[inline]
     fn as_ref(&self) -> &Uuid {
         self
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -932,6 +932,12 @@ impl Default for Uuid {
     }
 }
 
+impl AsRef<Uuid> for Uuid {
+    fn as_ref(&self) -> &Uuid {
+        self
+    }
+}
+
 impl AsRef<[u8]> for Uuid {
     #[inline]
     fn as_ref(&self) -> &[u8] {
@@ -1745,7 +1751,7 @@ mod tests {
     fn test_as_bytes() {
         let u = new();
         let ub = u.as_bytes();
-        let ur = u.as_ref();
+        let ur: &[u8] = u.as_ref();
 
         assert_eq!(ub.len(), 16);
         assert_eq!(ur.len(), 16);
@@ -1767,7 +1773,7 @@ mod tests {
         use crate::std::{convert::TryInto, vec::Vec};
 
         let u = new();
-        let ub = u.as_ref();
+        let ub: &[u8] = u.as_ref();
 
         let v: Vec<u8> = u.into();
 


### PR DESCRIPTION
Added the following AsRef impl:
```rust
impl AsRef<Uuid> for Uuid {
    #[inline]
    fn as_ref(&self) -> &Uuid {
        self
    }
}
```

Having this means you can write code like this that accepts `Braced`, `Hyphenated`, `Simple`, `Urn`, or `Uuid`:
```rust
fn find_with_uuid(uuid: impl AsRef<Uuid>) 
```

For completeness this is technical possible currently using something like this:
```rust
fn find_with_uuid(uuid: impl Borrow<Uuid>) 
```

However (and I am open to being corrected on this) my understanding is this is much less idiomatic then `AsRef<T>`. My understanding after reading over the std docs and some discussion online is: 
`Borrow<T>` implies a function doesn't care if it gets `T`, `&T`, or `&mut T`. 
`AsRef<T>` implies a function doesn't care what it gets as long as it can be represented as `&T`.

They both serve similar purposes (and have almost identical implementations). However `AsRef<T>` implies "I want `&T` and I don't mind if I need to do a low cost conversion to get it" where `Borrow<T>` implies "I don't care if you give me `T` or `&T` since I'll be borrowing it as `&T` anyway."

As an example the standard library recommends using `AsRef<str>` when you want a function to be able to accept any `&str`, `&String`, or `String`.

(Ideally the standard library would implement something like:
```rust
impl<T> AsRef<T> for T {
    #[inline]
    fn as_ref(&self) -> &T {
        self
    }
}
``` 
However currently this isn't possible due to some other conflicting traits so it needs to be implemented manually for each type.)