### PR TITLE
Avoid taking the shared lock when getting usable bits in Uuid::now_v7

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ v3 = ["md5"]
 v4 = ["rng"]
 v5 = ["sha1"]
 v6 = ["atomic"]
-v7 = ["atomic", "rng"]
+v7 = ["rng"]
 v8 = []
 
 js = ["dep:wasm-bindgen", "getrandom?/js"]


### PR DESCRIPTION
We previously would take the global lock when getting the number of bits the counter occupies in `Uuid::now_v7()`, despite this value being a constant.

As expected, it does reduce the cost of `Uuid::now_v7()`. On my M1 MacBook Pro:

Before:

```
test now_v7            ... bench:          61.51 ns/iter (+/- 0.83)
```

After:

```
test now_v7            ... bench:          55.67 ns/iter (+/- 2.43)
```