### PR TITLE
Wrap the error type used in time conversions

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -286,7 +286,7 @@ impl Uuid {
     /// ```
     pub fn from_slice(b: &[u8]) -> Result<Uuid, Error> {
         if b.len() != 16 {
-            return Err(Error(ErrorKind::ByteLength { len: b.len() }));
+            return Err(Error(ErrorKind::ParseByteLength { len: b.len() }));
         }
 
         let mut bytes: Bytes = [0; 16];
@@ -327,7 +327,7 @@ impl Uuid {
     /// ```
     pub fn from_slice_le(b: &[u8]) -> Result<Uuid, Error> {
         if b.len() != 16 {
-            return Err(Error(ErrorKind::ByteLength { len: b.len() }));
+            return Err(Error(ErrorKind::ParseByteLength { len: b.len() }));
         }
 
         let mut bytes: Bytes = [0; 16];

--- a/src/error.rs
+++ b/src/error.rs
@@ -36,7 +36,7 @@ pub(crate) enum ErrorKind {
     Nil,
     /// A system time was invalid.
     #[cfg(feature = "std")]
-    InvalidSystemTime(crate::std::string::String),
+    InvalidSystemTime(&'static str),
 }
 
 /// A string that is guaranteed to fail to parse to a [`Uuid`].

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,31 +9,34 @@ pub(crate) enum ErrorKind {
     /// Invalid character in the [`Uuid`] string.
     ///
     /// [`Uuid`]: ../struct.Uuid.html
-    Char { character: char, index: usize },
+    ParseChar { character: char, index: usize },
     /// A simple [`Uuid`] didn't contain 32 characters.
     ///
     /// [`Uuid`]: ../struct.Uuid.html
-    SimpleLength { len: usize },
+    ParseSimpleLength { len: usize },
     /// A byte array didn't contain 16 bytes
-    ByteLength { len: usize },
+    ParseByteLength { len: usize },
     /// A hyphenated [`Uuid`] didn't contain 5 groups
     ///
     /// [`Uuid`]: ../struct.Uuid.html
-    GroupCount { count: usize },
+    ParseGroupCount { count: usize },
     /// A hyphenated [`Uuid`] had a group that wasn't the right length
     ///
     /// [`Uuid`]: ../struct.Uuid.html
-    GroupLength {
+    ParseGroupLength {
         group: usize,
         len: usize,
         index: usize,
     },
     /// The input was not a valid UTF8 string
-    InvalidUTF8,
+    ParseInvalidUTF8,
+    /// Some other parsing error occurred.
+    ParseOther,
     /// The UUID is nil.
     Nil,
-    /// Some other error occurred.
-    Other,
+    /// A system time was invalid.
+    #[cfg(feature = "std")]
+    InvalidSystemTime(crate::std::string::String),
 }
 
 /// A string that is guaranteed to fail to parse to a [`Uuid`].
@@ -52,7 +55,7 @@ impl<'a> InvalidUuid<'a> {
         // Check whether or not the input was ever actually a valid UTF8 string
         let input_str = match std::str::from_utf8(self.0) {
             Ok(s) => s,
-            Err(_) => return Error(ErrorKind::InvalidUTF8),
+            Err(_) => return Error(ErrorKind::ParseInvalidUTF8),
         };
 
         let (uuid_str, offset, simple) = match input_str.as_bytes() {
@@ -74,7 +77,7 @@ impl<'a> InvalidUuid<'a> {
             let byte = character as u8;
             if character as u32 - byte as u32 > 0 {
                 // Multibyte char
-                return Error(ErrorKind::Char {
+                return Error(ErrorKind::ParseChar {
                     character,
                     index: index + offset + 1,
                 });
@@ -86,7 +89,7 @@ impl<'a> InvalidUuid<'a> {
                 hyphen_count += 1;
             } else if !byte.is_ascii_hexdigit() {
                 // Non-hex char
-                return Error(ErrorKind::Char {
+                return Error(ErrorKind::ParseChar {
                     character: byte as char,
                     index: index + offset + 1,
                 });
@@ -97,13 +100,13 @@ impl<'a> InvalidUuid<'a> {
             // This means that we tried and failed to parse a simple uuid.
             // Since we verified that all the characters are valid, this means
             // that it MUST have an invalid length.
-            Error(ErrorKind::SimpleLength {
+            Error(ErrorKind::ParseSimpleLength {
                 len: input_str.len(),
             })
         } else if hyphen_count != 4 {
             // We tried to parse a hyphenated variant, but there weren't
             // 5 groups (4 hyphen splits).
-            Error(ErrorKind::GroupCount {
+            Error(ErrorKind::ParseGroupCount {
                 count: hyphen_count + 1,
             })
         } else {
@@ -111,7 +114,7 @@ impl<'a> InvalidUuid<'a> {
             const BLOCK_STARTS: [usize; 5] = [0, 9, 14, 19, 24];
             for i in 0..4 {
                 if group_bounds[i] != BLOCK_STARTS[i + 1] - 1 {
-                    return Error(ErrorKind::GroupLength {
+                    return Error(ErrorKind::ParseGroupLength {
                         group: i,
                         len: group_bounds[i] - BLOCK_STARTS[i],
                         index: offset + BLOCK_STARTS[i] + 1,
@@ -120,7 +123,7 @@ impl<'a> InvalidUuid<'a> {
             }
 
             // The last group must be too long
-            Error(ErrorKind::GroupLength {
+            Error(ErrorKind::ParseGroupLength {
                 group: 4,
                 len: input_str.len() - BLOCK_STARTS[4],
                 index: offset + BLOCK_STARTS[4] + 1,
@@ -133,25 +136,25 @@ impl<'a> InvalidUuid<'a> {
 impl fmt::Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self.0 {
-            ErrorKind::Char {
+            ErrorKind::ParseChar {
                 character, index, ..
             } => {
                 write!(f, "invalid character: expected an optional prefix of `urn:uuid:` followed by [0-9a-fA-F-], found `{}` at {}", character, index)
             }
-            ErrorKind::SimpleLength { len } => {
+            ErrorKind::ParseSimpleLength { len } => {
                 write!(
                     f,
                     "invalid length: expected length 32 for simple format, found {}",
                     len
                 )
             }
-            ErrorKind::ByteLength { len } => {
+            ErrorKind::ParseByteLength { len } => {
                 write!(f, "invalid length: expected 16 bytes, found {}", len)
             }
-            ErrorKind::GroupCount { count } => {
+            ErrorKind::ParseGroupCount { count } => {
                 write!(f, "invalid group count: expected 5, found {}", count)
             }
-            ErrorKind::GroupLength { group, len, .. } => {
+            ErrorKind::ParseGroupLength { group, len, .. } => {
                 let expected = [8, 4, 4, 4, 12][group];
                 write!(
                     f,
@@ -159,9 +162,11 @@ impl fmt::Display for Error {
                     group, expected, len
                 )
             }
-            ErrorKind::InvalidUTF8 => write!(f, "non-UTF8 input"),
+            ErrorKind::ParseInvalidUTF8 => write!(f, "non-UTF8 input"),
             ErrorKind::Nil => write!(f, "the UUID is nil"),
-            ErrorKind::Other => write!(f, "failed to parse a UUID"),
+            ErrorKind::ParseOther => write!(f, "failed to parse a UUID"),
+            #[cfg(feature = "std")]
+            ErrorKind::InvalidSystemTime(ref e) => write!(f, "the system timestamp is invalid: {e}"),
         }
     }
 }
@@ -171,5 +176,5 @@ mod std_support {
     use super::*;
     use crate::std::error;
 
-    impl error::Error for Error {}
+    impl error::Error for Error { }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -139,7 +139,7 @@ impl Uuid {
             Ok(bytes) => Ok(Uuid::from_bytes(bytes)),
             // If parsing fails then we don't know exactly what went wrong
             // In this case, we just return a generic error
-            Err(_) => Err(Error(ErrorKind::Other)),
+            Err(_) => Err(Error(ErrorKind::ParseOther)),
         }
     }
 }
@@ -341,12 +341,12 @@ mod tests {
         // Invalid
         assert_eq!(
             Uuid::parse_str(""),
-            Err(Error(ErrorKind::SimpleLength { len: 0 }))
+            Err(Error(ErrorKind::ParseSimpleLength { len: 0 }))
         );
 
         assert_eq!(
             Uuid::parse_str("!"),
-            Err(Error(ErrorKind::Char {
+            Err(Error(ErrorKind::ParseChar {
                 character: '!',
                 index: 1,
             }))
@@ -354,7 +354,7 @@ mod tests {
 
         assert_eq!(
             Uuid::parse_str("F9168C5E-CEB2-4faa-B6BF-329BF39FA1E45"),
-            Err(Error(ErrorKind::GroupLength {
+            Err(Error(ErrorKind::ParseGroupLength {
                 group: 4,
                 len: 13,
                 index: 25,
@@ -363,7 +363,7 @@ mod tests {
 
         assert_eq!(
             Uuid::parse_str("F9168C5E-CEB2-4faa-BBF-329BF39FA1E4"),
-            Err(Error(ErrorKind::GroupLength {
+            Err(Error(ErrorKind::ParseGroupLength {
                 group: 3,
                 len: 3,
                 index: 20,
@@ -372,7 +372,7 @@ mod tests {
 
         assert_eq!(
             Uuid::parse_str("F9168C5E-CEB2-4faa-BGBF-329BF39FA1E4"),
-            Err(Error(ErrorKind::Char {
+            Err(Error(ErrorKind::ParseChar {
                 character: 'G',
                 index: 21,
             }))
@@ -380,27 +380,27 @@ mod tests {
 
         assert_eq!(
             Uuid::parse_str("F9168C5E-CEB2F4faaFB6BFF329BF39FA1E4"),
-            Err(Error(ErrorKind::GroupCount { count: 2 }))
+            Err(Error(ErrorKind::ParseGroupCount { count: 2 }))
         );
 
         assert_eq!(
             Uuid::parse_str("F9168C5E-CEB2-4faaFB6BFF329BF39FA1E4"),
-            Err(Error(ErrorKind::GroupCount { count: 3 }))
+            Err(Error(ErrorKind::ParseGroupCount { count: 3 }))
         );
 
         assert_eq!(
             Uuid::parse_str("F9168C5E-CEB2-4faa-B6BFF329BF39FA1E4"),
-            Err(Error(ErrorKind::GroupCount { count: 4 }))
+            Err(Error(ErrorKind::ParseGroupCount { count: 4 }))
         );
 
         assert_eq!(
             Uuid::parse_str("F9168C5E-CEB2-4faa"),
-            Err(Error(ErrorKind::GroupCount { count: 3 }))
+            Err(Error(ErrorKind::ParseGroupCount { count: 3 }))
         );
 
         assert_eq!(
             Uuid::parse_str("F9168C5E-CEB2-4faaXB6BFF329BF39FA1E4"),
-            Err(Error(ErrorKind::Char {
+            Err(Error(ErrorKind::ParseChar {
                 character: 'X',
                 index: 19,
             }))
@@ -408,7 +408,7 @@ mod tests {
 
         assert_eq!(
             Uuid::parse_str("{F9168C5E-CEB2-4faa9B6BFF329BF39FA1E41"),
-            Err(Error(ErrorKind::Char {
+            Err(Error(ErrorKind::ParseChar {
                 character: '{',
                 index: 1,
             }))
@@ -416,12 +416,12 @@ mod tests {
 
         assert_eq!(
             Uuid::parse_str("{F9168C5E-CEB2-4faa9B6BFF329BF39FA1E41}"),
-            Err(Error(ErrorKind::GroupCount { count: 3 }))
+            Err(Error(ErrorKind::ParseGroupCount { count: 3 }))
         );
 
         assert_eq!(
             Uuid::parse_str("F9168C5E-CEB-24fa-eB6BFF32-BF39FA1E4"),
-            Err(Error(ErrorKind::GroupLength {
+            Err(Error(ErrorKind::ParseGroupLength {
                 group: 1,
                 len: 3,
                 index: 10,
@@ -432,7 +432,7 @@ mod tests {
         // //
         assert_eq!(
             Uuid::parse_str("01020304-1112-2122-3132-41424344"),
-            Err(Error(ErrorKind::GroupLength {
+            Err(Error(ErrorKind::ParseGroupLength {
                 group: 4,
                 len: 8,
                 index: 25,
@@ -441,17 +441,17 @@ mod tests {
 
         assert_eq!(
             Uuid::parse_str("67e5504410b1426f9247bb680e5fe0c"),
-            Err(Error(ErrorKind::SimpleLength { len: 31 }))
+            Err(Error(ErrorKind::ParseSimpleLength { len: 31 }))
         );
 
         assert_eq!(
             Uuid::parse_str("67e5504410b1426f9247bb680e5fe0c88"),
-            Err(Error(ErrorKind::SimpleLength { len: 33 }))
+            Err(Error(ErrorKind::ParseSimpleLength { len: 33 }))
         );
 
         assert_eq!(
             Uuid::parse_str("67e5504410b1426f9247bb680e5fe0cg8"),
-            Err(Error(ErrorKind::Char {
+            Err(Error(ErrorKind::ParseChar {
                 character: 'g',
                 index: 32,
             }))
@@ -459,7 +459,7 @@ mod tests {
 
         assert_eq!(
             Uuid::parse_str("67e5504410b1426%9247bb680e5fe0c8"),
-            Err(Error(ErrorKind::Char {
+            Err(Error(ErrorKind::ParseChar {
                 character: '%',
                 index: 16,
             }))
@@ -467,22 +467,22 @@ mod tests {
 
         assert_eq!(
             Uuid::parse_str("231231212212423424324323477343246663"),
-            Err(Error(ErrorKind::SimpleLength { len: 36 }))
+            Err(Error(ErrorKind::ParseSimpleLength { len: 36 }))
         );
 
         assert_eq!(
             Uuid::parse_str("{00000000000000000000000000000000}"),
-            Err(Error(ErrorKind::GroupCount { count: 1 }))
+            Err(Error(ErrorKind::ParseGroupCount { count: 1 }))
         );
 
         assert_eq!(
             Uuid::parse_str("67e5504410b1426f9247bb680e5fe0c"),
-            Err(Error(ErrorKind::SimpleLength { len: 31 }))
+            Err(Error(ErrorKind::ParseSimpleLength { len: 31 }))
         );
 
         assert_eq!(
             Uuid::parse_str("67e550X410b1426f9247bb680e5fe0cd"),
-            Err(Error(ErrorKind::Char {
+            Err(Error(ErrorKind::ParseChar {
                 character: 'X',
                 index: 7,
             }))
@@ -490,12 +490,12 @@ mod tests {
 
         assert_eq!(
             Uuid::parse_str("67e550-4105b1426f9247bb680e5fe0c"),
-            Err(Error(ErrorKind::GroupCount { count: 2 }))
+            Err(Error(ErrorKind::ParseGroupCount { count: 2 }))
         );
 
         assert_eq!(
             Uuid::parse_str("F9168C5E-CEB2-4faa-B6BF1-02BF39FA1E4"),
-            Err(Error(ErrorKind::GroupLength {
+            Err(Error(ErrorKind::ParseGroupLength {
                 group: 3,
                 len: 5,
                 index: 20,
@@ -504,7 +504,7 @@ mod tests {
 
         assert_eq!(
             Uuid::parse_str("\u{bcf3c}"),
-            Err(Error(ErrorKind::Char {
+            Err(Error(ErrorKind::ParseChar {
                 character: '\u{bcf3c}',
                 index: 1
             }))

--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -196,9 +196,7 @@ impl std::convert::TryFrom<std::time::SystemTime> for Timestamp {
     /// This method will fail if the system time is earlier than the Unix Epoch.
     /// On some platforms it may panic instead.
     fn try_from(st: std::time::SystemTime) -> Result<Self, Self::Error> {
-        use crate::std::string::ToString;
-
-        let dur = st.duration_since(std::time::UNIX_EPOCH).map_err(|e| crate::Error(crate::error::ErrorKind::InvalidSystemTime(e.to_string())))?;
+        let dur = st.duration_since(std::time::UNIX_EPOCH).map_err(|_| crate::Error(crate::error::ErrorKind::InvalidSystemTime("unable to convert the system tie into a Unix timestamp")))?;
 
         Ok(Self::from_unix_time(
             dur.as_secs(),
@@ -1260,10 +1258,7 @@ mod test_conversion {
     fn from_system_time_before_epoch() {
         let before_epoch = match SystemTime::UNIX_EPOCH.checked_sub(Duration::from_nanos(1_000)) {
             Some(st) => st,
-            None => {
-                println!("SystemTime before UNIX_EPOCH is not supported on this platform");
-                return;
-            }
+            None => return,
         };
 
         Timestamp::try_from(before_epoch)


### PR DESCRIPTION
Follow-up to #835

This PR just wraps the error type in our `TryFrom` impl so that we can fail under other circumstances if we need.