### PR TITLE
Update atomic and zerocopy to latest

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,7 +106,8 @@ version = "1.1.3"
 # See: https://github.com/uuid-rs/uuid/issues/588
 [dependencies.zerocopy]
 optional = true
-version = "0.6"
+version = "0.7"
+features = ["derive"]
 
 # Public: Used in trait impls on `Uuid`
 [dependencies.borsh]
@@ -154,7 +155,7 @@ optional = true
 [dependencies.atomic]
 default-features = false
 optional = true
-version = "0.5"
+version = "0.6"
 
 # Private
 [target.'cfg(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"))'.dependencies.wasm-bindgen]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -227,7 +227,7 @@ extern crate std;
 extern crate core as std;
 
 #[cfg(all(uuid_unstable, feature = "zerocopy"))]
-use zerocopy::{AsBytes, FromBytes, Unaligned};
+use zerocopy::{AsBytes, FromBytes, FromZeroes, Unaligned};
 
 mod builder;
 mod error;
@@ -438,7 +438,7 @@ pub enum Variant {
 #[derive(Clone, Copy, Eq, Hash, Ord, PartialEq, PartialOrd)]
 #[cfg_attr(
     all(uuid_unstable, feature = "zerocopy"),
-    derive(AsBytes, FromBytes, Unaligned)
+    derive(AsBytes, FromBytes, FromZeroes, Unaligned)
 )]
 #[cfg_attr(
     feature = "borsh",


### PR DESCRIPTION
The `zerocopy` update is a breaking change, but it's breaking an unstable dependency, so this makes sure we stay current with whatever version a consumer would be expecting to use.