### PR TITLE
Add a get_node_id method for v1 and v6 UUIDs

### DIFF
--- a/macros/src/error.rs
+++ b/macros/src/error.rs
@@ -70,7 +70,7 @@ impl<'a> InvalidUuid<'a> {
                     group_bounds[hyphen_count] = index;
                 }
                 hyphen_count += 1;
-            } else if !matches!(byte, b'0'..=b'9' | b'a'..=b'f' | b'A'..=b'F') {
+            } else if !byte.is_ascii_hexdigit() {
                 // Non-hex char
                 return Error(ErrorKind::Char {
                     character: byte as char,

--- a/src/error.rs
+++ b/src/error.rs
@@ -82,7 +82,7 @@ impl<'a> InvalidUuid<'a> {
                     group_bounds[hyphen_count] = index;
                 }
                 hyphen_count += 1;
-            } else if !matches!(byte, b'0'..=b'9' | b'a'..=b'f' | b'A'..=b'F') {
+            } else if !byte.is_ascii_hexdigit() {
                 // Non-hex char
                 return Error(ErrorKind::Char {
                     character: byte as char,

--- a/src/external/serde_support.rs
+++ b/src/external/serde_support.rs
@@ -184,7 +184,7 @@ pub mod compact {
     #[cfg(test)]
     mod tests {
         use serde_derive::*;
-        use serde_test::{self, Configure};
+        use serde_test::Configure;
 
         #[test]
         fn test_serialize_compact() {

--- a/src/external/slog_support.rs
+++ b/src/external/slog_support.rs
@@ -26,7 +26,7 @@ impl slog::Value for Uuid {
 mod tests {
     use crate::tests::new;
 
-    use slog::{self, crit, Drain};
+    use slog::{crit, Drain};
 
     #[test]
     fn test_slog_kv() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -211,6 +211,7 @@
 
 #![no_std]
 #![deny(missing_debug_implementations, missing_docs)]
+#![allow(clippy::mixed_attributes_style)]
 #![doc(
     html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
     html_favicon_url = "https://www.rust-lang.org/favicon.ico",

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -151,6 +151,7 @@ const fn try_parse(input: &[u8]) -> Result<[u8; 16], InvalidUuid> {
 }
 
 #[inline]
+#[allow(dead_code)]
 pub(crate) const fn parse_braced(input: &[u8]) -> Result<[u8; 16], InvalidUuid> {
     if let (38, [b'{', s @ .., b'}']) = (input.len(), input) {
         parse_hyphenated(s)
@@ -160,6 +161,7 @@ pub(crate) const fn parse_braced(input: &[u8]) -> Result<[u8; 16], InvalidUuid> 
 }
 
 #[inline]
+#[allow(dead_code)]
 pub(crate) const fn parse_urn(input: &[u8]) -> Result<[u8; 16], InvalidUuid> {
     if let (45, [b'u', b'r', b'n', b':', b'u', b'u', b'i', b'd', b':', s @ ..]) =
         (input.len(), input)

--- a/src/v1.rs
+++ b/src/v1.rs
@@ -135,6 +135,8 @@ mod tests {
 
         assert_eq!(ts.0 - 0x01B2_1DD2_1381_4000, 14_968_545_358_129_460);
 
+        assert_eq!(Some(node), uuid.get_node_id(),);
+
         // Ensure parsing the same UUID produces the same timestamp
         let parsed = Uuid::parse_str("20616934-4ba2-11e7-8000-010203040506").unwrap();
 
@@ -142,6 +144,8 @@ mod tests {
             uuid.get_timestamp().unwrap(),
             parsed.get_timestamp().unwrap()
         );
+
+        assert_eq!(uuid.get_node_id().unwrap(), parsed.get_node_id().unwrap(),);
     }
 
     #[test]

--- a/src/v6.rs
+++ b/src/v6.rs
@@ -137,6 +137,8 @@ mod tests {
 
         assert_eq!(ts.0 - 0x01B2_1DD2_1381_4000, 14_968_545_358_129_460);
 
+        assert_eq!(Some(node), uuid.get_node_id(),);
+
         // Ensure parsing the same UUID produces the same timestamp
         let parsed = Uuid::parse_str("1e74ba22-0616-6934-8000-010203040506").unwrap();
 
@@ -144,6 +146,8 @@ mod tests {
             uuid.get_timestamp().unwrap(),
             parsed.get_timestamp().unwrap()
         );
+
+        assert_eq!(uuid.get_node_id().unwrap(), parsed.get_node_id().unwrap(),);
     }
 
     #[test]

--- a/tests/ui/compile_pass/hygiene.rs
+++ b/tests/ui/compile_pass/hygiene.rs
@@ -1,3 +1,5 @@
+#![allow(non_snake_case)]
+
 use uuid::{uuid, Uuid};
 
 fn Ok() {}


### PR DESCRIPTION
Closes #648 

This PR adds a `Uuid::get_node_id` method that returns `Some([a, b, c, d, e, f])` for V1 and V6 UUIDs, and `None` for others. It can help support conversion between V1 and V6 UUIDs.

I've also just fixed up some new warnings along the way.