### PR TITLE
deps: replace rand with fastrand for fast-rng feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -71,7 +71,7 @@ v8 = []
 js = ["dep:wasm-bindgen", "getrandom?/js"]
 
 rng = ["dep:getrandom"]
-fast-rng = ["rng", "dep:rand"]
+fast-rng = ["rng", "dep:fastrand"]
 
 sha1 = ["dep:sha1_smol"]
 md5 = ["dep:md-5"]
@@ -131,9 +131,9 @@ optional = true
 version = "0.2"
 
 # Private
-[dependencies.rand]
+[dependencies.fastrand]
 optional = true
-version = "0.8"
+version = "2.2"
 
 # Private
 [dependencies.md-5]

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -14,7 +14,7 @@ pub(crate) fn u128() -> u128 {
 
     #[cfg(feature = "fast-rng")]
     {
-        rand::random()
+        fastrand::u128()
     }
 }
 
@@ -34,7 +34,7 @@ pub(crate) fn u16() -> u16 {
 
     #[cfg(feature = "fast-rng")]
     {
-        rand::random()
+        fastrand::u16()
     }
 }
 
@@ -54,6 +54,6 @@ pub(crate) fn u64() -> u64 {
 
     #[cfg(feature = "fast-rng")]
     {
-        rand::random()
+        fastrand::u64()
     }
 }


### PR DESCRIPTION
Replace the `rand` crate with `fastrand` in the `fast-rng` feature path. `fastrand` is a simpler and lighter-weight RNG implementation that better suits the needs of the `fast-rng` feature.