### PR TITLE
Improve error messages for ambiguous formats

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -14,13 +14,13 @@ pub(crate) enum ErrorKind {
     ///
     /// [`Uuid`]: ../struct.Uuid.html
     ParseSimpleLength { len: usize },
-    /// A byte array didn't contain 16 bytes
+    /// A byte array didn't contain 16 bytes.
     ParseByteLength { len: usize },
     /// A hyphenated [`Uuid`] didn't contain 5 groups
     ///
     /// [`Uuid`]: ../struct.Uuid.html
     ParseGroupCount { count: usize },
-    /// A hyphenated [`Uuid`] had a group that wasn't the right length
+    /// A hyphenated [`Uuid`] had a group that wasn't the right length.
     ///
     /// [`Uuid`]: ../struct.Uuid.html
     ParseGroupLength {
@@ -28,8 +28,10 @@ pub(crate) enum ErrorKind {
         len: usize,
         index: usize,
     },
-    /// The input was not a valid UTF8 string
+    /// The input was not a valid UTF8 string.
     ParseInvalidUTF8,
+    /// The input has an invalid length.
+    ParseLength { len: usize },
     /// Some other parsing error occurred.
     ParseOther,
     /// The UUID is nil.
@@ -46,24 +48,61 @@ pub(crate) enum ErrorKind {
 /// details. To get details, use `InvalidUuid::into_err`.
 ///
 /// [`Uuid`]: ../struct.Uuid.html
-#[derive(Clone, Debug, Eq, Hash, PartialEq)]
-pub struct InvalidUuid<'a>(pub(crate) &'a [u8]);
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub(crate) struct InvalidUuid<'a>(pub(crate) &'a [u8], pub(crate) RequestedUuid);
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub(crate) enum RequestedUuid {
+    Any,
+    Simple,
+    Hyphenated,
+    Braced,
+    Urn,
+}
 
 impl<'a> InvalidUuid<'a> {
     /// Converts the lightweight error type into detailed diagnostics.
     pub fn into_err(self) -> Error {
+        if self.0.len() == 0 || self.0.len() > 45 {
+            // Don't waste time looking at strings that may be enormous
+            return Error(ErrorKind::ParseLength { len: self.0.len() });
+        }
+
         // Check whether or not the input was ever actually a valid UTF8 string
         let input_str = match std::str::from_utf8(self.0) {
             Ok(s) => s,
             Err(_) => return Error(ErrorKind::ParseInvalidUTF8),
         };
 
-        let (uuid_str, offset, simple) = match input_str.as_bytes() {
-            [b'{', s @ .., b'}'] => (s, 1, false),
-            [b'u', b'r', b'n', b':', b'u', b'u', b'i', b'd', b':', s @ ..] => {
-                (s, "urn:uuid:".len(), false)
+        let (bounds, format) = match (self.1, self.0) {
+            (RequestedUuid::Any | RequestedUuid::Braced, [b'{', s @ .., b'}']) => {
+                (1..s.len() - 1, RequestedUuid::Braced)
             }
-            s => (s, 0, true),
+            (RequestedUuid::Braced, _) => {
+                if self.0[0] != b'{' {
+                    // The first character is invalid
+                    let (index, character) = input_str.char_indices().next().unwrap();
+
+                    return Error(ErrorKind::ParseChar { character, index });
+                } else {
+                    // The last character is invalid
+                    let (index, character) = input_str.char_indices().last().unwrap();
+
+                    return Error(ErrorKind::ParseChar { character, index });
+                }
+            }
+            (
+                RequestedUuid::Any | RequestedUuid::Urn,
+                [b'u', b'r', b'n', b':', b'u', b'u', b'i', b'd', b':', s @ ..],
+            ) => ("urn:uuid:".len()..s.len(), RequestedUuid::Urn),
+            (RequestedUuid::Urn, _) => {
+                return Error(ErrorKind::ParseChar {
+                    character: input_str.chars().next().unwrap(),
+                    index: 0,
+                })
+            }
+            (RequestedUuid::Any, s) => (0..s.len(), RequestedUuid::Simple),
+            (r, s) => (0..s.len(), r),
         };
 
         let mut hyphen_count = 0;
@@ -71,32 +110,36 @@ impl<'a> InvalidUuid<'a> {
 
         // SAFETY: the byte array came from a valid utf8 string,
         // and is aligned along char boundaries.
-        let uuid_str = unsafe { std::str::from_utf8_unchecked(uuid_str) };
+        let uuid_str = unsafe { std::str::from_utf8_unchecked(self.0) };
 
-        for (index, character) in uuid_str.char_indices() {
+        for (index, character) in uuid_str[bounds.clone()].char_indices() {
             let byte = character as u8;
-            if character as u32 - byte as u32 > 0 {
-                // Multibyte char
-                return Error(ErrorKind::ParseChar {
-                    character,
-                    index: index + offset + 1,
-                });
-            } else if byte == b'-' {
-                // While we search, also count group breaks
-                if hyphen_count < 4 {
-                    group_bounds[hyphen_count] = index;
+
+            match (format, byte.to_ascii_lowercase()) {
+                (_, b'0'..=b'9' | b'a'..=b'f') => (),
+                (RequestedUuid::Simple, b'-') => {
+                    return Error(ErrorKind::ParseChar {
+                        character: '-',
+                        index: index + bounds.start + 1,
+                    })
                 }
-                hyphen_count += 1;
-            } else if !byte.is_ascii_hexdigit() {
-                // Non-hex char
-                return Error(ErrorKind::ParseChar {
-                    character: byte as char,
-                    index: index + offset + 1,
-                });
+                (_, b'-') => {
+                    if hyphen_count < 4 {
+                        // While we search, also count group breaks
+                        group_bounds[hyphen_count] = index;
+                    }
+                    hyphen_count += 1;
+                }
+                _ => {
+                    return Error(ErrorKind::ParseChar {
+                        character: byte as char,
+                        index: index + bounds.start + 1,
+                    })
+                }
             }
         }
 
-        if hyphen_count == 0 && simple {
+        if format == RequestedUuid::Simple {
             // This means that we tried and failed to parse a simple uuid.
             // Since we verified that all the characters are valid, this means
             // that it MUST have an invalid length.
@@ -117,7 +160,7 @@ impl<'a> InvalidUuid<'a> {
                     return Error(ErrorKind::ParseGroupLength {
                         group: i,
                         len: group_bounds[i] - BLOCK_STARTS[i],
-                        index: offset + BLOCK_STARTS[i] + 1,
+                        index: bounds.start + BLOCK_STARTS[i] + 1,
                     });
                 }
             }
@@ -126,7 +169,7 @@ impl<'a> InvalidUuid<'a> {
             Error(ErrorKind::ParseGroupLength {
                 group: 4,
                 len: input_str.len() - BLOCK_STARTS[4],
-                index: offset + BLOCK_STARTS[4] + 1,
+                index: bounds.start + BLOCK_STARTS[4] + 1,
             })
         }
     }
@@ -164,6 +207,7 @@ impl fmt::Display for Error {
             }
             ErrorKind::ParseInvalidUTF8 => write!(f, "non-UTF8 input"),
             ErrorKind::Nil => write!(f, "the UUID is nil"),
+            ErrorKind::ParseLength { len } => write!(f, "invalid length: found {}", len),
             ErrorKind::ParseOther => write!(f, "failed to parse a UUID"),
             #[cfg(feature = "std")]
             ErrorKind::InvalidSystemTime(ref e) => {

--- a/src/error.rs
+++ b/src/error.rs
@@ -10,10 +10,6 @@ pub(crate) enum ErrorKind {
     ///
     /// [`Uuid`]: ../struct.Uuid.html
     ParseChar { character: char, index: usize },
-    /// A simple [`Uuid`] didn't contain 32 characters.
-    ///
-    /// [`Uuid`]: ../struct.Uuid.html
-    ParseSimpleLength { len: usize },
     /// A byte array didn't contain 16 bytes.
     ParseByteLength { len: usize },
     /// A hyphenated [`Uuid`] didn't contain 5 groups
@@ -74,7 +70,7 @@ impl<'a> InvalidUuid<'a> {
             Err(_) => return Error(ErrorKind::ParseInvalidUTF8),
         };
 
-        let (bounds, format) = match (self.1, self.0) {
+        let (bounds, mut format) = match (self.1, self.0) {
             (RequestedUuid::Any | RequestedUuid::Braced, [b'{', s @ .., b'}']) => {
                 (1..s.len() - 1, RequestedUuid::Braced)
             }
@@ -101,7 +97,6 @@ impl<'a> InvalidUuid<'a> {
                     index: 0,
                 })
             }
-            (RequestedUuid::Any, s) => (0..s.len(), RequestedUuid::Simple),
             (r, s) => (0..s.len(), r),
         };
 
@@ -120,10 +115,14 @@ impl<'a> InvalidUuid<'a> {
                 (RequestedUuid::Simple, b'-') => {
                     return Error(ErrorKind::ParseChar {
                         character: '-',
-                        index: index + bounds.start + 1,
+                        index: index + bounds.start,
                     })
                 }
                 (_, b'-') => {
+                    if format == RequestedUuid::Any {
+                        format = RequestedUuid::Hyphenated;
+                    }
+
                     if hyphen_count < 4 {
                         // While we search, also count group breaks
                         group_bounds[hyphen_count] = index;
@@ -132,18 +131,18 @@ impl<'a> InvalidUuid<'a> {
                 }
                 _ => {
                     return Error(ErrorKind::ParseChar {
-                        character: byte as char,
-                        index: index + bounds.start + 1,
+                        character,
+                        index: index + bounds.start,
                     })
                 }
             }
         }
 
-        if format == RequestedUuid::Simple {
+        if format == RequestedUuid::Any || format == RequestedUuid::Simple {
             // This means that we tried and failed to parse a simple uuid.
             // Since we verified that all the characters are valid, this means
             // that it MUST have an invalid length.
-            Error(ErrorKind::ParseSimpleLength {
+            Error(ErrorKind::ParseLength {
                 len: input_str.len(),
             })
         } else if hyphen_count != 4 {
@@ -183,13 +182,6 @@ impl fmt::Display for Error {
                 character, index, ..
             } => {
                 write!(f, "invalid character: found `{}` at {}", character, index)
-            }
-            ErrorKind::ParseSimpleLength { len } => {
-                write!(
-                    f,
-                    "invalid length: expected length 32 for simple format, found {}",
-                    len
-                )
             }
             ErrorKind::ParseByteLength { len } => {
                 write!(f, "invalid length: expected 16 bytes, found {}", len)

--- a/src/external/serde_support.rs
+++ b/src/external/serde_support.rs
@@ -476,7 +476,12 @@ pub mod simple {
                     Token::BorrowedStr(HYPHENATED_UUID_STR),
                     Token::TupleStructEnd,
                 ],
-                &format!("{}", de::value::Error::custom("UUID parsing failed: invalid group length in group 4: expected 12, found 12")),
+                &format!(
+                    "{}",
+                    de::value::Error::custom(
+                        "UUID parsing failed: invalid character: found `-` at 8"
+                    )
+                ),
             );
         }
     }
@@ -599,7 +604,12 @@ pub mod braced {
                     Token::BorrowedStr(HYPHENATED_UUID_STR),
                     Token::TupleStructEnd,
                 ],
-                &format!("{}", de::value::Error::custom("UUID parsing failed: invalid group length in group 4: expected 12, found 12")),
+                &format!(
+                    "{}",
+                    de::value::Error::custom(
+                        "UUID parsing failed: invalid character: found `f` at 0"
+                    )
+                ),
             );
         }
     }
@@ -723,7 +733,12 @@ pub mod hyphenated {
                     Token::BorrowedStr(BRACED_UUID_STR),
                     Token::TupleStructEnd,
                 ],
-                &format!("{}", de::value::Error::custom("UUID parsing failed: invalid group length in group 4: expected 12, found 14")),
+                &format!(
+                    "{}",
+                    de::value::Error::custom(
+                        "UUID parsing failed: invalid character: found `{` at 0"
+                    )
+                ),
             );
         }
     }
@@ -845,7 +860,12 @@ pub mod urn {
                     Token::BorrowedStr(HYPHENATED_UUID_STR),
                     Token::TupleStructEnd,
                 ],
-                &format!("{}", de::value::Error::custom("UUID parsing failed: invalid group length in group 4: expected 12, found 12")),
+                &format!(
+                    "{}",
+                    de::value::Error::custom(
+                        "UUID parsing failed: invalid character: found `f` at 0"
+                    )
+                ),
             );
         }
     }
@@ -950,7 +970,7 @@ mod serde_tests {
     fn test_de_failure() {
         serde_test::assert_de_tokens_error::<Readable<Uuid>>(
             &[Token::Str("hello_world")],
-            "UUID parsing failed: invalid character: found `h` at 1",
+            "UUID parsing failed: invalid character: found `h` at 0",
         );
 
         serde_test::assert_de_tokens_error::<Compact<Uuid>>(

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -882,7 +882,7 @@ impl FromStr for Simple {
     type Err = Error;
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
-        crate::parser::parse_simple(s.as_bytes())
+        crate::parser::parse_simple(s.as_bytes(), false)
             .map(|b| Simple(Uuid(b)))
             .map_err(|invalid| invalid.into_err())
     }
@@ -1115,53 +1115,5 @@ mod tests {
     fn braced_to_inner() {
         let braced = Uuid::nil().braced();
         assert_eq!(Uuid::from(braced), Uuid::nil());
-    }
-
-    #[test]
-    fn error_reporting() {
-        assert_eq!(
-            "invalid length: found 0",
-            Hyphenated::from_str("").unwrap_err().to_string()
-        );
-
-        assert_eq!(
-            "invalid group count: expected 5, found 1",
-            Hyphenated::from_str("550e8400e29b41d4a716446655440000")
-                .unwrap_err()
-                .to_string()
-        );
-
-        assert_eq!(
-            "invalid character: found `-` at 9",
-            Simple::from_str("550e8400-e29b-41d4-a716-446655440000")
-                .unwrap_err()
-                .to_string()
-        );
-
-        assert_eq!(
-            "invalid character: found `5` at 0",
-            Urn::from_str("550e8400-e29b-41d4-a716-446655440000")
-                .unwrap_err()
-                .to_string()
-        );
-        assert_eq!(
-            "invalid character: found `:` at 0",
-            Urn::from_str(":550e8400-e29b-41d4-a716-446655440000")
-                .unwrap_err()
-                .to_string()
-        );
-
-        assert_eq!(
-            "invalid character: found `5` at 0",
-            Braced::from_str("550e8400-e29b-41d4-a716-446655440000")
-                .unwrap_err()
-                .to_string()
-        );
-        assert_eq!(
-            "invalid character: found `{` at 2",
-            Braced::from_str("{{550e8400-e29b-41d4-a716-446655440000}}")
-                .unwrap_err()
-                .to_string()
-        );
     }
 }

--- a/src/fmt.rs
+++ b/src/fmt.rs
@@ -1116,4 +1116,52 @@ mod tests {
         let braced = Uuid::nil().braced();
         assert_eq!(Uuid::from(braced), Uuid::nil());
     }
+
+    #[test]
+    fn error_reporting() {
+        assert_eq!(
+            "invalid length: found 0",
+            Hyphenated::from_str("").unwrap_err().to_string()
+        );
+
+        assert_eq!(
+            "invalid group count: expected 5, found 1",
+            Hyphenated::from_str("550e8400e29b41d4a716446655440000")
+                .unwrap_err()
+                .to_string()
+        );
+
+        assert_eq!(
+            "invalid character: found `-` at 9",
+            Simple::from_str("550e8400-e29b-41d4-a716-446655440000")
+                .unwrap_err()
+                .to_string()
+        );
+
+        assert_eq!(
+            "invalid character: found `5` at 0",
+            Urn::from_str("550e8400-e29b-41d4-a716-446655440000")
+                .unwrap_err()
+                .to_string()
+        );
+        assert_eq!(
+            "invalid character: found `:` at 0",
+            Urn::from_str(":550e8400-e29b-41d4-a716-446655440000")
+                .unwrap_err()
+                .to_string()
+        );
+
+        assert_eq!(
+            "invalid character: found `5` at 0",
+            Braced::from_str("550e8400-e29b-41d4-a716-446655440000")
+                .unwrap_err()
+                .to_string()
+        );
+        assert_eq!(
+            "invalid character: found `{` at 2",
+            Braced::from_str("{{550e8400-e29b-41d4-a716-446655440000}}")
+                .unwrap_err()
+                .to_string()
+        );
+    }
 }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -158,7 +158,7 @@ const fn try_parse(input: &'_ [u8]) -> Result<[u8; 16], InvalidUuid<'_>> {
             parse_hyphenated(s)
         }
         // Any other shaped input is immediately invalid
-        _ => Err(InvalidUuid(input)),
+        _ => Err(InvalidUuid(input, RequestedUuid::Any)),
     }
 }
 
@@ -168,7 +168,7 @@ pub(crate) const fn parse_braced(input: &'_ [u8]) -> Result<[u8; 16], InvalidUui
     if let (38, [b'{', s @ .., b'}']) = (input.len(), input) {
         parse_hyphenated(s)
     } else {
-        Err(InvalidUuid(input))
+        Err(InvalidUuid(input, RequestedUuid::Braced))
     }
 }
 
@@ -180,7 +180,7 @@ pub(crate) const fn parse_urn(input: &'_ [u8]) -> Result<[u8; 16], InvalidUuid<'
     {
         parse_hyphenated(s)
     } else {
-        Err(InvalidUuid(input))
+        Err(InvalidUuid(input, RequestedUuid::Urn))
     }
 }
 
@@ -189,7 +189,7 @@ pub(crate) const fn parse_simple(s: &'_ [u8]) -> Result<[u8; 16], InvalidUuid<'_
     // This length check here removes all other bounds
     // checks in this function
     if s.len() != 32 {
-        return Err(InvalidUuid(s));
+        return Err(InvalidUuid(s, RequestedUuid::Simple));
     }
 
     let mut buf: [u8; 16] = [0; 16];
@@ -204,7 +204,7 @@ pub(crate) const fn parse_simple(s: &'_ [u8]) -> Result<[u8; 16], InvalidUuid<'_
         // We use `0xff` as a sentinel value to indicate
         // an invalid hex character sequence (like the letter `G`)
         if h1 | h2 == 0xff {
-            return Err(InvalidUuid(s));
+            return Err(InvalidUuid(s, RequestedUuid::Simple));
         }
 
         // The upper nibble needs to be shifted into position
@@ -221,7 +221,7 @@ pub(crate) const fn parse_hyphenated(s: &'_ [u8]) -> Result<[u8; 16], InvalidUui
     // This length check here removes all other bounds
     // checks in this function
     if s.len() != 36 {
-        return Err(InvalidUuid(s));
+        return Err(InvalidUuid(s, RequestedUuid::Hyphenated));
     }
 
     // We look at two hex-encoded values (4 chars) at a time because
@@ -236,7 +236,7 @@ pub(crate) const fn parse_hyphenated(s: &'_ [u8]) -> Result<[u8; 16], InvalidUui
     // First, ensure the hyphens appear in the right places
     match [s[8], s[13], s[18], s[23]] {
         [b'-', b'-', b'-', b'-'] => {}
-        _ => return Err(InvalidUuid(s)),
+        _ => return Err(InvalidUuid(s, RequestedUuid::Hyphenated)),
     }
 
     let positions: [u8; 8] = [0, 4, 9, 14, 19, 24, 28, 32];
@@ -254,7 +254,7 @@ pub(crate) const fn parse_hyphenated(s: &'_ [u8]) -> Result<[u8; 16], InvalidUui
         let h4 = HEX_TABLE[s[(i + 3) as usize] as usize];
 
         if h1 | h2 | h3 | h4 == 0xff {
-            return Err(InvalidUuid(s));
+            return Err(InvalidUuid(s, RequestedUuid::Hyphenated));
         }
 
         buf[j * 2] = SHL4_TABLE[h1 as usize] | h2;
@@ -341,7 +341,7 @@ mod tests {
         // Invalid
         assert_eq!(
             Uuid::parse_str(""),
-            Err(Error(ErrorKind::ParseSimpleLength { len: 0 }))
+            Err(Error(ErrorKind::ParseLength { len: 0 }))
         );
 
         assert_eq!(
@@ -429,7 +429,6 @@ mod tests {
         );
 
         // // (group, found, expecting)
-        // //
         assert_eq!(
             Uuid::parse_str("01020304-1112-2122-3132-41424344"),
             Err(Error(ErrorKind::ParseGroupLength {

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -147,7 +147,7 @@ impl Uuid {
 const fn try_parse(input: &'_ [u8]) -> Result<[u8; 16], InvalidUuid<'_>> {
     match (input.len(), input) {
         // Inputs of 32 bytes must be a non-hyphenated UUID
-        (32, s) => parse_simple(s),
+        (32, s) => parse_simple(s, true),
         // Hyphenated UUIDs may be wrapped in various ways:
         // - `{UUID}` for braced UUIDs
         // - `urn:uuid:UUID` for URNs
@@ -185,11 +185,21 @@ pub(crate) const fn parse_urn(input: &'_ [u8]) -> Result<[u8; 16], InvalidUuid<'
 }
 
 #[inline]
-pub(crate) const fn parse_simple(s: &'_ [u8]) -> Result<[u8; 16], InvalidUuid<'_>> {
+pub(crate) const fn parse_simple(
+    s: &'_ [u8],
+    speculative: bool,
+) -> Result<[u8; 16], InvalidUuid<'_>> {
     // This length check here removes all other bounds
     // checks in this function
     if s.len() != 32 {
-        return Err(InvalidUuid(s, RequestedUuid::Simple));
+        return Err(InvalidUuid(
+            s,
+            if speculative {
+                RequestedUuid::Any
+            } else {
+                RequestedUuid::Simple
+            },
+        ));
     }
 
     let mut buf: [u8; 16] = [0; 16];
@@ -204,7 +214,14 @@ pub(crate) const fn parse_simple(s: &'_ [u8]) -> Result<[u8; 16], InvalidUuid<'_
         // We use `0xff` as a sentinel value to indicate
         // an invalid hex character sequence (like the letter `G`)
         if h1 | h2 == 0xff {
-            return Err(InvalidUuid(s, RequestedUuid::Simple));
+            return Err(InvalidUuid(
+                s,
+                if speculative {
+                    RequestedUuid::Any
+                } else {
+                    RequestedUuid::Simple
+                },
+            ));
         }
 
         // The upper nibble needs to be shifted into position
@@ -303,10 +320,14 @@ const SHL4_TABLE: &[u8; 256] = &{
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::{std::string::ToString, tests::some_uuid_iter};
+    use crate::{
+        fmt::*,
+        std::{str::FromStr, string::ToString},
+        tests::some_uuid_iter,
+    };
 
     #[test]
-    fn test_parse_uuid_v4_valid() {
+    fn test_parse_valid() {
         let from_hyphenated = Uuid::parse_str("67e55044-10b1-426f-9247-bb680e5fe0c8").unwrap();
         let from_simple = Uuid::parse_str("67e5504410b1426f9247bb680e5fe0c8").unwrap();
         let from_urn = Uuid::parse_str("urn:uuid:67e55044-10b1-426f-9247-bb680e5fe0c8").unwrap();
@@ -337,7 +358,7 @@ mod tests {
     }
 
     #[test]
-    fn test_parse_uuid_v4_invalid() {
+    fn test_parse_invalid() {
         // Invalid
         assert_eq!(
             Uuid::parse_str(""),
@@ -348,7 +369,7 @@ mod tests {
             Uuid::parse_str("!"),
             Err(Error(ErrorKind::ParseChar {
                 character: '!',
-                index: 1,
+                index: 0,
             }))
         );
 
@@ -374,7 +395,7 @@ mod tests {
             Uuid::parse_str("F9168C5E-CEB2-4faa-BGBF-329BF39FA1E4"),
             Err(Error(ErrorKind::ParseChar {
                 character: 'G',
-                index: 21,
+                index: 20,
             }))
         );
 
@@ -402,7 +423,7 @@ mod tests {
             Uuid::parse_str("F9168C5E-CEB2-4faaXB6BFF329BF39FA1E4"),
             Err(Error(ErrorKind::ParseChar {
                 character: 'X',
-                index: 19,
+                index: 18,
             }))
         );
 
@@ -410,7 +431,7 @@ mod tests {
             Uuid::parse_str("{F9168C5E-CEB2-4faa9B6BFF329BF39FA1E41"),
             Err(Error(ErrorKind::ParseChar {
                 character: '{',
-                index: 1,
+                index: 0,
             }))
         );
 
@@ -440,19 +461,19 @@ mod tests {
 
         assert_eq!(
             Uuid::parse_str("67e5504410b1426f9247bb680e5fe0c"),
-            Err(Error(ErrorKind::ParseSimpleLength { len: 31 }))
+            Err(Error(ErrorKind::ParseLength { len: 31 }))
         );
 
         assert_eq!(
             Uuid::parse_str("67e5504410b1426f9247bb680e5fe0c88"),
-            Err(Error(ErrorKind::ParseSimpleLength { len: 33 }))
+            Err(Error(ErrorKind::ParseLength { len: 33 }))
         );
 
         assert_eq!(
             Uuid::parse_str("67e5504410b1426f9247bb680e5fe0cg8"),
             Err(Error(ErrorKind::ParseChar {
                 character: 'g',
-                index: 32,
+                index: 31,
             }))
         );
 
@@ -460,13 +481,13 @@ mod tests {
             Uuid::parse_str("67e5504410b1426%9247bb680e5fe0c8"),
             Err(Error(ErrorKind::ParseChar {
                 character: '%',
-                index: 16,
+                index: 15,
             }))
         );
 
         assert_eq!(
             Uuid::parse_str("231231212212423424324323477343246663"),
-            Err(Error(ErrorKind::ParseSimpleLength { len: 36 }))
+            Err(Error(ErrorKind::ParseGroupCount { count: 1 }))
         );
 
         assert_eq!(
@@ -476,14 +497,14 @@ mod tests {
 
         assert_eq!(
             Uuid::parse_str("67e5504410b1426f9247bb680e5fe0c"),
-            Err(Error(ErrorKind::ParseSimpleLength { len: 31 }))
+            Err(Error(ErrorKind::ParseLength { len: 31 }))
         );
 
         assert_eq!(
             Uuid::parse_str("67e550X410b1426f9247bb680e5fe0cd"),
             Err(Error(ErrorKind::ParseChar {
                 character: 'X',
-                index: 7,
+                index: 6,
             }))
         );
 
@@ -505,8 +526,56 @@ mod tests {
             Uuid::parse_str("\u{bcf3c}"),
             Err(Error(ErrorKind::ParseChar {
                 character: '\u{bcf3c}',
-                index: 1
+                index: 0,
             }))
+        );
+
+        assert_eq!(
+            Err(Error(ErrorKind::ParseLength { len: 0 })),
+            Hyphenated::from_str("")
+        );
+
+        assert_eq!(
+            Err(Error(ErrorKind::ParseGroupCount { count: 1 })),
+            Hyphenated::from_str("550e8400e29b41d4a716446655440000")
+        );
+
+        assert_eq!(
+            Err(Error(ErrorKind::ParseChar {
+                character: '-',
+                index: 8
+            })),
+            Simple::from_str("550e8400-e29b-41d4-a716-446655440000")
+        );
+
+        assert_eq!(
+            Err(Error(ErrorKind::ParseChar {
+                character: '5',
+                index: 0
+            })),
+            Urn::from_str("550e8400-e29b-41d4-a716-446655440000")
+        );
+        assert_eq!(
+            Err(Error(ErrorKind::ParseChar {
+                character: ':',
+                index: 0
+            })),
+            Urn::from_str(":550e8400-e29b-41d4-a716-446655440000")
+        );
+
+        assert_eq!(
+            Err(Error(ErrorKind::ParseChar {
+                character: '5',
+                index: 0
+            })),
+            Braced::from_str("550e8400-e29b-41d4-a716-446655440000")
+        );
+        assert_eq!(
+            Err(Error(ErrorKind::ParseChar {
+                character: '{',
+                index: 1
+            })),
+            Braced::from_str("{{550e8400-e29b-41d4-a716-446655440000}}")
         );
     }
 


### PR DESCRIPTION
Closes #880 
Closes #881 

This PR improves our error reporting so when attempting to parse a specific format we don't report errors suggesting a different format is malformed. I've also made our indexes zero-based instead of 1-based. These fields aren't public so are unlikely to be relied on.