### PR TITLE
Clean up new Timestamp APIs

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -904,7 +904,7 @@ impl Uuid {
                 let seconds = millis / 1000;
                 let nanos = ((millis % 1000) * 1_000_000) as u32;
 
-                Some(Timestamp::from_unix_time(seconds, nanos, 0))
+                Some(Timestamp::from_unix_time(seconds, nanos, 0, 0))
             }
             _ => None,
         }

--- a/src/v7.rs
+++ b/src/v7.rs
@@ -13,7 +13,7 @@ impl Uuid {
     /// guaranteed to be ordered by their creation.
     #[cfg(feature = "std")]
     pub fn now_v7() -> Self {
-        Self::new_v7(Timestamp::now_128(
+        Self::new_v7(Timestamp::now(
             crate::timestamp::context::shared_context_v7(),
         ))
     }
@@ -50,8 +50,8 @@ impl Uuid {
     /// ```rust
     /// # use uuid::{Uuid, Timestamp, ContextV7};
     /// let context = ContextV7::new();
-    /// let uuid1 = Uuid::new_v7(Timestamp::from_unix_128(&context, 1497624119, 1234));
-    /// let uuid2 = Uuid::new_v7(Timestamp::from_unix_128(&context, 1497624119, 1234));
+    /// let uuid1 = Uuid::new_v7(Timestamp::from_unix(&context, 1497624119, 1234));
+    /// let uuid2 = Uuid::new_v7(Timestamp::from_unix(&context, 1497624119, 1234));
     ///
     /// assert!(uuid1 < uuid2);
     /// ```
@@ -98,7 +98,7 @@ impl Uuid {
 #[cfg(test)]
 mod tests {
     use super::*;
-    
+
     use crate::{std::string::ToString, ClockSequence, NoContext, Variant, Version};
 
     #[cfg(all(
@@ -227,8 +227,8 @@ mod tests {
         let time_fraction: u32 = 812_000_000;
 
         // Ensure we don't overflow here
-        let ts = Timestamp::from_unix_128(MaxContext, time, time_fraction);
-        
+        let ts = Timestamp::from_unix(MaxContext, time, time_fraction);
+
         let uuid = Uuid::new_v7(ts);
 
         assert_eq!(uuid.get_version(), Some(Version::SortRand));


### PR DESCRIPTION
We can generalize the `impl ClockSequence<Output = u16>` APIs to `impl ClockSequence<Output = impl Into<u128>>` without major breakage so don't need to introduce new APIs for them. The `Timestamp::from_unix_time` API is new, so we can generalize it too before we release it.