### PR TITLE
Remove some unsafe; stabilize zerocopy

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -104,13 +104,8 @@ version = "2"
 optional = true
 version = "1.1.3"
 
-# Public (unstable): Used in `zerocopy` derive
-# Unstable: also need RUSTFLAGS="--cfg uuid_unstable" to work
-# This feature may break between releases, or be removed entirely before
-# stabilization.
-# See: https://github.com/uuid-rs/uuid/issues/588
+# Public: Used in trait impls on `Uuid`
 [dependencies.zerocopy]
-optional = true
 version = "0.8"
 features = ["derive"]
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -431,8 +431,7 @@ impl Uuid {
     /// ```
     #[inline]
     pub fn from_bytes_ref(bytes: &Bytes) -> &Uuid {
-        // SAFETY: `Bytes` and `Uuid` have the same ABI
-        unsafe { &*(bytes as *const Bytes as *const Uuid) }
+        zerocopy::transmute_ref!(bytes)
     }
 
     // NOTE: There is no `from_u128_ref` because in little-endian

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -11,10 +11,12 @@
 
 //! Adapters for alternative string formats.
 
-use core::str::FromStr;
+use core::{convert::TryInto as _, str::FromStr};
+
+use zerocopy::{transmute_ref, FromBytes, Immutable, IntoBytes, KnownLayout, Unaligned};
 
 use crate::{
-    std::{borrow::Borrow, fmt, ptr, str},
+    std::{borrow::Borrow, fmt, str},
     Error, Uuid, Variant,
 };
 
@@ -67,25 +69,85 @@ impl fmt::UpperHex for Uuid {
 
 /// Format a [`Uuid`] as a hyphenated string, like
 /// `67e55044-10b1-426f-9247-bb680e5fe0c8`.
-#[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Default,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    IntoBytes,
+    FromBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+)]
 #[repr(transparent)]
 pub struct Hyphenated(Uuid);
 
 /// Format a [`Uuid`] as a simple string, like
 /// `67e5504410b1426f9247bb680e5fe0c8`.
-#[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Default,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    IntoBytes,
+    FromBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+)]
 #[repr(transparent)]
 pub struct Simple(Uuid);
 
 /// Format a [`Uuid`] as a URN string, like
 /// `urn:uuid:67e55044-10b1-426f-9247-bb680e5fe0c8`.
-#[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Default,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    IntoBytes,
+    FromBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+)]
 #[repr(transparent)]
 pub struct Urn(Uuid);
 
 /// Format a [`Uuid`] as a braced hyphenated string, like
 /// `{67e55044-10b1-426f-9247-bb680e5fe0c8}`.
-#[derive(Clone, Copy, Debug, Default, Eq, Hash, Ord, PartialEq, PartialOrd)]
+#[derive(
+    Clone,
+    Copy,
+    Debug,
+    Default,
+    Eq,
+    Hash,
+    Ord,
+    PartialEq,
+    PartialOrd,
+    IntoBytes,
+    FromBytes,
+    KnownLayout,
+    Immutable,
+    Unaligned,
+)]
 #[repr(transparent)]
 pub struct Braced(Uuid);
 
@@ -99,8 +161,7 @@ impl Uuid {
     /// Get a borrowed [`Hyphenated`] formatter.
     #[inline]
     pub fn as_hyphenated(&self) -> &Hyphenated {
-        // SAFETY: `Uuid` and `Hyphenated` have the same ABI
-        unsafe { &*(self as *const Uuid as *const Hyphenated) }
+        transmute_ref!(self)
     }
 
     /// Get a [`Simple`] formatter.
@@ -112,8 +173,7 @@ impl Uuid {
     /// Get a borrowed [`Simple`] formatter.
     #[inline]
     pub fn as_simple(&self) -> &Simple {
-        // SAFETY: `Uuid` and `Simple` have the same ABI
-        unsafe { &*(self as *const Uuid as *const Simple) }
+        transmute_ref!(self)
     }
 
     /// Get a [`Urn`] formatter.
@@ -125,8 +185,7 @@ impl Uuid {
     /// Get a borrowed [`Urn`] formatter.
     #[inline]
     pub fn as_urn(&self) -> &Urn {
-        // SAFETY: `Uuid` and `Urn` have the same ABI
-        unsafe { &*(self as *const Uuid as *const Urn) }
+        transmute_ref!(self)
     }
 
     /// Get a [`Braced`] formatter.
@@ -138,8 +197,7 @@ impl Uuid {
     /// Get a borrowed [`Braced`] formatter.
     #[inline]
     pub fn as_braced(&self) -> &Braced {
-        // SAFETY: `Uuid` and `Braced` have the same ABI
-        unsafe { &*(self as *const Uuid as *const Braced) }
+        transmute_ref!(self)
     }
 }
 
@@ -194,43 +252,46 @@ const fn format_hyphenated(src: &[u8; 16], upper: bool) -> [u8; 36] {
 #[inline]
 fn encode_simple<'b>(src: &[u8; 16], buffer: &'b mut [u8], upper: bool) -> &'b mut str {
     let buf = &mut buffer[..Simple::LENGTH];
-    let dst = buf.as_mut_ptr();
+    let buf: &mut [u8; Simple::LENGTH] = buf.try_into().unwrap();
+    *buf = format_simple(src, upper);
 
-    // SAFETY: `buf` is guaranteed to be at least `LEN` bytes
     // SAFETY: The encoded buffer is ASCII encoded
-    unsafe {
-        ptr::write(dst.cast(), format_simple(src, upper));
-        str::from_utf8_unchecked_mut(buf)
-    }
+    unsafe { str::from_utf8_unchecked_mut(buf) }
 }
 
 #[inline]
 fn encode_hyphenated<'b>(src: &[u8; 16], buffer: &'b mut [u8], upper: bool) -> &'b mut str {
     let buf = &mut buffer[..Hyphenated::LENGTH];
-    let dst = buf.as_mut_ptr();
+    let buf: &mut [u8; Hyphenated::LENGTH] = buf.try_into().unwrap();
+    *buf = format_hyphenated(src, upper);
 
-    // SAFETY: `buf` is guaranteed to be at least `LEN` bytes
     // SAFETY: The encoded buffer is ASCII encoded
-    unsafe {
-        ptr::write(dst.cast(), format_hyphenated(src, upper));
-        str::from_utf8_unchecked_mut(buf)
-    }
+    unsafe { str::from_utf8_unchecked_mut(buf) }
 }
 
 #[inline]
 fn encode_braced<'b>(src: &[u8; 16], buffer: &'b mut [u8], upper: bool) -> &'b mut str {
-    let buf = &mut buffer[..Braced::LENGTH];
-    buf[0] = b'{';
-    buf[Braced::LENGTH - 1] = b'}';
+    let buf = &mut buffer[..Hyphenated::LENGTH + 2];
+    let buf: &mut [u8; Hyphenated::LENGTH + 2] = buf.try_into().unwrap();
 
-    // SAFETY: `buf` is guaranteed to be at least `LEN` bytes
-    // SAFETY: The encoded buffer is ASCII encoded
-    unsafe {
-        let dst = buf.as_mut_ptr().add(1);
-
-        ptr::write(dst.cast(), format_hyphenated(src, upper));
-        str::from_utf8_unchecked_mut(buf)
+    #[derive(IntoBytes)]
+    #[repr(C)]
+    struct Braced {
+        open_curly: u8,
+        hyphenated: [u8; Hyphenated::LENGTH],
+        close_curly: u8,
     }
+
+    let braced = Braced {
+        open_curly: b'{',
+        hyphenated: format_hyphenated(src, upper),
+        close_curly: b'}',
+    };
+
+    *buf = zerocopy::transmute!(braced);
+
+    // SAFETY: The encoded buffer is ASCII encoded
+    unsafe { str::from_utf8_unchecked_mut(buf) }
 }
 
 #[inline]
@@ -238,14 +299,12 @@ fn encode_urn<'b>(src: &[u8; 16], buffer: &'b mut [u8], upper: bool) -> &'b mut 
     let buf = &mut buffer[..Urn::LENGTH];
     buf[..9].copy_from_slice(b"urn:uuid:");
 
-    // SAFETY: `buf` is guaranteed to be at least `LEN` bytes
-    // SAFETY: The encoded buffer is ASCII encoded
-    unsafe {
-        let dst = buf.as_mut_ptr().add(9);
+    let dst = &mut buf[9..(9 + Hyphenated::LENGTH)];
+    let dst: &mut [u8; Hyphenated::LENGTH] = dst.try_into().unwrap();
+    *dst = format_hyphenated(src, upper);
 
-        ptr::write(dst.cast(), format_hyphenated(src, upper));
-        str::from_utf8_unchecked_mut(buf)
-    }
+    // SAFETY: The encoded buffer is ASCII encoded
+    unsafe { str::from_utf8_unchecked_mut(buf) }
 }
 
 impl Hyphenated {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -439,22 +439,19 @@ pub enum Variant {
 #[repr(transparent)]
 // NOTE: Also check `NonNilUuid` when ading new derives here
 #[cfg_attr(
-    all(uuid_unstable, feature = "zerocopy"),
-    derive(
-        zerocopy::IntoBytes,
-        zerocopy::FromBytes,
-        zerocopy::KnownLayout,
-        zerocopy::Immutable,
-        zerocopy::Unaligned
-    )
-)]
-#[cfg_attr(
     feature = "borsh",
     derive(borsh_derive::BorshDeserialize, borsh_derive::BorshSerialize)
 )]
 #[cfg_attr(
     feature = "bytemuck",
     derive(bytemuck::Zeroable, bytemuck::Pod, bytemuck::TransparentWrapper)
+)]
+#[derive(
+    zerocopy::IntoBytes,
+    zerocopy::FromBytes,
+    zerocopy::KnownLayout,
+    zerocopy::Immutable,
+    zerocopy::Unaligned,
 )]
 pub struct Uuid(Bytes);
 


### PR DESCRIPTION
Remove a number of `unsafe` blocks, replacing them with uses of zerocopy. In order to do this, we stabilize zerocopy as a (non-optional) dependency.

Closes #588