### PR TITLE
Fix non-ASCII character handling in parse diagnostics

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -104,17 +104,15 @@ impl<'a> InvalidUuid<'a> {
         let mut group_bounds = [0; 4];
 
         for (index, character) in input_str[bounds.clone()].char_indices() {
-            let byte = character as u8;
-
-            match (format, byte.to_ascii_lowercase()) {
-                (_, b'0'..=b'9' | b'a'..=b'f') => (),
-                (RequestedUuid::Simple, b'-') => {
+            match (format, character) {
+                (_, character) if character.is_ascii_hexdigit() => (),
+                (RequestedUuid::Simple, '-') => {
                     return Error(ErrorKind::ParseChar {
                         character: '-',
                         index: index + bounds.start,
                     })
                 }
-                (_, b'-') => {
+                (_, '-') => {
                     if format == RequestedUuid::Any {
                         format = RequestedUuid::Hyphenated;
                     }

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -540,6 +540,14 @@ mod tests {
         );
 
         assert_eq!(
+            Uuid::parse_str("\u{130}"),
+            Err(Error(ErrorKind::ParseChar {
+                character: '\u{130}',
+                index: 0,
+            }))
+        );
+
+        assert_eq!(
             Err(Error(ErrorKind::ParseLength { len: 0 })),
             Hyphenated::from_str("")
         );


### PR DESCRIPTION
Closes https://github.com/uuid-rs/uuid/issues/898

## Summary

Fix detailed UUID parse diagnostics for non-ASCII characters whose low byte matches a valid ASCII UUID character.

`InvalidUuid::into_err` previously cast each Unicode `char` to `u8` before classifying it. This lossy conversion could misclassify characters such as `U+0130` (`İ`) as ASCII hexadecimal digits.

The diagnostic logic now checks the original character with `char::is_ascii_hexdigit()`, avoiding the truncating conversion.

A regression test verifies that `U+0130` produces:

```text
invalid character: found `İ` at 0
```

