### PR TITLE
renaming rfc4122 functions

### DIFF
--- a/examples/src/windows_guid.rs
+++ b/examples/src/windows_guid.rs
@@ -105,7 +105,7 @@ fn uuid_from_cocreateguid() {
 
     let uuid = Uuid::from_fields(guid.data1, guid.data2, guid.data3, &guid.data4);
 
-    assert_eq!(Variant::RFC4122, uuid.get_variant());
+    assert_eq!(Variant::RFC, uuid.get_variant());
     assert_eq!(Some(Version::Random), uuid.get_version());
 }
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -40,7 +40,7 @@ use crate::{error::*, timestamp, Bytes, Uuid, Variant, Version};
 /// let uuid = Builder::from_random_bytes(random_bytes).into_uuid();
 ///
 /// assert_eq!(Some(Version::Random), uuid.get_version());
-/// assert_eq!(Variant::RFC4122, uuid.get_variant());
+/// assert_eq!(Variant::RFC, uuid.get_variant());
 /// ```
 #[allow(missing_copy_implementations)]
 #[derive(Debug)]
@@ -559,7 +559,7 @@ impl Builder {
     /// Creates a `Builder` for a version 3 UUID using the supplied MD5 hashed bytes.
     pub const fn from_md5_bytes(md5_bytes: Bytes) -> Self {
         Builder(Uuid::from_bytes(md5_bytes))
-            .with_variant(Variant::RFC4122)
+            .with_variant(Variant::RFC)
             .with_version(Version::Md5)
     }
 
@@ -580,11 +580,11 @@ impl Builder {
     /// let uuid = Builder::from_random_bytes(random_bytes).into_uuid();
     ///
     /// assert_eq!(Some(Version::Random), uuid.get_version());
-    /// assert_eq!(Variant::RFC4122, uuid.get_variant());
+    /// assert_eq!(Variant::RFC, uuid.get_variant());
     /// ```
     pub const fn from_random_bytes(random_bytes: Bytes) -> Self {
         Builder(Uuid::from_bytes(random_bytes))
-            .with_variant(Variant::RFC4122)
+            .with_variant(Variant::RFC)
             .with_version(Version::Random)
     }
 
@@ -594,7 +594,7 @@ impl Builder {
     /// bits for the UUID version and variant.
     pub const fn from_sha1_bytes(sha1_bytes: Bytes) -> Self {
         Builder(Uuid::from_bytes(sha1_bytes))
-            .with_variant(Variant::RFC4122)
+            .with_variant(Variant::RFC)
             .with_version(Version::Sha1)
     }
 
@@ -636,7 +636,7 @@ impl Builder {
     /// let uuid = Builder::from_unix_timestamp_millis(ts.as_millis().try_into()?, &random_bytes).into_uuid();
     ///
     /// assert_eq!(Some(Version::SortRand), uuid.get_version());
-    /// assert_eq!(Variant::RFC4122, uuid.get_variant());
+    /// assert_eq!(Variant::RFC, uuid.get_variant());
     /// # Ok(())
     /// # }
     /// ```
@@ -653,7 +653,7 @@ impl Builder {
     /// bits for the UUID version and variant.
     pub const fn from_custom_bytes(custom_bytes: Bytes) -> Self {
         Builder::from_bytes(custom_bytes)
-            .with_variant(Variant::RFC4122)
+            .with_variant(Variant::RFC)
             .with_version(Version::Custom)
     }
 
@@ -846,9 +846,12 @@ impl Builder {
 
         (self.0).0[8] = match v {
             Variant::NCS => byte & 0x7f,
-            Variant::RFC4122 => (byte & 0x3f) | 0x80,
+            Variant::RFC => (byte & 0x3f) | 0x80,
             Variant::Microsoft => (byte & 0x1f) | 0xc0,
             Variant::Future => byte | 0xe0,
+            // Deprecated. Remove when major version changes (2.0.0)
+            #[allow(deprecated)]
+            Variant::RFC4122 => (byte & 0x3f) | 0x80,
         };
 
         self

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -550,8 +550,10 @@ impl Builder {
     }
 
     /// Creates a `Builder` for a version 1 UUID using the supplied timestamp and node ID.
-    pub const fn from_rfc4122_timestamp(ticks: u64, counter: u16, node_id: &[u8; 6]) -> Self {
-        Builder(timestamp::encode_rfc4122_timestamp(ticks, counter, node_id))
+    pub const fn from_gregorian_timestamp(ticks: u64, counter: u16, node_id: &[u8; 6]) -> Self {
+        Builder(timestamp::encode_gregorian_timestamp(
+            ticks, counter, node_id,
+        ))
     }
 
     /// Creates a `Builder` for a version 3 UUID using the supplied MD5 hashed bytes.
@@ -599,12 +601,12 @@ impl Builder {
     /// Creates a `Builder` for a version 6 UUID using the supplied timestamp and node ID.
     ///
     /// This method will encode the ticks, counter, and node ID in a sortable UUID.
-    pub const fn from_sorted_rfc4122_timestamp(
+    pub const fn from_sorted_gregorian_timestamp(
         ticks: u64,
         counter: u16,
         node_id: &[u8; 6],
     ) -> Self {
-        Builder(timestamp::encode_sorted_rfc4122_timestamp(
+        Builder(timestamp::encode_sorted_gregorian_timestamp(
             ticks, counter, node_id,
         ))
     }
@@ -901,5 +903,29 @@ impl Builder {
     /// ```
     pub const fn into_uuid(self) -> Uuid {
         self.0
+    }
+}
+
+// Deprecations. Remove when major version changes (2.0.0)
+#[doc(hidden)]
+impl Builder {
+    #[deprecated(
+        since = "1.10.0",
+        note = "Deprecated! Use `from_gregorian_timestamp()` instead!"
+    )]
+    pub const fn from_rfc4122_timestamp(ticks: u64, counter: u16, node_id: &[u8; 6]) -> Self {
+        Builder::from_gregorian_timestamp(ticks, counter, node_id)
+    }
+
+    #[deprecated(
+        since = "1.10.0",
+        note = "Deprecated! Use `from_sorted_gregorian_timestamp()` instead!"
+    )]
+    pub const fn from_sorted_rfc4122_timestamp(
+        ticks: u64,
+        counter: u16,
+        node_id: &[u8; 6],
+    ) -> Self {
+        Builder::from_sorted_gregorian_timestamp(ticks, counter, node_id)
     }
 }

--- a/src/external/arbitrary_support.rs
+++ b/src/external/arbitrary_support.rs
@@ -30,7 +30,7 @@ mod tests {
         let uuid = Uuid::arbitrary(&mut bytes).unwrap();
 
         assert_eq!(Some(Version::Random), uuid.get_version());
-        assert_eq!(Variant::RFC4122, uuid.get_variant());
+        assert_eq!(Variant::RFC, uuid.get_variant());
     }
 
     #[test]

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -43,9 +43,12 @@ impl fmt::Display for Variant {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match *self {
             Variant::NCS => write!(f, "NCS"),
-            Variant::RFC4122 => write!(f, "RFC4122"),
+            Variant::RFC => write!(f, "RFC"),
             Variant::Microsoft => write!(f, "Microsoft"),
             Variant::Future => write!(f, "Future"),
+            // Deprecated. Remove when major version changes (2.0.0)
+            #[allow(deprecated)]
+            Variant::RFC4122 => write!(f, "RFC4122"),
         }
     }
 }
@@ -924,6 +927,7 @@ impl_fmt_traits! {
 
 #[cfg(test)]
 mod tests {
+
     use super::*;
 
     #[test]
@@ -1036,5 +1040,11 @@ mod tests {
     fn braced_to_inner() {
         let braced = Uuid::nil().braced();
         assert_eq!(Uuid::from(braced), Uuid::nil());
+    }
+
+    #[test]
+    #[allow(deprecated)]
+    fn fmt_variant() {
+        assert_eq!(format!("{}", Variant::RFC4122), "RFC4122");
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -889,14 +889,14 @@ impl Uuid {
     pub const fn get_timestamp(&self) -> Option<Timestamp> {
         match self.get_version() {
             Some(Version::Mac) => {
-                let (ticks, counter) = timestamp::decode_rfc4122_timestamp(self);
+                let (ticks, counter) = timestamp::decode_gregorian_timestamp(self);
 
-                Some(Timestamp::from_rfc4122(ticks, counter))
+                Some(Timestamp::from_gregorian(ticks, counter))
             }
             Some(Version::SortMac) => {
-                let (ticks, counter) = timestamp::decode_sorted_rfc4122_timestamp(self);
+                let (ticks, counter) = timestamp::decode_sorted_gregorian_timestamp(self);
 
-                Some(Timestamp::from_rfc4122(ticks, counter))
+                Some(Timestamp::from_gregorian(ticks, counter))
             }
             Some(Version::SortRand) => {
                 let millis = timestamp::decode_unix_timestamp_millis(self);

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -55,7 +55,7 @@ impl Uuid {
     /// let uuid = Uuid::parse_str("550e8400-e29b-41d4-a716-446655440000")?;
     ///
     /// assert_eq!(Some(Version::Random), uuid.get_version());
-    /// assert_eq!(Variant::RFC4122, uuid.get_variant());
+    /// assert_eq!(Variant::RFC, uuid.get_variant());
     /// # Ok(())
     /// # }
     /// ```
@@ -88,7 +88,7 @@ impl Uuid {
     /// let uuid = Uuid::try_parse("550e8400-e29b-41d4-a716-446655440000")?;
     ///
     /// assert_eq!(Some(Version::Random), uuid.get_version());
-    /// assert_eq!(Variant::RFC4122, uuid.get_variant());
+    /// assert_eq!(Variant::RFC, uuid.get_variant());
     /// # Ok(())
     /// # }
     /// ```
@@ -116,7 +116,7 @@ impl Uuid {
     /// let uuid = Uuid::try_parse_ascii(b"550e8400-e29b-41d4-a716-446655440000")?;
     ///
     /// assert_eq!(Some(Version::Random), uuid.get_version());
-    /// assert_eq!(Variant::RFC4122, uuid.get_variant());
+    /// assert_eq!(Variant::RFC, uuid.get_variant());
     /// # Ok(())
     /// # }
     /// ```

--- a/src/v1.rs
+++ b/src/v1.rs
@@ -125,7 +125,7 @@ mod tests {
         let uuid = Uuid::new_v1(Timestamp::from_unix(&context, time, time_fraction), &node);
 
         assert_eq!(uuid.get_version(), Some(Version::Mac));
-        assert_eq!(uuid.get_variant(), Variant::RFC4122);
+        assert_eq!(uuid.get_variant(), Variant::RFC);
         assert_eq!(
             uuid.hyphenated().to_string(),
             "20616934-4ba2-11e7-8000-010203040506"
@@ -164,6 +164,6 @@ mod tests {
         let uuid = Uuid::now_v1(&node);
 
         assert_eq!(uuid.get_version(), Some(Version::Mac));
-        assert_eq!(uuid.get_variant(), Variant::RFC4122);
+        assert_eq!(uuid.get_variant(), Variant::RFC);
     }
 }

--- a/src/v1.rs
+++ b/src/v1.rs
@@ -71,7 +71,7 @@ impl Uuid {
     /// ```
     /// # use uuid::{Uuid, Timestamp, Context, ClockSequence};
     /// let context = Context::new(42);
-    /// let ts = Timestamp::from_rfc4122(14976234442241191232, context.generate_sequence(0, 0));
+    /// let ts = Timestamp::from_gregorian(14976234442241191232, context.generate_sequence(0, 0));
     ///
     /// let uuid = Uuid::new_v1(ts, &[1, 2, 3, 4, 5, 6]);
     ///
@@ -89,9 +89,9 @@ impl Uuid {
     /// [`ClockSequence`]: v1/trait.ClockSequence.html
     /// [`Context`]: v1/struct.Context.html
     pub fn new_v1(ts: Timestamp, node_id: &[u8; 6]) -> Self {
-        let (ticks, counter) = ts.to_rfc4122();
+        let (ticks, counter) = ts.to_gregorian();
 
-        Builder::from_rfc4122_timestamp(ticks, counter, node_id).into_uuid()
+        Builder::from_gregorian_timestamp(ticks, counter, node_id).into_uuid()
     }
 }
 
@@ -131,7 +131,7 @@ mod tests {
             "20616934-4ba2-11e7-8000-010203040506"
         );
 
-        let ts = uuid.get_timestamp().unwrap().to_rfc4122();
+        let ts = uuid.get_timestamp().unwrap().to_gregorian();
 
         assert_eq!(ts.0 - 0x01B2_1DD2_1381_4000, 14_968_545_358_129_460);
 

--- a/src/v3.rs
+++ b/src/v3.rs
@@ -148,7 +148,7 @@ mod tests {
         for &(ref ns, ref name, _) in FIXTURE {
             let uuid = Uuid::new_v3(*ns, name.as_bytes());
             assert_eq!(uuid.get_version(), Some(Version::Md5));
-            assert_eq!(uuid.get_variant(), Variant::RFC4122);
+            assert_eq!(uuid.get_variant(), Variant::RFC);
         }
     }
 

--- a/src/v4.rs
+++ b/src/v4.rs
@@ -64,7 +64,7 @@ mod tests {
         let uuid = Uuid::new_v4();
 
         assert_eq!(uuid.get_version(), Some(Version::Random));
-        assert_eq!(uuid.get_variant(), Variant::RFC4122);
+        assert_eq!(uuid.get_variant(), Variant::RFC);
     }
 
     #[test]

--- a/src/v5.rs
+++ b/src/v5.rs
@@ -181,7 +181,7 @@ mod tests {
             let uuid = Uuid::new_v5(*ns, name.as_bytes());
 
             assert_eq!(uuid.get_version(), Some(Version::Sha1));
-            assert_eq!(uuid.get_variant(), Variant::RFC4122);
+            assert_eq!(uuid.get_variant(), Variant::RFC);
             assert_eq!(Ok(uuid), u.parse());
         }
     }

--- a/src/v6.rs
+++ b/src/v6.rs
@@ -72,7 +72,7 @@ impl Uuid {
     /// # use uuid::{Uuid, Timestamp, Context, ClockSequence};
     /// # fn random_seed() -> u16 { 42 }
     /// let context = Context::new(random_seed());
-    /// let ts = Timestamp::from_rfc4122(14976241191231231313, context.generate_sequence(0, 0) );
+    /// let ts = Timestamp::from_gregorian(14976241191231231313, context.generate_sequence(0, 0));
     ///
     /// let uuid = Uuid::new_v6(ts, &[1, 2, 3, 4, 5, 6]);
     ///
@@ -90,9 +90,9 @@ impl Uuid {
     /// [`ClockSequence`]: timestamp/trait.ClockSequence.html
     /// [`Context`]: timestamp/context/struct.Context.html
     pub fn new_v6(ts: Timestamp, node_id: &[u8; 6]) -> Self {
-        let (ticks, counter) = ts.to_rfc4122();
+        let (ticks, counter) = ts.to_gregorian();
 
-        Builder::from_sorted_rfc4122_timestamp(ticks, counter, node_id).into_uuid()
+        Builder::from_sorted_gregorian_timestamp(ticks, counter, node_id).into_uuid()
     }
 }
 
@@ -133,7 +133,7 @@ mod tests {
             "1e74ba22-0616-6934-8000-010203040506"
         );
 
-        let ts = uuid.get_timestamp().unwrap().to_rfc4122();
+        let ts = uuid.get_timestamp().unwrap().to_gregorian();
 
         assert_eq!(ts.0 - 0x01B2_1DD2_1381_4000, 14_968_545_358_129_460);
 

--- a/src/v6.rs
+++ b/src/v6.rs
@@ -127,7 +127,7 @@ mod tests {
         let uuid = Uuid::new_v6(Timestamp::from_unix(context, time, time_fraction), &node);
 
         assert_eq!(uuid.get_version(), Some(Version::SortMac));
-        assert_eq!(uuid.get_variant(), Variant::RFC4122);
+        assert_eq!(uuid.get_variant(), Variant::RFC);
         assert_eq!(
             uuid.hyphenated().to_string(),
             "1e74ba22-0616-6934-8000-010203040506"
@@ -166,6 +166,6 @@ mod tests {
         let uuid = Uuid::now_v6(&node);
 
         assert_eq!(uuid.get_version(), Some(Version::SortMac));
-        assert_eq!(uuid.get_variant(), Variant::RFC4122);
+        assert_eq!(uuid.get_variant(), Variant::RFC);
     }
 }

--- a/src/v7.rs
+++ b/src/v7.rs
@@ -127,7 +127,7 @@ mod tests {
         let uustr = uuid.hyphenated().to_string();
 
         assert_eq!(uuid.get_version(), Some(Version::SortRand));
-        assert_eq!(uuid.get_variant(), Variant::RFC4122);
+        assert_eq!(uuid.get_variant(), Variant::RFC);
         assert!(uuid.hyphenated().to_string().starts_with("017f22e2-79b0-7"));
 
         // Ensure parsing the same UUID produces the same timestamp
@@ -150,7 +150,7 @@ mod tests {
         let uuid = Uuid::now_v7();
 
         assert_eq!(uuid.get_version(), Some(Version::SortRand));
-        assert_eq!(uuid.get_variant(), Variant::RFC4122);
+        assert_eq!(uuid.get_variant(), Variant::RFC);
     }
 
     #[test]
@@ -232,7 +232,7 @@ mod tests {
         let uuid = Uuid::new_v7(ts);
 
         assert_eq!(uuid.get_version(), Some(Version::SortRand));
-        assert_eq!(uuid.get_variant(), Variant::RFC4122);
+        assert_eq!(uuid.get_variant(), Variant::RFC);
 
         let decoded_ts = uuid.get_timestamp().unwrap();
 

--- a/src/v8.rs
+++ b/src/v8.rs
@@ -58,7 +58,7 @@ mod tests {
         ];
         let uuid = Uuid::new_v8(buf);
         assert_eq!(uuid.get_version(), Some(Version::Custom));
-        assert_eq!(uuid.get_variant(), Variant::RFC4122);
+        assert_eq!(uuid.get_variant(), Variant::RFC);
         assert_eq!(uuid.get_version_num(), 8);
         assert_eq!(
             uuid.hyphenated().to_string(),


### PR DESCRIPTION
Hey!

My second contribution is a small rename of certain obsolete function names. (namely, contains rfc4122)

The changes are cosmetic, does not carry real value...
... but it has some documental changes and additions regarding deprecation messages.

---

**Majority of the functions were private, but there was also a few public ones. This latter ones got proxy functions in place to not break BC, with the proper deprecation warning.**

During my testing it works as expected... also, I took the liberty and put the next version number into the deprecation messages, indicating there will be a patch version published.

When we will have version 2.0, we could clean up deprecated features.

Preferably should be merged after #753 