### PR TITLE
Add support for the wincode crate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: Continuous integration
 
 env:
   VERSION_FEATURES: "v1 v3 v4 v5 v6 v7 v8"
-  DEP_FEATURES: "slog serde arbitrary borsh zerocopy bytemuck"
+  DEP_FEATURES: "slog serde arbitrary borsh zerocopy bytemuck wincode"
 
 on:
   pull_request:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ rust-version = "1.63.0"
 rustc-args = ["--cfg", "uuid_unstable"]
 rustdoc-args = ["--cfg", "uuid_unstable"]
 targets = ["x86_64-unknown-linux-gnu"]
-features = ["serde", "arbitrary", "slog", "borsh", "v1", "v3", "v4", "v5", "v6", "v7", "v8"]
+features = ["serde", "arbitrary", "slog", "borsh", "wincode", "v1", "v3", "v4", "v5", "v6", "v7", "v8"]
 
 [package.metadata.playground]
 features = ["serde", "v1", "v3", "v4", "v5", "v6", "v7", "v8"]
@@ -83,6 +83,8 @@ atomic = ["dep:atomic"]
 
 borsh = ["dep:borsh", "dep:borsh-derive"]
 
+wincode = ["dep:wincode"]
+
 # Public: Used in trait impls on `Uuid`
 [dependencies.bytemuck]
 version = "1.19.0"
@@ -126,6 +128,16 @@ default-features = false
 optional = true
 version = "1"
 default-features = false
+
+# Public (unstable): Used in `wincode` derive
+# Unstable: also need RUSTFLAGS="--cfg uuid_unstable" to work
+# This feature may break between releases, or be removed entirely before
+# stabilization.
+[dependencies.wincode]
+optional = true
+version = "0.2"
+default-features = false
+features = ["derive"]
 
 # NOTE: `getrandom` will throw a compiler error for the following target configuration when `wasm_js` is not enabled:
 # all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none"))
@@ -211,6 +223,9 @@ version = "1.0.52"
 
 [dev-dependencies.rustversion]
 version = "1"
+
+[dev-dependencies.wincode]
+version = "0.2"
 
 [workspace]
 members = [

--- a/src/external.rs
+++ b/src/external.rs
@@ -6,3 +6,5 @@ pub(crate) mod borsh_support;
 pub(crate) mod serde_support;
 #[cfg(feature = "slog")]
 pub(crate) mod slog_support;
+#[cfg(feature = "wincode")]
+pub(crate) mod wincode_support;

--- a/src/external/wincode_support.rs
+++ b/src/external/wincode_support.rs
@@ -1,0 +1,25 @@
+#[cfg(test)]
+mod wincode_tests {
+    use crate::Uuid;
+    use std::string::ToString;
+
+    #[test]
+    fn test_serialize() {
+        let uuid_str = "f9168c5e-ceb2-4faa-b6bf-329bf39fa1e4";
+        let uuid = Uuid::parse_str(uuid_str).unwrap();
+        let uuid_bytes = uuid.as_bytes();
+        let wincode_bytes = wincode::serialize(&uuid).unwrap();
+        assert_eq!(uuid_bytes, wincode_bytes.as_slice());
+    }
+
+    #[test]
+    fn test_deserialize() {
+        let uuid_str = "f9168c5e-ceb2-4faa-b6bf-329bf39fa1e4";
+        let uuid = Uuid::parse_str(uuid_str).unwrap();
+        let uuid_bytes = uuid.as_bytes();
+        let deserialized = wincode::deserialize::<Uuid>(uuid_bytes)
+            .unwrap()
+            .to_string();
+        assert_eq!(uuid_str, deserialized);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -120,6 +120,8 @@
 //!
 //! * `zerocopy` - adds support for zero-copy deserialization using the
 //!   `zerocopy` library.
+//! * `wincode` - adds the ability to serialize and deserialize a UUID using
+//!   `wincode`.
 //!
 //! Unstable features may break between minor releases.
 //!
@@ -453,6 +455,10 @@ pub enum Variant {
         zerocopy::Immutable,
         zerocopy::Unaligned
     )
+)]
+#[cfg_attr(
+    all(uuid_unstable, feature = "wincode"),
+    derive(wincode::SchemaWrite, wincode::SchemaRead)
 )]
 pub struct Uuid(Bytes);
 


### PR DESCRIPTION
As the title says, this adds support for the [wincode crate](https://crates.io/crates/wincode).

The crate is currently pre `1.0`, so gating the feature under `uuid_unstable` as specified in the documentation. 