### PR TITLE
Support bincode 2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -81,6 +81,7 @@ md5 = ["dep:md-5"]
 atomic = ["dep:atomic"]
 
 borsh = ["dep:borsh", "dep:borsh-derive"]
+bincode2 = ["dep:bincode"]
 
 # Public: Used in trait impls on `Uuid`
 [dependencies.bytemuck]
@@ -103,6 +104,14 @@ version = "2"
 [dependencies.arbitrary]
 optional = true
 version = "1.1.3"
+
+# Public: Used in trait impls on `Uuid`
+[dependencies.bincode]
+default-features = false
+features = ["derive"]
+optional = true
+version = "2.0"
+
 
 # Public (unstable): Used in `zerocopy` derive
 # Unstable: also need RUSTFLAGS="--cfg uuid_unstable" to work

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -455,6 +455,7 @@ pub enum Variant {
     feature = "bytemuck",
     derive(bytemuck::Zeroable, bytemuck::Pod, bytemuck::TransparentWrapper)
 )]
+#[cfg_attr(feature = "bincode2", derive(bincode::Decode, bincode::Encode))]
 pub struct Uuid(Bytes);
 
 impl Uuid {


### PR DESCRIPTION
This PR adds a new feature (`bincode2`) that when enabled, derives [`Encode`](https://docs.rs/bincode/latest/bincode/enc/trait.Encode.html) and [`Decode`](https://docs.rs/bincode/latest/bincode/de/trait.Decode.html) for `Uuid`. See [this section of the migration guide](https://docs.rs/bincode/latest/bincode/migration_guide/index.html#bincode-derive-and-libraries) for bincode 2.
 