### PR TITLE
Add a manual `Debug` implementation for NonNilUUid

### DIFF
--- a/src/non_nil.rs
+++ b/src/non_nil.rs
@@ -38,13 +38,13 @@ pub struct NonNilUuid(NonZeroU128);
 
 impl fmt::Debug for NonNilUuid {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", Uuid::from(*self))
+        fmt::Debug::fmt(&Uuid::from(*self), f)
     }
 }
 
 impl fmt::Display for NonNilUuid {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "{}", Uuid::from(*self))
+        fmt::Display::fmt(&Uuid::from(*self), f)
     }
 }
 

--- a/src/non_nil.rs
+++ b/src/non_nil.rs
@@ -33,8 +33,14 @@ use crate::{
 /// may change. It is currently only guaranteed that `NonNilUuid` and `Option<NonNilUuid>`
 /// are the same size as `Uuid`.
 #[repr(transparent)]
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash)]
+#[derive(Copy, Clone, PartialEq, Eq, Hash)]
 pub struct NonNilUuid(NonZeroU128);
+
+impl fmt::Debug for NonNilUuid {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", Uuid::from(*self))
+    }
+}
 
 impl fmt::Display for NonNilUuid {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
@@ -138,5 +144,14 @@ mod tests {
 
         assert!(NonNilUuid::try_from(Uuid::nil()).is_err());
         assert!(NonNilUuid::new(Uuid::nil()).is_none());
+    }
+
+    #[test]
+    fn test_non_nil_formatting() {
+        let uuid = Uuid::from_u128(0x0123456789abcdef0123456789abcdef);
+        let non_nil = NonNilUuid::try_from(uuid).unwrap();
+
+        assert_eq!(format!("{uuid}"), format!("{non_nil}"));
+        assert_eq!(format!("{uuid:?}"), format!("{non_nil:?}"));
     }
 }


### PR DESCRIPTION
`NonNilUuid` currently has an automatic `Debug` trait implementation, resulting in an output that is not very useful:

```
NonNilUuid(1512366075204170929049582354406559215)
```

This PR adds a manual implementation of the `Debug` trait that properly formats the uuid, matching that of the `Uuid` type.