### PR TITLE
Remove myself from the authors line in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,6 @@
 [package]
 authors = [
     "Ashley Mannix<ashleymannix@live.com.au>",
-    "Christopher Armstrong",
     "Dylan DPC<dylan.dpc@gmail.com>",
     "Hunar Roop Kahlon<hunar.roop@gmail.com>"
 ]


### PR DESCRIPTION
While I volunteered when the original request for volunteers was made, I never ended up actually doing anything in uuid-rs, so I don't think I belong in the authors line.