### PR TITLE
Remove deprecated `msrv` feature from wasm-bindgen dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -170,7 +170,6 @@ version = "0.6"
 # Private
 [target.'cfg(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none")))'.dependencies.wasm-bindgen]
 default-features = false
-features = ["msrv"]
 version = "0.2"
 optional = true
 


### PR DESCRIPTION
The `msrv` feature was deprecated in wasm-bindgen 0.2.99 and removed in newer versions. This removes the `features = ["msrv"]` from the `wasm-bindgen` dependency for `wasm32-unknown-unknown` targets, ensuring compatibility with current and future wasm-bindgen releases.

* Removed `features = ["msrv"]` from `[target.'cfg(all(target_arch = "wasm32", any(target_os = "unknown", target_os = "none")))'.dependencies.wasm-bindgen]` in `Cargo.toml`

No functional change — the `msrv` feature was a no-op in recent wasm-bindgen versions before its removal.