### PR TITLE
Add v6 to v8 draft link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ For more details on using `uuid`, [see the library documentation](https://docs.r
 * [`uuid` library docs](https://docs.rs/uuid/1.7.0/uuid).
 * [Wikipedia: Universally Unique Identifier](http://en.wikipedia.org/wiki/Universally_unique_identifier).
 * [RFC4122: A Universally Unique IDentifier (UUID) URN Namespace](http://tools.ietf.org/html/rfc4122).
+* [Revision of RFC4122: Universally Unique IDentifiers (UUID)](https://www.ietf.org/archive/id/draft-ietf-uuidrev-rfc4122bis-14.html).
 
 ---
 # License


### PR DESCRIPTION
This PR just adds a link to the draft spec for v6 to v8 UUIDs. It's a rewrite of RFC4122 that's more consistent and modern in its recommendations for other versions too.