### PR TITLE
Add repository field to uuid-macro-internal crate

### DIFF
--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -13,6 +13,7 @@ categories = [
 ]
 description = "Private implementation details of the uuid! macro."
 documentation = "https://docs.rs/uuid"
+repository = "https://github.com/uuid-rs/uuid"
 license = "Apache-2.0 OR MIT"
 
 [lib]


### PR DESCRIPTION
Hi! While scraping crates.io I've found `uuid-macro-internal` to be missing the repository field, making it difficult for users and automated tools to find out about the repository. This PR fixes it.