### PR TITLE
Default to rand 0.10

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -146,7 +146,7 @@ optional = true
 
 # Private
 [target.'cfg(not(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none"))))'.dependencies.rand]
-version = "0.9"
+version = "0.10"
 optional = true
 
 # Private


### PR DESCRIPTION
rand 0.10.0 was [released 2026-02-08](https://github.com/rust-random/rand/releases/tag/0.10.0) and can be used without code change. Default to it while still allowing 0.9.x for wider compatibility.