### PR TITLE
Support counters in v7 UUIDs

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -609,9 +609,11 @@ impl Builder {
         ))
     }
 
-    /// Creates a `Builder` for a version 7 UUID using the supplied Unix timestamp and random bytes.
+    /// Creates a `Builder` for a version 7 UUID using the supplied Unix timestamp and counter bytes.
     ///
-    /// This method assumes the bytes are already sufficiently random.
+    /// This method will set the variant field within the counter bytes without attempting to shift
+    /// the data around it. Callers using the counter as a monotonic value should be careful not to
+    /// store significant data in the 2 least significant bits of the 3rd byte.
     ///
     /// # Examples
     ///

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -636,10 +636,10 @@ impl Builder {
     /// # Ok(())
     /// # }
     /// ```
-    pub const fn from_unix_timestamp_millis(millis: u64, random_bytes: &[u8; 10]) -> Self {
+    pub const fn from_unix_timestamp_millis(millis: u64, counter_random_bytes: &[u8; 10]) -> Self {
         Builder(timestamp::encode_unix_timestamp_millis(
             millis,
-            random_bytes,
+            counter_random_bytes,
         ))
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -241,6 +241,9 @@ pub use timestamp::{context::NoContext, ClockSequence, Timestamp};
 #[cfg(any(feature = "v1", feature = "v6"))]
 pub use timestamp::context::Context;
 
+#[cfg(feature = "v7")]
+pub use timestamp::context::ContextV7;
+
 #[cfg(feature = "v1")]
 #[doc(hidden)]
 // Soft-deprecated (Rust doesn't support deprecating re-exports)

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -904,12 +904,7 @@ impl Uuid {
                 let seconds = millis / 1000;
                 let nanos = ((millis % 1000) * 1_000_000) as u32;
 
-                Some(Timestamp {
-                    seconds,
-                    nanos,
-                    #[cfg(any(feature = "v1", feature = "v6"))]
-                    counter: 0,
-                })
+                Some(Timestamp::from_unix_time(seconds, nanos, 0))
             }
             _ => None,
         }

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -18,6 +18,11 @@ pub(crate) fn bytes() -> [u8; 16] {
     }
 }
 
+#[cfg(any(feature = "v4", feature = "v7"))]
+pub(crate) fn u128() -> u128 {
+    u128::from_be_bytes(bytes())
+}
+
 #[cfg(any(feature = "v1", feature = "v6"))]
 pub(crate) fn u16() -> u16 {
     #[cfg(not(feature = "fast-rng"))]

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -20,7 +20,7 @@ pub(crate) fn bytes() -> [u8; 16] {
 
 #[cfg(any(feature = "v4", feature = "v7"))]
 pub(crate) fn u128() -> u128 {
-    u128::from_be_bytes(bytes())
+    u128::from_ne_bytes(bytes())
 }
 
 #[cfg(any(feature = "v1", feature = "v6"))]
@@ -34,7 +34,27 @@ pub(crate) fn u16() -> u16 {
             panic!("could not retrieve random bytes for uuid: {}", err)
         });
 
-        ((bytes[0] as u16) << 8) | (bytes[1] as u16)
+        u16::from_ne_bytes(bytes)
+    }
+
+    #[cfg(feature = "fast-rng")]
+    {
+        rand::random()
+    }
+}
+
+#[cfg(feature = "v7")]
+pub(crate) fn u64() -> u64 {
+    #[cfg(not(feature = "fast-rng"))]
+    {
+        let mut bytes = [0u8; 8];
+
+        getrandom::getrandom(&mut bytes).unwrap_or_else(|err| {
+            // NB: getrandom::Error has no source; this is adequate display
+            panic!("could not retrieve random bytes for uuid: {}", err)
+        });
+
+        u64::from_ne_bytes(bytes)
     }
 
     #[cfg(feature = "fast-rng")]

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -1,5 +1,5 @@
 #[cfg(any(feature = "v4", feature = "v7"))]
-pub(crate) fn bytes() -> [u8; 16] {
+pub(crate) fn u128() -> u128 {
     #[cfg(not(feature = "fast-rng"))]
     {
         let mut bytes = [0u8; 16];
@@ -9,18 +9,13 @@ pub(crate) fn bytes() -> [u8; 16] {
             panic!("could not retrieve random bytes for uuid: {}", err)
         });
 
-        bytes
+        u128::from_ne_bytes(bytes)
     }
 
     #[cfg(feature = "fast-rng")]
     {
         rand::random()
     }
-}
-
-#[cfg(any(feature = "v4", feature = "v7"))]
-pub(crate) fn u128() -> u128 {
-    u128::from_ne_bytes(bytes())
 }
 
 #[cfg(any(feature = "v1", feature = "v6"))]

--- a/src/v1.rs
+++ b/src/v1.rs
@@ -166,39 +166,4 @@ mod tests {
         assert_eq!(uuid.get_version(), Some(Version::Mac));
         assert_eq!(uuid.get_variant(), Variant::RFC4122);
     }
-
-    #[test]
-    #[cfg_attr(
-        all(
-            target_arch = "wasm32",
-            target_vendor = "unknown",
-            target_os = "unknown"
-        ),
-        wasm_bindgen_test
-    )]
-    fn test_new_context() {
-        let time: u64 = 1_496_854_535;
-        let time_fraction: u32 = 812_946_000;
-        let node = [1, 2, 3, 4, 5, 6];
-
-        // This context will wrap
-        let context = Context::new(u16::MAX >> 2);
-
-        let uuid1 = Uuid::new_v1(Timestamp::from_unix(&context, time, time_fraction), &node);
-
-        let time: u64 = 1_496_854_536;
-
-        let uuid2 = Uuid::new_v1(Timestamp::from_unix(&context, time, time_fraction), &node);
-
-        assert_eq!(uuid1.get_timestamp().unwrap().to_rfc4122().1, 16383);
-        assert_eq!(uuid2.get_timestamp().unwrap().to_rfc4122().1, 0);
-
-        let time = 1_496_854_535;
-
-        let uuid3 = Uuid::new_v1(Timestamp::from_unix(&context, time, time_fraction), &node);
-        let uuid4 = Uuid::new_v1(Timestamp::from_unix(&context, time, time_fraction), &node);
-
-        assert_eq!(uuid3.get_timestamp().unwrap().to_rfc4122().1, 1);
-        assert_eq!(uuid4.get_timestamp().unwrap().to_rfc4122().1, 2);
-    }
 }

--- a/src/v4.rs
+++ b/src/v4.rs
@@ -31,7 +31,9 @@ impl Uuid {
     /// [`getrandom`]: https://crates.io/crates/getrandom
     /// [from_random_bytes]: struct.Builder.html#method.from_random_bytes
     pub fn new_v4() -> Uuid {
-        crate::Builder::from_random_bytes(crate::rng::bytes()).into_uuid()
+        // This is an optimized method for generating random UUIDs that just masks
+        // out the bits for the version and variant and sets them both together
+        Uuid::from_u128(crate::rng::u128() & 0xFFFFFFFFFFFF4FFFBFFFFFFFFFFFFFFF | 0x40008000000000000000)
     }
 }
 

--- a/src/v4.rs
+++ b/src/v4.rs
@@ -33,7 +33,9 @@ impl Uuid {
     pub fn new_v4() -> Uuid {
         // This is an optimized method for generating random UUIDs that just masks
         // out the bits for the version and variant and sets them both together
-        Uuid::from_u128(crate::rng::u128() & 0xFFFFFFFFFFFF4FFFBFFFFFFFFFFFFFFF | 0x40008000000000000000)
+        Uuid::from_u128(
+            crate::rng::u128() & 0xFFFFFFFFFFFF4FFFBFFFFFFFFFFFFFFF | 0x40008000000000000000,
+        )
     }
 }
 

--- a/src/v6.rs
+++ b/src/v6.rs
@@ -168,39 +168,4 @@ mod tests {
         assert_eq!(uuid.get_version(), Some(Version::SortMac));
         assert_eq!(uuid.get_variant(), Variant::RFC4122);
     }
-
-    #[test]
-    #[cfg_attr(
-        all(
-            target_arch = "wasm32",
-            target_vendor = "unknown",
-            target_os = "unknown"
-        ),
-        wasm_bindgen_test
-    )]
-    fn test_new_context() {
-        let time: u64 = 1_496_854_535;
-        let time_fraction: u32 = 812_946_000;
-        let node = [1, 2, 3, 4, 5, 6];
-
-        // This context will wrap
-        let context = Context::new(u16::MAX >> 2);
-
-        let uuid1 = Uuid::new_v6(Timestamp::from_unix(&context, time, time_fraction), &node);
-
-        let time: u64 = 1_496_854_536;
-
-        let uuid2 = Uuid::new_v6(Timestamp::from_unix(&context, time, time_fraction), &node);
-
-        assert_eq!(uuid1.get_timestamp().unwrap().to_rfc4122().1, 16383);
-        assert_eq!(uuid2.get_timestamp().unwrap().to_rfc4122().1, 0);
-
-        let time = 1_496_854_535;
-
-        let uuid3 = Uuid::new_v6(Timestamp::from_unix(&context, time, time_fraction), &node);
-        let uuid4 = Uuid::new_v6(Timestamp::from_unix(&context, time, time_fraction), &node);
-
-        assert_eq!(uuid3.get_timestamp().unwrap().to_rfc4122().1, 1);
-        assert_eq!(uuid4.get_timestamp().unwrap().to_rfc4122().1, 2);
-    }
 }

--- a/src/v6.rs
+++ b/src/v6.rs
@@ -200,7 +200,7 @@ mod tests {
         let uuid3 = Uuid::new_v6(Timestamp::from_unix(&context, time, time_fraction), &node);
         let uuid4 = Uuid::new_v6(Timestamp::from_unix(&context, time, time_fraction), &node);
 
-        assert_eq!(uuid3.get_timestamp().unwrap().counter, 1);
-        assert_eq!(uuid4.get_timestamp().unwrap().counter, 2);
+        assert_eq!(uuid3.get_timestamp().unwrap().to_rfc4122().1, 1);
+        assert_eq!(uuid4.get_timestamp().unwrap().to_rfc4122().1, 2);
     }
 }

--- a/src/v7.rs
+++ b/src/v7.rs
@@ -9,9 +9,8 @@ impl Uuid {
     /// Create a new version 7 UUID using the current time value.
     ///
     /// This method is a convenient alternative to [`Uuid::new_v7`] that uses the current system time
-    /// as the source timestamp. UUIDs generated on the same thread will remain ordered based on the
-    /// order they were created in. UUIDs generated on multiple threads are not guaranteed to share a
-    /// global ordering within the same millisecond.
+    /// as the source timestamp. All UUIDs generated through this method by the same process are
+    /// guaranteed to be ordered by their creation.
     #[cfg(feature = "std")]
     pub fn now_v7() -> Self {
         Self::new_v7(Timestamp::now_128(

--- a/src/v7.rs
+++ b/src/v7.rs
@@ -69,8 +69,8 @@ impl Uuid {
         counter_and_random &= u128::MAX
             .overflowing_shr(cmp::min(128, counter_bits as u32))
             .0;
-        counter_and_random |= (counter as u128)
-            .overflowing_shl(128usize.saturating_sub(counter_bits) as u32)
+        counter_and_random |= counter
+            .overflowing_shl(128u8.saturating_sub(counter_bits) as u32)
             .0;
 
         Builder::from_unix_timestamp_millis(

--- a/src/v7.rs
+++ b/src/v7.rs
@@ -14,7 +14,7 @@ impl Uuid {
     /// as the source timestamp.
     #[cfg(feature = "std")]
     pub fn now_v7() -> Self {
-        Self::new_v7(Timestamp::now(crate::NoContext))
+        Self::new_v7(Timestamp::now_128(crate::timestamp::context::shared_context_v7()))
     }
 
     /// Create a new version 7 UUID using a time value and random bytes.

--- a/src/v7.rs
+++ b/src/v7.rs
@@ -8,10 +8,12 @@ use core::cmp;
 use crate::{rng, std::convert::TryInto, timestamp::Timestamp, Builder, Uuid};
 
 impl Uuid {
-    /// Create a new version 7 UUID using the current time value and random bytes.
+    /// Create a new version 7 UUID using the current time value.
     ///
     /// This method is a convenient alternative to [`Uuid::new_v7`] that uses the current system time
-    /// as the source timestamp.
+    /// as the source timestamp. UUIDs generated on the same thread will remain ordered based on the
+    /// order they were created in. UUIDs generated on multiple threads are not guaranteed to share a
+    /// global ordering within the same millisecond.
     #[cfg(feature = "std")]
     pub fn now_v7() -> Self {
         Self::new_v7(Timestamp::now_128(crate::timestamp::context::shared_context_v7()))
@@ -47,10 +49,10 @@ impl Uuid {
     /// UUIDs created together remain sortable:
     ///
     /// ```rust
-    /// # use uuid::{Uuid, Timestamp, Context};
-    /// let context = Context::new(42);
-    /// let uuid1 = Uuid::new_v7(Timestamp::from_unix(&context, 1497624119, 1234));
-    /// let uuid2 = Uuid::new_v7(Timestamp::from_unix(&context, 1497624119, 1234));
+    /// # use uuid::{Uuid, Timestamp, ContextV7};
+    /// let context = ContextV7::new();
+    /// let uuid1 = Uuid::new_v7(Timestamp::from_unix_128(&context, 1497624119, 1234));
+    /// let uuid2 = Uuid::new_v7(Timestamp::from_unix_128(&context, 1497624119, 1234));
     ///
     /// assert!(uuid1 < uuid2);
     /// ```


### PR DESCRIPTION
For #717

This PR sketches out a solution to make the v7 support respect the input counter, while retaining existing semantics around filling with random data. It requires a bit of fudgery to keep compatibility with existing APIs, but I think the overall solution works out ok. I need to actually fill it all in fully and then explore ways to better integrate the existing `Timestamp` API, which may involve deprecating bits.

The gist of it is to add a `usable_bits` method to `ClockSequence`, so it can tell how many bits a given counter occupies. The UUID constructor can then do appropriate shifts and fill the rest with random bytes. That way a caller creating a v7 UUID can decide how many bits to dedicate to sequencing and how many to randomness.

As part of this PR I'm expecting to find some solution to re-seeding sequences, which will probably remain an implementation detail of the given `ClockSequence`.