### PR TITLE
feat: remove required std feature for Error trait impl

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -173,10 +173,4 @@ impl fmt::Display for Error {
     }
 }
 
-#[cfg(feature = "std")]
-mod std_support {
-    use super::*;
-    use crate::std::error;
-
-    impl error::Error for Error {}
-}
+impl core::error::Error for Error {}


### PR DESCRIPTION
Error trait can be implemented without std since it belongs to core