### PR TITLE
fix: Timestamp::from_gregorian deprecation note

### DIFF
--- a/src/timestamp.rs
+++ b/src/timestamp.rs
@@ -167,7 +167,7 @@ impl Timestamp {
 impl Timestamp {
     #[deprecated(
         since = "1.10.0",
-        note = "use `Timestamp::from_gregorian(ticks, counter)`"
+        note = "use `Timestamp::from_gregorian_time(ticks, counter)`"
     )]
     pub const fn from_rfc4122(ticks: u64, counter: u16) -> Self {
         Timestamp::from_gregorian_time(ticks, counter)
@@ -188,7 +188,7 @@ impl Timestamp {
 
     #[deprecated(
         since = "1.23.0",
-        note = "use `Timestamp::from_gregorian(ticks, counter)`"
+        note = "use `Timestamp::from_gregorian_time(ticks, counter)`"
     )]
     pub const fn from_gregorian(ticks: u64, counter: u16) -> Self {
         Timestamp::from_gregorian_time(ticks, counter)


### PR DESCRIPTION
Fix deprecation note for `Timestamp::{from_gregorian,from_rfc4122}` from erroneously recommending to use `Timestamp::from_gregorian` instead of the correct `from_gregorian_time`.

This leads to an especially insidious-looking deprecation warning which left me in disbelief:

<img width="859" height="59" alt="Screenshot 2026-04-15 at 09 32 27" src="https://github.com/user-attachments/assets/bcc85176-09fd-4ce1-af7e-1e50618ff610" />
