### PR TITLE
Prepare for 1.13.0 release

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ homepage = "https://github.com/uuid-rs/uuid"
 name = "uuid"
 readme = "README.md"
 repository = "https://github.com/uuid-rs/uuid"
-version = "1.12.1" # remember to update html_root_url in lib.rs
+version = "1.13.0" # remember to update html_root_url in lib.rs
 rust-version = "1.63.0"
 
 [package.metadata.docs.rs]
@@ -135,7 +135,7 @@ optional = true
 [target.'cfg(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"))'.dependencies.uuid-rng-internal-lib]
 # Work-around lack of support for both `dep:x` and `x/` in MSRV
 package = "uuid-rng-internal"
-version = "1.12.1"
+version = "1.13.0"
 path = "rng"
 optional = true
 
@@ -158,7 +158,7 @@ version = "1"
 
 # Public: Re-exported
 [dependencies.uuid-macro-internal]
-version = "1.12.1"
+version = "1.13.0"
 path = "macros"
 optional = true
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Add the following to your `Cargo.toml`:
 
 ```toml
 [dependencies.uuid]
-version = "1.12.1"
+version = "1.13.0"
 features = [
     "v4",                # Lets you generate random UUIDs
     "fast-rng",          # Use a faster (but still sufficiently random) RNG
@@ -65,11 +65,11 @@ assert_eq!(Some(Version::Random), my_uuid.get_version());
 If you'd like to parse UUIDs _really_ fast, check out the [`uuid-simd`](https://github.com/nugine/uuid-simd)
 library.
 
-For more details on using `uuid`, [see the library documentation](https://docs.rs/uuid/1.12.1/uuid).
+For more details on using `uuid`, [see the library documentation](https://docs.rs/uuid/1.13.0/uuid).
 
 ## References
 
-* [`uuid` library docs](https://docs.rs/uuid/1.12.1/uuid).
+* [`uuid` library docs](https://docs.rs/uuid/1.13.0/uuid).
 * [Wikipedia: Universally Unique Identifier](http://en.wikipedia.org/wiki/Universally_unique_identifier).
 * [RFC 9562: Universally Unique IDentifiers (UUID)](https://www.ietf.org/rfc/rfc9562.html).
 

--- a/macros/Cargo.toml
+++ b/macros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uuid-macro-internal"
-version = "1.12.1"
+version = "1.13.0"
 edition = "2018"
 authors = [
     "QnnOkabayashi"

--- a/rng/Cargo.toml
+++ b/rng/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "uuid-rng-internal"
-version = "1.12.1"
+version = "1.13.0"
 edition = "2018"
 authors = [
     "uuid-rs contributors"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -38,7 +38,7 @@
 //!
 //! ```toml
 //! [dependencies.uuid]
-//! version = "1.12.1"
+//! version = "1.13.0"
 //! features = [
 //!     "v4",                # Lets you generate random UUIDs
 //!     "fast-rng",          # Use a faster (but still sufficiently random) RNG
@@ -138,7 +138,7 @@
 //!
 //! ```toml
 //! [dependencies.uuid]
-//! version = "1.12.1"
+//! version = "1.13.0"
 //! features = [
 //!     "v4",
 //!     "v7",
@@ -153,7 +153,7 @@
 //!
 //! ```toml
 //! [dependencies.uuid]
-//! version = "1.12.1"
+//! version = "1.13.0"
 //! default-features = false
 //! ```
 //!
@@ -211,7 +211,7 @@
 #![doc(
     html_logo_url = "https://www.rust-lang.org/logos/rust-logo-128x128-blk-v2.png",
     html_favicon_url = "https://www.rust-lang.org/favicon.ico",
-    html_root_url = "https://docs.rs/uuid/1.12.1"
+    html_root_url = "https://docs.rs/uuid/1.13.0"
 )]
 
 #[cfg(any(feature = "std", test))]


### PR DESCRIPTION
## :warning: Potential Breakage

This release updates our version of `getrandom` to `0.3` and `rand` to `0.9`. It is a **potentially breaking change** for the following users:

1. Those in no-std environments enabling the `rng` feature (probably via `v4` or `v7`) and using `getrandom`'s APIs to configure a source of randomness on those platforms. These users can upgrade their version of `getrandom` and follow its new docs on configuring a backend.
2. Those in `wasm32-unknown-unknown` enabling the `rng` feature as above, but without also using the `js` feature. These users can upgrade their version of `getrandom` as above, and also enable the `rng-getrandom` or `rng-rand` feature of `uuid` to force it to be used.

If you're on `wasm32-unknown-unknown` and using the `js` feature, you shouldn't see any breakage. We've kept this behavior by vendoring in `getrandom`'s web-based backend.

## What's Changed
* Update `getrandom` to `0.3` and `rand` to `0.9` by @KodrAus in https://github.com/uuid-rs/uuid/pull/793