### PR TITLE
Add FromStr impls to the fmt structs

### DIFF
--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -11,9 +11,11 @@
 
 //! Adapters for alternative string formats.
 
+use core::str::FromStr;
+
 use crate::{
     std::{borrow::Borrow, fmt, ptr, str},
-    Uuid, Variant,
+    Error, Uuid, Variant,
 };
 
 #[cfg(feature = "std")]
@@ -826,6 +828,46 @@ impl Urn {
     /// ```
     pub const fn into_uuid(self) -> Uuid {
         self.0
+    }
+}
+
+impl FromStr for Hyphenated {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        crate::parser::parse_hyphenated(s.as_bytes())
+            .map(|b| Hyphenated(Uuid(b)))
+            .map_err(|invalid| invalid.into_err())
+    }
+}
+
+impl FromStr for Simple {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        crate::parser::parse_simple(s.as_bytes())
+            .map(|b| Simple(Uuid(b)))
+            .map_err(|invalid| invalid.into_err())
+    }
+}
+
+impl FromStr for Urn {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        crate::parser::parse_urn(s.as_bytes())
+            .map(|b| Urn(Uuid(b)))
+            .map_err(|invalid| invalid.into_err())
+    }
+}
+
+impl FromStr for Braced {
+    type Err = Error;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        crate::parser::parse_braced(s.as_bytes())
+            .map(|b| Braced(Uuid(b)))
+            .map_err(|invalid| invalid.into_err())
     }
 }
 

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -205,7 +205,7 @@ pub(crate) const fn parse_simple(s: &[u8]) -> Result<[u8; 16], InvalidUuid> {
 }
 
 #[inline]
-const fn parse_hyphenated(s: &[u8]) -> Result<[u8; 16], InvalidUuid> {
+pub(crate) const fn parse_hyphenated(s: &[u8]) -> Result<[u8; 16], InvalidUuid> {
     // This length check here removes all other bounds
     // checks in this function
     if s.len() != 36 {

--- a/src/rng.rs
+++ b/src/rng.rs
@@ -104,7 +104,11 @@ mod imp {
 
     use super::*;
 
-    #[cfg(all(not(feature = "js"), not(feature = "rng-getrandom"), not(feature = "rng-rand")))]
+    #[cfg(all(
+        not(feature = "js"),
+        not(feature = "rng-getrandom"),
+        not(feature = "rng-rand")
+    ))]
     compile_error!("to use `uuid` on `wasm32-unknown-unknown`, specify a source of randomness using one of the `js`, `rng-getrandom`, or `rng-rand` features");
 
     // Using `rand`
@@ -249,7 +253,7 @@ mod imp {
         */
 
         use wasm_bindgen::{prelude::wasm_bindgen, JsValue};
-    
+
         #[cfg(target_feature = "atomics")]
         use core::convert::TryInto;
 


### PR DESCRIPTION
### Use Case
My specific use case is that I want to take a `Uuid` in `Simple` form as a query parameter and track it with a [signal](https://docs.rs/leptos_router/latest/leptos_router/hooks/fn.query_signal.html) while using Leptos. I don't want to accept other forms of `Uuid` in the query parameter, and when I update the parameter myself, I want the `Simple` form to show up in the browser's address bar. Using the `FromStr` and `Display` impls of `Uuid` won't get me what I want.

You could argue that this is more an issue with the Leptos query signal API, but I think it's sensible enough and I suspect this is not the only case wherein someone might want to restrict their string representation of a `Uuid` to a single format.

### Implementation
What I've submitted here is just a naive implementation of the desired traits. It'd be nicer to incorporate this into the `impl_fmt_traits` macro, but I don't think there's a good way currently to get at the various parse fns (`parse_hyphenated`, `parse_simple`, etc.) from the macro input. One way to do it would be something like this:

```rust

// repeat the below impl for the other three formats, changing only which `parse_` fn is called

impl Simple {
    fn parse(bytes: &[u8]) -> Result<[u8; 16], InvalidUuid> {
        crate::parser::parse_simple(bytes)
    }
}

// and then add this to `impl_fmt_traits`

macro_rules! impl_fmt_traits {
    ($($T:ident<$($a:lifetime),*>),+) => {$(
        impl<$($a),*> core::str::FromStr for $T<$($a),*> {
            type Err = crate::error::Error;
            #[inline]
            fn from_str(s: &str) -> Result<Self, Self::Err> {
                $T::parse(s.as_bytes())
                    .map(|b| $T(Uuid(b)))
                    .map_err(|invalid| invalid.into_err())
            }
        }
        // the rest of this macro omitted for brevity
    )+}
}

```

but maybe y'all have a better idea for how to do this. If that looks good I can update this PR with those additions.