### PR TITLE
Fix `wasm32` with `atomics`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -133,6 +133,11 @@ jobs:
       - name: Fast RNG
         run: wasm-pack test --node -- --features "js v4 fast-rng"
 
+      - name: +atomics
+        env:
+          RUSTFLAGS: '-C target-feature=+atomics'
+        run: cargo check --target wasm32-unknown-unknown --features "$VERSION_FEATURES $DEP_FEATURES js"
+
       - name: rng-getrandom
         env:
           RUSTFLAGS: '--cfg getrandom_backend="wasm_js"'

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ v6 = ["atomic"]
 v7 = ["rng"]
 v8 = []
 
-js = ["dep:wasm-bindgen"]
+js = ["dep:wasm-bindgen", "dep:js-sys"]
 
 rng = ["dep:getrandom"]
 rng-getrandom = ["rng", "dep:getrandom", "uuid-rng-internal-lib", "uuid-rng-internal-lib/getrandom"]
@@ -171,6 +171,11 @@ version = "0.6"
 # Private
 [target.'cfg(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown"))'.dependencies.wasm-bindgen]
 version = "0.2"
+optional = true
+
+# Private
+[target.'cfg(all(target_arch = "wasm32", target_vendor = "unknown", target_os = "unknown", target_feature = "atomics"))'.dependencies.js-sys]
+version = "0.3"
 optional = true
 
 [dev-dependencies.bincode]

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -244,6 +244,9 @@ mod imp {
         */
 
         use wasm_bindgen::{prelude::wasm_bindgen, JsValue};
+    
+        #[cfg(target_feature = "atomics")]
+        use core::convert::TryInto;
 
         // Maximum buffer size allowed in `Crypto.getRandomValuesSize` is 65536 bytes.
         // See https://developer.mozilla.org/en-US/docs/Web/API/Crypto/getRandomValues
@@ -287,7 +290,7 @@ mod imp {
                     return false;
                 }
 
-                sub_buf.copy_to_uninit(chunk);
+                sub_buf.copy_to(chunk);
             }
 
             true


### PR DESCRIPTION
# Objective

- Fixes #796

# Solution

- Include `js_sys` explicitly when enabling the `js` feature on `wasm32` when compiling with the `atomics` `target_feature` enabled.
- Fix possibly outdated code from vendoring

# Notes

- `js_sys` was already in the dependency graph due to `wasm-bindgen`, it just needed to be exposed when compiling under the conditions described in the attached issue.
- This is not a breaking change and could be published as 1.13.1 to fix 1.13.0 failing to compile in the aforementioned conditions.