### PR TITLE
Add a compile_error when no source of randomness is available on wasm32-unknown-unknown

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,6 @@ Add the following to your `Cargo.toml`:
 version = "1.13.1"
 features = [
     "v4",                # Lets you generate random UUIDs
-    "fast-rng",          # Use a faster (but still sufficiently random) RNG
-    "macro-diagnostics", # Enable better diagnostics for compile-time UUIDs
 ]
 ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -107,9 +107,11 @@
 //!   `borsh`.
 //! * `arbitrary` - adds an `Arbitrary` trait implementation to `Uuid` for
 //!   fuzzing.
-//! * `fast-rng` - uses a faster algorithm for generating random UUIDs.
+//! * `fast-rng` - uses a faster algorithm for generating random UUIDs when available.
 //!   This feature requires more dependencies to compile, but is just as suitable for
 //!   UUIDs as the default algorithm.
+//! * `rng-rand` - forces `rand` as the backend for randomness.
+//! * `rng-getrandom` - forces `getrandom` as the backend for randomness.
 //! * `bytemuck` - adds a `Pod` trait implementation to `Uuid` for byte manipulation
 //!
 //! # Unstable features
@@ -166,9 +168,9 @@
 //! produce random bytes yourself and then pass them to [`Builder::from_random_bytes`]
 //! without enabling the `v4` or `v7` features.
 //!
-//! Versions of `uuid` `1.12` or earlier relied on `getrandom` for randomness, this
-//! is no longer guaranteed and configuring `getrandom`'s provider is not guaranteed
-//! to make other features relying on randomness work.
+//! If you're using `getrandom`, you can specify the `rng-getrandom` or `rng-rand`
+//! features of `uuid` and configure `getrandom`'s provider per its docs. `uuid`
+//! may upgrade its version of `getrandom` in minor releases.
 //!
 //! # Examples
 //!

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -1,4 +1,4 @@
-#![allow(dead_code)] // Keeps our cfg's from becoming too convoluted in here
+#![allow(dead_code, unused_imports)] // Keeps our cfg's from becoming too convoluted in here
 
 trait Rng {
     fn u128() -> u128;
@@ -100,7 +100,12 @@ mod imp {
     Random support for `wasm32-unknown-unknown`.
     */
 
+    #![allow(dead_code, unused_imports)] // Keeps our cfg's from becoming too convoluted in here
+
     use super::*;
+
+    #[cfg(all(not(feature = "js"), not(feature = "rng-getrandom"), not(feature = "rng-rand")))]
+    compile_error!("to use `uuid` on `wasm32-unknown-unknown`, specify a source of randomness using one of the `js`, `rng-getrandom`, or `rng-rand` features");
 
     // Using `rand`
     #[cfg(feature = "rng-rand")]


### PR DESCRIPTION
For #802 

If you're compiling on `wasm32-unknown-unknown` without the `js` feature, and without `rng-getrandom` we won't have any random backend available and will fail to compile with a wall of unhelpful errors.

This PR adds a note to enable one of the appropriate features to specify the source of randomness.