### PR TITLE
Prepare for 1.9.0 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ homepage = "https://github.com/uuid-rs/uuid"
 name = "uuid"
 readme = "README.md"
 repository = "https://github.com/uuid-rs/uuid"
-version = "1.8.0" # remember to update html_root_url in lib.rs
+version = "1.9.0" # remember to update html_root_url in lib.rs
 rust-version = "1.60.0"
 
 [package.metadata.docs.rs]
@@ -149,7 +149,7 @@ version = "1"
 
 # Public: Re-exported
 [dependencies.uuid-macro-internal]
-version = "1.8.0"
+version = "1.9.0"
 path = "macros"
 optional = true
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Add the following to your `Cargo.toml`:
 
 ```toml
 [dependencies.uuid]
-version = "1.8.0"
+version = "1.9.0"
 features = [
     "v4",                # Lets you generate random UUIDs
     "fast-rng",          # Use a faster (but still sufficiently random) RNG
@@ -65,11 +65,11 @@ assert_eq!(Some(Version::Random), my_uuid.get_version());
 If you'd like to parse UUIDs _really_ fast, check out the [`uuid-simd`](https://github.com/nugine/uuid-simd)
 library.
 
-For more details on using `uuid`, [see the library documentation](https://docs.rs/uuid/1.8.0/uuid).
+For more details on using `uuid`, [see the library documentation](https://docs.rs/uuid/1.9.0/uuid).
 
 ## References
 
-* [`uuid` library docs](https://docs.rs/uuid/1.8.0/uuid).
+* [`uuid` library docs](https://docs.rs/uuid/1.9.0/uuid).
 * [Wikipedia: Universally Unique Identifier](http://en.wikipedia.org/wiki/Universally_unique_identifier).
 * [RFC 9562: Universally Unique IDentifiers (UUID)](https://www.ietf.org/rfc/rfc9562.html).
 

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uuid-macro-internal"
-version = "1.8.0"
+version = "1.9.0"
 edition = "2018"
 authors = [
     "QnnOkabayashi"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@
 //!
 //! ```toml
 //! [dependencies.uuid]
-//! version = "1.8.0"
+//! version = "1.9.0"
 //! features = [
 //!     "v4",                # Lets you generate random UUIDs
 //!     "fast-rng",          # Use a faster (but still sufficiently random) RNG
@@ -138,7 +138,7 @@
 //!
 //! ```toml
 //! [dependencies.uuid]
-//! version = "1.8.0"
+//! version = "1.9.0"
 //! features = [
 //!     "v4",
 //!     "v7",
@@ -153,7 +153,7 @@
 //!
 //! ```toml
 //! [dependencies.uuid]
-//! version = "1.8.0"
+//! version = "1.9.0"
 //! default-features = false
 //! ```
 //!
@@ -211,7 +211,7 @@
 #![doc(
     html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
     html_favicon_url = "https://www.rust-lang.org/favicon.ico",
-    html_root_url = "https://docs.rs/uuid/1.8.0"
+    html_root_url = "https://docs.rs/uuid/1.9.0"
 )]
 
 #[cfg(any(feature = "std", test))]


### PR DESCRIPTION
## What's Changed
* Add a get_node_id method for v1 and v6 UUIDs by @KodrAus in https://github.com/uuid-rs/uuid/pull/748
* Update atomic and zerocopy to latest by @KodrAus in https://github.com/uuid-rs/uuid/pull/750
* Add repository field to uuid-macro-internal crate by @paolobarbolini in https://github.com/uuid-rs/uuid/pull/752
* update docs to updated RFC (from 4122 to 9562) by @Mikopet in https://github.com/uuid-rs/uuid/pull/753
* Support counters in v7 UUIDs by @KodrAus in https://github.com/uuid-rs/uuid/pull/755
