### PR TITLE
Fix links to namespaces in documentation

### DIFF
--- a/src/v5.rs
+++ b/src/v5.rs
@@ -29,10 +29,10 @@ impl Uuid {
     /// * [UUID Version 5 in RFC 9562](https://www.ietf.org/rfc/rfc9562.html#section-5.5)
     /// * [Name-Based UUID Generation in RFC 9562](https://www.ietf.org/rfc/rfc9562.html#section-6.5)
     ///
-    /// [`NAMESPACE_DNS`]: struct.Uuid.html#associatedconst.NAMESPACE_DNS
-    /// [`NAMESPACE_OID`]: struct.Uuid.html#associatedconst.NAMESPACE_OID
-    /// [`NAMESPACE_URL`]: struct.Uuid.html#associatedconst.NAMESPACE_URL
-    /// [`NAMESPACE_X500`]: struct.Uuid.html#associatedconst.NAMESPACE_X500
+    /// [`NAMESPACE_DNS`]: struct.Uuid.html#associatedconstant.NAMESPACE_DNS
+    /// [`NAMESPACE_OID`]: struct.Uuid.html#associatedconstant.NAMESPACE_OID
+    /// [`NAMESPACE_URL`]: struct.Uuid.html#associatedconstant.NAMESPACE_URL
+    /// [`NAMESPACE_X500`]: struct.Uuid.html#associatedconstant.NAMESPACE_X500
     pub fn new_v5(namespace: &Uuid, name: &[u8]) -> Uuid {
         crate::Builder::from_sha1_bytes(crate::sha1::hash(namespace.as_bytes(), name)).into_uuid()
     }


### PR DESCRIPTION
They're correct for [`Uuid::new_v3`](https://docs.rs/uuid/1.12.0/uuid/struct.Uuid.html#method.new_v3) but not for [`Uuid::new_v5`](https://docs.rs/uuid/1.12.0/uuid/struct.Uuid.html#method.new_v5).