### PR TITLE
Use const identifier in uuid macro

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -4,7 +4,7 @@ macro_rules! define_uuid_macro {
         #[cfg(feature = "macro-diagnostics")]
         #[macro_export]
         macro_rules! uuid {
-            ($uuid:ident) => {{
+            ($uuid:expr) => {{
                 const OUTPUT: $crate::Uuid = match $crate::Uuid::try_parse($uuid) {
                     $crate::__macro_support::Ok(u) => u,
                     $crate::__macro_support::Err(_) => panic!("invalid UUID"),

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -20,6 +20,13 @@ macro_rules! define_uuid_macro {
                 };
                 OUTPUT
             }};
+            ($uuid:ident) => {{
+                const OUTPUT: $crate::Uuid = match $crate::Uuid::try_parse($uuid) {
+                    $crate::__macro_support::Ok(u) => u,
+                    $crate::__macro_support::Err(_) => panic!("invalid UUID"),
+                };
+                OUTPUT
+            }};
         }
     }
 }
@@ -50,6 +57,12 @@ define_uuid_macro! {
 /// # use uuid::uuid;
 /// let uuid = uuid!("urn:uuid:F9168C5E-CEB2-4faa-B6BF-329BF39FA1E4");
 /// ```
+/// Using a const variable:
+/// ```
+/// # use uuid::uuid;
+/// const UUID_STR: &str = "12345678-1234-5678-1234-567812345678";
+/// let UUID = uuid!(UUID_STR);
+/// ```
 ///
 /// ## Compilation Failures
 ///
@@ -69,23 +82,6 @@ define_uuid_macro! {
 ///     |
 ///     |     let id = uuid!("F9168C5E-ZEB2-4FAA-B6BF-329BF39FA1E4");
 ///     |                              ^
-/// ```
-///
-/// Tokens that aren't string literals are also rejected:
-///
-/// ```compile_fail
-/// # use uuid::uuid;
-/// let uuid_str: &str = "550e8400e29b41d4a716446655440000";
-/// let uuid = uuid!(uuid_str);
-/// ```
-///
-/// Provides the following compilation error:
-///
-/// ```txt
-/// error: expected string literal
-///   |
-///   |     let uuid = uuid!(uuid_str);
-///   |                      ^^^^^^^^
 /// ```
 ///
 /// [uuid::Uuid]: https://docs.rs/uuid/*/uuid/struct.Uuid.html

--- a/src/macros.rs
+++ b/src/macros.rs
@@ -4,6 +4,13 @@ macro_rules! define_uuid_macro {
         #[cfg(feature = "macro-diagnostics")]
         #[macro_export]
         macro_rules! uuid {
+            ($uuid:ident) => {{
+                const OUTPUT: $crate::Uuid = match $crate::Uuid::try_parse($uuid) {
+                    $crate::__macro_support::Ok(u) => u,
+                    $crate::__macro_support::Err(_) => panic!("invalid UUID"),
+                };
+                OUTPUT
+            }};
             ($uuid:literal) => {{
                 $crate::Uuid::from_bytes($crate::uuid_macro_internal::parse_lit!($uuid))
             }};
@@ -13,14 +20,7 @@ macro_rules! define_uuid_macro {
         #[cfg(not(feature = "macro-diagnostics"))]
         #[macro_export]
         macro_rules! uuid {
-            ($uuid:literal) => {{
-                const OUTPUT: $crate::Uuid = match $crate::Uuid::try_parse($uuid) {
-                    $crate::__macro_support::Ok(u) => u,
-                    $crate::__macro_support::Err(_) => panic!("invalid UUID"),
-                };
-                OUTPUT
-            }};
-            ($uuid:ident) => {{
+            ($uuid:expr) => {{
                 const OUTPUT: $crate::Uuid = match $crate::Uuid::try_parse($uuid) {
                     $crate::__macro_support::Ok(u) => u,
                     $crate::__macro_support::Err(_) => panic!("invalid UUID"),


### PR DESCRIPTION
The code below works when the user doesn't enable `macro-diagnostics` feature.

It's not possible to convert the value of identifier into a string literal at compile time, but is there another way we can go about this so we can give more details when this feature is enabled. 

If not, we can just paste the same code inside the macro where macro-diagnostics is enabled so that at least there wouldn't be a compile time error.
```rust
($uuid:ident) => {{
    const OUTPUT: $crate::Uuid = match $crate::Uuid::try_parse($uuid) {
        $crate::__macro_support::Ok(u) => u,
        $crate::__macro_support::Err(_) => panic!("invalid UUID"),
    };
    OUTPUT
}};
```

Closes #756